### PR TITLE
Remove unused functions, variables, and test helpers

### DIFF
--- a/cmd/novactl/cmd/metrics_query.go
+++ b/cmd/novactl/cmd/metrics_query.go
@@ -16,7 +16,6 @@ import (
 
 var (
 	prometheusEndpoint  string
-	prometheusQuery     string
 	prometheusStart     string
 	prometheusEnd       string
 	prometheusStep      string

--- a/internal/agent/config/failover.go
+++ b/internal/agent/config/failover.go
@@ -937,36 +937,6 @@ func (w *FailoverWatcher) getControllerReachability() *pb.ControllerReachability
 	return reachability
 }
 
-// updateControllerReachability updates the reachability status for a controller
-func (w *FailoverWatcher) updateControllerReachability(name string, reachable bool, latency time.Duration) {
-	w.reachabilityMu.Lock()
-	defer w.reachabilityMu.Unlock()
-
-	if info, ok := w.controllerReachability[name]; ok {
-		info.Reachable = reachable
-		if reachable {
-			info.LastContact = time.Now()
-			info.Latency = latency
-		}
-	}
-}
-
-// probeAllControllers probes all controllers and updates reachability
-// This should be called periodically to maintain accurate reachability info
-func (w *FailoverWatcher) probeAllControllers() {
-	w.controllersMu.RLock()
-	controllers := w.controllers
-	w.controllersMu.RUnlock()
-
-	for _, ctrl := range controllers {
-		start := time.Now()
-		err := w.pingController(ctrl)
-		latency := time.Since(start)
-
-		w.updateControllerReachability(ctrl.Name, err == nil, latency)
-	}
-}
-
 // GetVectorClock returns the last known vector clock
 func (w *FailoverWatcher) GetVectorClock() map[string]int64 {
 	w.snapshotMu.RLock()

--- a/internal/agent/metrics/metrics.go
+++ b/internal/agent/metrics/metrics.go
@@ -87,19 +87,6 @@ func (t *endpointCardinalityTracker) shouldTrackEndpoint(cluster, endpoint strin
 	return true
 }
 
-// removeEndpoint removes an endpoint from tracking
-func (t *endpointCardinalityTracker) removeEndpoint(cluster, endpoint string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if clusterEndpoints, exists := t.endpoints[cluster]; exists {
-		delete(clusterEndpoints, endpoint)
-		if len(clusterEndpoints) == 0 {
-			delete(t.endpoints, cluster)
-		}
-	}
-}
-
 // cleanupCluster removes all endpoints for a cluster
 func (t *endpointCardinalityTracker) cleanupCluster(cluster string) {
 	t.mu.Lock()

--- a/internal/agent/router/websocket.go
+++ b/internal/agent/router/websocket.go
@@ -22,22 +22,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
 )
-
-// Buffer pool for WebSocket message copying to reduce allocations
-// Note: gorilla/websocket manages its own message buffers, but we can still
-// use pools for other temporary allocations if needed in the future
-var wsMessagePool = sync.Pool{
-	New: func() interface{} {
-		// Pre-allocate 64KB buffer for large WebSocket messages
-		buf := make([]byte, 65536)
-		return &buf
-	},
-}
 
 // WebSocketProxy handles WebSocket connection proxying
 type WebSocketProxy struct {

--- a/internal/agent/server/tls_config.go
+++ b/internal/agent/server/tls_config.go
@@ -27,23 +27,6 @@ import (
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
-// createTLSConfig creates a tls.Config from protobuf TLS configuration with SNI support
-func (s *HTTPServer) createTLSConfig(tlsConfig *pb.TLSConfig, hostnames []string) (*tls.Config, error) {
-	// Parse default certificate and key
-	cert, err := tls.X509KeyPair(tlsConfig.Cert, tlsConfig.Key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse default certificate: %w", err)
-	}
-
-	config := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   s.parseTLSVersion(tlsConfig.MinVersion),
-		CipherSuites: s.parseCipherSuites(tlsConfig.CipherSuites),
-	}
-
-	return config, nil
-}
-
 // createTLSConfigWithSNI creates a tls.Config with SNI support for multiple certificates
 func (s *HTTPServer) createTLSConfigWithSNI(listener *pb.Listener) (*tls.Config, error) {
 	// Parse all certificates for SNI

--- a/internal/controller/federation/client.go
+++ b/internal/controller/federation/client.go
@@ -477,34 +477,3 @@ func NewPeerClientWithCerts(peer *PeerInfo, config *FederationConfig, logger *za
 	}
 }
 
-// buildTLSConfig builds the TLS configuration with certificates
-func (c *PeerClientWithCerts) buildTLSConfig() (*tls.Config, error) {
-	config := &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: c.peer.InsecureSkipVerify,
-	}
-
-	if c.peer.TLSServerName != "" {
-		config.ServerName = c.peer.TLSServerName
-	}
-
-	// Add CA certificate
-	if len(c.caCert) > 0 {
-		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(c.caCert) {
-			return nil, fmt.Errorf("failed to parse CA certificate")
-		}
-		config.RootCAs = certPool
-	}
-
-	// Add client certificate for mTLS
-	if len(c.clientCert) > 0 && len(c.clientKey) > 0 {
-		cert, err := tls.X509KeyPair(c.clientCert, c.clientKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load client certificate: %w", err)
-		}
-		config.Certificates = []tls.Certificate{cert}
-	}
-
-	return config, nil
-}

--- a/internal/controller/ingress_translator.go
+++ b/internal/controller/ingress_translator.go
@@ -509,35 +509,6 @@ func (t *IngressTranslator) translateRouteRule(ingress *networkingv1.Ingress, pa
 	return rule
 }
 
-// convertPathMatch converts Ingress path type to ProxyRoute path match
-func (t *IngressTranslator) convertPathMatch(path networkingv1.HTTPIngressPath) *novaedgev1alpha1.HTTPPathMatch {
-	if path.Path == "" {
-		return nil
-	}
-
-	pathMatch := &novaedgev1alpha1.HTTPPathMatch{
-		Value: path.Path,
-	}
-
-	// Convert path type
-	if path.PathType != nil {
-		switch *path.PathType {
-		case networkingv1.PathTypeExact:
-			pathMatch.Type = novaedgev1alpha1.PathMatchExact
-		case networkingv1.PathTypePrefix:
-			pathMatch.Type = novaedgev1alpha1.PathMatchPathPrefix
-		case networkingv1.PathTypeImplementationSpecific:
-			// Default to prefix for implementation-specific
-			pathMatch.Type = novaedgev1alpha1.PathMatchPathPrefix
-		}
-	} else {
-		// Default to prefix if not specified
-		pathMatch.Type = novaedgev1alpha1.PathMatchPathPrefix
-	}
-
-	return pathMatch
-}
-
 // convertPathMatchWithIngress converts path with regex support from annotation
 func (t *IngressTranslator) convertPathMatchWithIngress(ingress *networkingv1.Ingress, path networkingv1.HTTPIngressPath) *novaedgev1alpha1.HTTPPathMatch {
 	if path.Path == "" {
@@ -873,41 +844,9 @@ func (t *IngressTranslator) getRequestHeaders(ingress *networkingv1.Ingress) map
 	return headers
 }
 
-// getResponseHeaders parses response headers annotation (JSON map)
-func (t *IngressTranslator) getResponseHeaders(ingress *networkingv1.Ingress) map[string]string {
-	headersJSON, exists := ingress.Annotations[AnnotationResponseHeaders]
-	if !exists || headersJSON == "" {
-		return nil
-	}
-
-	var headers map[string]string
-	if err := json.Unmarshal([]byte(headersJSON), &headers); err != nil {
-		return nil
-	}
-	return headers
-}
-
 // getRemoveRequestHeaders parses remove request headers annotation (comma-separated)
 func (t *IngressTranslator) getRemoveRequestHeaders(ingress *networkingv1.Ingress) []string {
 	headers, exists := ingress.Annotations[AnnotationRemoveRequestHeaders]
-	if !exists || headers == "" {
-		return nil
-	}
-
-	parts := strings.Split(headers, ",")
-	result := make([]string, 0, len(parts))
-	for _, part := range parts {
-		trimmed := strings.TrimSpace(part)
-		if trimmed != "" {
-			result = append(result, trimmed)
-		}
-	}
-	return result
-}
-
-// getRemoveResponseHeaders parses remove response headers annotation (comma-separated)
-func (t *IngressTranslator) getRemoveResponseHeaders(ingress *networkingv1.Ingress) []string {
-	headers, exists := ingress.Annotations[AnnotationRemoveResponseHeaders]
 	if !exists || headers == "" {
 		return nil
 	}
@@ -1193,18 +1132,3 @@ func (t *IngressTranslator) useRegexPathMatching(ingress *networkingv1.Ingress) 
 	return strings.ToLower(ingress.Annotations[AnnotationUseRegex]) == "true"
 }
 
-// splitCommaSeparated splits a comma-separated string and trims whitespace
-func splitCommaSeparated(s string) []string {
-	if s == "" {
-		return nil
-	}
-	parts := strings.Split(s, ",")
-	result := make([]string, 0, len(parts))
-	for _, part := range parts {
-		trimmed := strings.TrimSpace(part)
-		if trimmed != "" {
-			result = append(result, trimmed)
-		}
-	}
-	return result
-}

--- a/internal/controller/snapshot/builder_test.go
+++ b/internal/controller/snapshot/builder_test.go
@@ -22,7 +22,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
@@ -230,12 +229,3 @@ func TestSnapshotCacheOperations(t *testing.T) {
 	}
 }
 
-func newTestClient(objs ...client.Object) client.Client {
-	scheme := runtime.NewScheme()
-	_ = novaedgev1alpha1.AddToScheme(scheme)
-
-	return fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(objs...).
-		Build()
-}

--- a/internal/controller/test_setup.go
+++ b/internal/controller/test_setup.go
@@ -47,13 +47,6 @@ type testEnv struct {
 	proxyPolicyReconciler  *ProxyPolicyReconciler
 }
 
-// setupTestEnvironment creates a fake Kubernetes client with all required schemes
-func setupTestEnvironment(t *testing.T) client.Client {
-	t.Helper()
-	env := setupTestEnv(t)
-	return env.client
-}
-
 // setupTestEnv creates a full test environment with all reconcilers
 func setupTestEnv(t *testing.T) *testEnv {
 	t.Helper()
@@ -176,14 +169,6 @@ func (e *testEnv) reconcileProxyBackend(ctx context.Context, name, namespace str
 // reconcileProxyGateway manually triggers reconciliation for a ProxyGateway
 func (e *testEnv) reconcileProxyGateway(ctx context.Context, name, namespace string) error {
 	_, err := e.proxyGatewayReconciler.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: name, Namespace: namespace},
-	})
-	return err
-}
-
-// reconcileProxyRoute manually triggers reconciliation for a ProxyRoute
-func (e *testEnv) reconcileProxyRoute(ctx context.Context, name, namespace string) error {
-	_, err := e.proxyRouteReconciler.Reconcile(ctx, ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: name, Namespace: namespace},
 	})
 	return err


### PR DESCRIPTION
## Summary
- Removed 14 pieces of dead code (unused functions, methods, variables, and test helpers) across 9 files, totaling 205 lines deleted
- Cleaned up orphaned imports (`sync` in websocket.go, `client` in builder_test.go) that became unused after the removals
- Verified the codebase compiles (`go build ./...`), all tests pass (`go test ./...`), and `golangci-lint --enable unused` reports no unused code warnings

## Details

### Production code removed
| Item | File |
|------|------|
| `endpointCardinalityTracker.removeEndpoint` | `internal/agent/metrics/metrics.go` |
| `FailoverWatcher.updateControllerReachability` | `internal/agent/config/failover.go` |
| `FailoverWatcher.probeAllControllers` | `internal/agent/config/failover.go` |
| `wsMessagePool` (sync.Pool) | `internal/agent/router/websocket.go` |
| `HTTPServer.createTLSConfig` | `internal/agent/server/tls_config.go` |
| `PeerClientWithCerts.buildTLSConfig` | `internal/controller/federation/client.go` |
| `IngressTranslator.convertPathMatch` | `internal/controller/ingress_translator.go` |
| `IngressTranslator.getResponseHeaders` | `internal/controller/ingress_translator.go` |
| `IngressTranslator.getRemoveResponseHeaders` | `internal/controller/ingress_translator.go` |
| `splitCommaSeparated` | `internal/controller/ingress_translator.go` |
| `prometheusQuery` variable | `cmd/novactl/cmd/metrics_query.go` |

### Test helpers removed
| Item | File |
|------|------|
| `setupTestEnvironment` | `internal/controller/test_setup.go` |
| `testEnv.reconcileProxyRoute` | `internal/controller/test_setup.go` |
| `newTestClient` | `internal/controller/snapshot/builder_test.go` |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run --enable unused` reports no unused code

Resolves #33