### PR TITLE
Fix incorrect Go version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ NovaEdge is now **production-ready** and enterprise-grade, capable of replacing 
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.24+
 - Kubernetes cluster (1.29+)
 - kubectl configured
 - make


### PR DESCRIPTION
## Summary
- README.md stated Go 1.25+ as a prerequisite, but go.mod specifies go 1.24.0
- Updated the prerequisite to Go 1.24+ to match the actual requirement

## Test plan
- [x] Verified go.mod specifies `go 1.24.0`
- [x] Verified no other occurrences of "Go 1.25" remain in README.md

Resolves #37