### PR TITLE
Add unit tests for untested packages

### DIFF
--- a/internal/acme/client_test.go
+++ b/internal/acme/client_test.go
@@ -1,0 +1,240 @@
+package acme
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// memoryStorage implements Storage interface for testing without filesystem or mocks
+type memoryStorage struct {
+	certs   map[string]*Certificate
+	account *AccountInfo
+}
+
+func newMemoryStorage() *memoryStorage {
+	return &memoryStorage{
+		certs: make(map[string]*Certificate),
+	}
+}
+
+func (s *memoryStorage) SaveCertificate(_ context.Context, cert *Certificate) error {
+	if len(cert.Domains) > 0 {
+		s.certs[cert.Domains[0]] = cert
+	}
+	return nil
+}
+
+func (s *memoryStorage) LoadCertificate(_ context.Context, domain string) (*Certificate, error) {
+	cert, ok := s.certs[domain]
+	if !ok {
+		return nil, &notFoundError{domain: domain}
+	}
+	return cert, nil
+}
+
+func (s *memoryStorage) DeleteCertificate(_ context.Context, domain string) error {
+	delete(s.certs, domain)
+	return nil
+}
+
+func (s *memoryStorage) ListCertificates(_ context.Context) ([]*Certificate, error) {
+	var result []*Certificate
+	for _, cert := range s.certs {
+		result = append(result, cert)
+	}
+	return result, nil
+}
+
+func (s *memoryStorage) SaveAccount(_ context.Context, account *AccountInfo) error {
+	s.account = account
+	return nil
+}
+
+func (s *memoryStorage) LoadAccount(_ context.Context) (*AccountInfo, error) {
+	if s.account == nil {
+		return nil, &notFoundError{domain: "account"}
+	}
+	return s.account, nil
+}
+
+type notFoundError struct {
+	domain string
+}
+
+func (e *notFoundError) Error() string {
+	return "not found: " + e.domain
+}
+
+func TestNewClient_NilConfig(t *testing.T) {
+	_, err := NewClient(nil, newMemoryStorage(), nil, zap.NewNop())
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+}
+
+func TestNewClient_NilStorage(t *testing.T) {
+	config := &Config{Email: "test@example.com"}
+	_, err := NewClient(config, nil, nil, zap.NewNop())
+	if err == nil {
+		t.Fatal("expected error for nil storage")
+	}
+}
+
+func TestNewClient_NilLogger(t *testing.T) {
+	config := &Config{Email: "test@example.com"}
+	storage := newMemoryStorage()
+
+	client, err := NewClient(config, storage, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if client.logger == nil {
+		t.Error("expected logger to be set to nop logger when nil")
+	}
+}
+
+func TestNewClient_Success(t *testing.T) {
+	config := &Config{
+		Email:  "test@example.com",
+		Server: LetsEncryptStaging,
+	}
+	storage := newMemoryStorage()
+	logger := zap.NewNop()
+
+	client, err := NewClient(config, storage, nil, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if client.config.Server != LetsEncryptStaging {
+		t.Errorf("expected server %q, got %q", LetsEncryptStaging, client.config.Server)
+	}
+}
+
+func TestNewClient_AppliesDefaults(t *testing.T) {
+	config := &Config{
+		Email: "test@example.com",
+	}
+	storage := newMemoryStorage()
+
+	client, err := NewClient(config, storage, nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// After ApplyDefaults, Server should be set
+	if client.config.Server != DefaultServer {
+		t.Errorf("expected default server %q, got %q", DefaultServer, client.config.Server)
+	}
+	if client.config.KeyType != DefaultKeyType {
+		t.Errorf("expected default key type %q, got %q", DefaultKeyType, client.config.KeyType)
+	}
+	if client.config.RenewalDays != DefaultRenewalDays {
+		t.Errorf("expected default renewal days %d, got %d", DefaultRenewalDays, client.config.RenewalDays)
+	}
+}
+
+func TestClient_ObtainCertificate_NotInitialized(t *testing.T) {
+	config := &Config{Email: "test@example.com"}
+	storage := newMemoryStorage()
+	client, err := NewClient(config, storage, nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ObtainCertificate without Initialize should fail
+	_, err = client.ObtainCertificate(context.Background(), &CertificateRequest{
+		Domains: []string{"example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected error when client is not initialized")
+	}
+}
+
+func TestClient_ObtainCertificate_EmptyDomains(t *testing.T) {
+	config := &Config{Email: "test@example.com"}
+	storage := newMemoryStorage()
+	client, err := NewClient(config, storage, nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Manually set client to simulate initialization
+	// We can't actually call Initialize (requires ACME server) so we test the domain validation
+	_, err = client.ObtainCertificate(context.Background(), &CertificateRequest{
+		Domains: []string{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty domains")
+	}
+}
+
+func TestClient_Close(t *testing.T) {
+	config := &Config{Email: "test@example.com"}
+	storage := newMemoryStorage()
+	client, err := NewClient(config, storage, nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = client.Close()
+	if err != nil {
+		t.Fatalf("unexpected error on close: %v", err)
+	}
+}
+
+func TestParseCertificatePEM_InvalidData(t *testing.T) {
+	_, err := ParseCertificatePEM([]byte("not a certificate"))
+	if err == nil {
+		t.Fatal("expected error for invalid certificate data")
+	}
+}
+
+func TestParseCertificatePEM_ValidSelfSigned(t *testing.T) {
+	// Generate a real self-signed cert to parse
+	cert, err := QuickSelfSigned("test.example.com")
+	if err != nil {
+		t.Fatalf("failed to generate self-signed cert: %v", err)
+	}
+
+	parsed, err := ParseCertificatePEM(cert.CertificatePEM)
+	if err != nil {
+		t.Fatalf("failed to parse valid certificate PEM: %v", err)
+	}
+
+	if parsed.Subject.CommonName != "test.example.com" {
+		t.Errorf("expected CN 'test.example.com', got %q", parsed.Subject.CommonName)
+	}
+}
+
+func TestUser_GetEmail(t *testing.T) {
+	u := &User{email: "user@example.com"}
+	if u.GetEmail() != "user@example.com" {
+		t.Errorf("expected email 'user@example.com', got %q", u.GetEmail())
+	}
+}
+
+func TestUser_GetRegistration_Empty(t *testing.T) {
+	u := &User{email: "user@example.com"}
+	if u.GetRegistration() != nil {
+		t.Error("expected nil registration for user with no account URI")
+	}
+}
+
+func TestUser_GetRegistration_WithURI(t *testing.T) {
+	u := &User{email: "user@example.com", accountURI: "https://acme.example.com/account/123"}
+	reg := u.GetRegistration()
+	if reg == nil {
+		t.Fatal("expected non-nil registration")
+	}
+	if reg.URI != "https://acme.example.com/account/123" {
+		t.Errorf("expected URI, got %q", reg.URI)
+	}
+}

--- a/internal/acme/selfsigned_test.go
+++ b/internal/acme/selfsigned_test.go
@@ -1,0 +1,339 @@
+package acme
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestGenerateSelfSigned_WithDomains(t *testing.T) {
+	config := &SelfSignedConfig{
+		Domains:      []string{"example.com", "www.example.com"},
+		Organization: "Test Org",
+		Validity:     24 * time.Hour,
+		KeyType:      KeyTypeEC256,
+	}
+
+	cert, err := GenerateSelfSigned(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cert == nil {
+		t.Fatal("expected non-nil certificate")
+	}
+	if len(cert.CertificatePEM) == 0 {
+		t.Error("expected non-empty certificate PEM")
+	}
+	if len(cert.PrivateKeyPEM) == 0 {
+		t.Error("expected non-empty private key PEM")
+	}
+	if cert.Issuer != "Self-Signed" {
+		t.Errorf("expected issuer 'Self-Signed', got %q", cert.Issuer)
+	}
+
+	// Parse and verify the certificate
+	block, _ := pem.Decode(cert.CertificatePEM)
+	if block == nil {
+		t.Fatal("failed to decode certificate PEM")
+	}
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if x509Cert.Subject.CommonName != "example.com" {
+		t.Errorf("expected CN 'example.com', got %q", x509Cert.Subject.CommonName)
+	}
+	if len(x509Cert.DNSNames) != 2 {
+		t.Errorf("expected 2 DNS names, got %d", len(x509Cert.DNSNames))
+	}
+}
+
+func TestGenerateSelfSigned_WithIPs(t *testing.T) {
+	config := &SelfSignedConfig{
+		IPs:     []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("::1")},
+		KeyType: KeyTypeEC256,
+	}
+
+	cert, err := GenerateSelfSigned(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	block, _ := pem.Decode(cert.CertificatePEM)
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if len(x509Cert.IPAddresses) != 2 {
+		t.Errorf("expected 2 IP addresses, got %d", len(x509Cert.IPAddresses))
+	}
+}
+
+func TestGenerateSelfSigned_NoDomainsOrIPs(t *testing.T) {
+	config := &SelfSignedConfig{}
+
+	_, err := GenerateSelfSigned(config)
+	if err == nil {
+		t.Fatal("expected error for empty domains and IPs")
+	}
+}
+
+func TestGenerateSelfSigned_RSA2048(t *testing.T) {
+	config := &SelfSignedConfig{
+		Domains: []string{"rsa.example.com"},
+		KeyType: KeyTypeRSA2048,
+	}
+
+	cert, err := GenerateSelfSigned(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify key type by checking the PEM block type
+	block, _ := pem.Decode(cert.PrivateKeyPEM)
+	if block == nil {
+		t.Fatal("failed to decode private key PEM")
+	}
+	if block.Type != "RSA PRIVATE KEY" {
+		t.Errorf("expected RSA PRIVATE KEY, got %q", block.Type)
+	}
+}
+
+func TestGenerateSelfSigned_RSA4096(t *testing.T) {
+	config := &SelfSignedConfig{
+		Domains: []string{"rsa4096.example.com"},
+		KeyType: KeyTypeRSA4096,
+	}
+
+	cert, err := GenerateSelfSigned(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	block, _ := pem.Decode(cert.PrivateKeyPEM)
+	if block == nil {
+		t.Fatal("failed to decode private key PEM")
+	}
+	if block.Type != "RSA PRIVATE KEY" {
+		t.Errorf("expected RSA PRIVATE KEY, got %q", block.Type)
+	}
+}
+
+func TestGenerateSelfSigned_EC384(t *testing.T) {
+	config := &SelfSignedConfig{
+		Domains: []string{"ec384.example.com"},
+		KeyType: KeyTypeEC384,
+	}
+
+	cert, err := GenerateSelfSigned(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	block, _ := pem.Decode(cert.PrivateKeyPEM)
+	if block == nil {
+		t.Fatal("failed to decode private key PEM")
+	}
+	if block.Type != "EC PRIVATE KEY" {
+		t.Errorf("expected EC PRIVATE KEY, got %q", block.Type)
+	}
+}
+
+func TestGenerateSelfSigned_UnsupportedKeyType(t *testing.T) {
+	config := &SelfSignedConfig{
+		Domains: []string{"bad.example.com"},
+		KeyType: "INVALID_KEY_TYPE",
+	}
+
+	_, err := GenerateSelfSigned(config)
+	if err == nil {
+		t.Fatal("expected error for unsupported key type")
+	}
+}
+
+func TestGenerateSelfSigned_DefaultValues(t *testing.T) {
+	config := &SelfSignedConfig{
+		Domains: []string{"defaults.example.com"},
+	}
+
+	cert, err := GenerateSelfSigned(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Defaults should be applied: 1 year validity, EC256
+	expectedExpiry := time.Now().Add(365 * 24 * time.Hour)
+	diff := cert.NotAfter.Sub(expectedExpiry)
+	if diff > 5*time.Second || diff < -5*time.Second {
+		t.Errorf("expected ~1 year validity, got NotAfter=%v", cert.NotAfter)
+	}
+
+	block, _ := pem.Decode(cert.PrivateKeyPEM)
+	if block.Type != "EC PRIVATE KEY" {
+		t.Errorf("expected default EC key, got %q", block.Type)
+	}
+}
+
+func TestGenerateSelfSigned_CACertificate(t *testing.T) {
+	config := &SelfSignedConfig{
+		Domains:      []string{"CA"},
+		Organization: "Test CA",
+		IsCA:         true,
+		KeyType:      KeyTypeEC256,
+	}
+
+	cert, err := GenerateSelfSigned(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	block, _ := pem.Decode(cert.CertificatePEM)
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if !x509Cert.IsCA {
+		t.Error("expected CA certificate")
+	}
+	if x509Cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Error("expected cert signing key usage for CA")
+	}
+}
+
+func TestGenerateCA(t *testing.T) {
+	cert, err := GenerateCA("Test Organization", 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	block, _ := pem.Decode(cert.CertificatePEM)
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA certificate: %v", err)
+	}
+
+	if !x509Cert.IsCA {
+		t.Error("expected CA certificate from GenerateCA")
+	}
+}
+
+func TestSignCertificate(t *testing.T) {
+	// Generate CA
+	caCert, err := GenerateCA("Test CA", 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	// Sign a certificate with the CA
+	config := &SelfSignedConfig{
+		Domains:      []string{"signed.example.com"},
+		Organization: "Test Org",
+		Validity:     24 * time.Hour,
+		KeyType:      KeyTypeEC256,
+	}
+
+	cert, err := SignCertificate(caCert, config)
+	if err != nil {
+		t.Fatalf("failed to sign certificate: %v", err)
+	}
+
+	if cert == nil {
+		t.Fatal("expected non-nil certificate")
+	}
+
+	// Verify the certificate was signed by the CA
+	block, _ := pem.Decode(cert.CertificatePEM)
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse signed certificate: %v", err)
+	}
+
+	caBlock, _ := pem.Decode(caCert.CertificatePEM)
+	caX509, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA certificate: %v", err)
+	}
+
+	// Verify chain
+	pool := x509.NewCertPool()
+	pool.AddCert(caX509)
+	_, err = x509Cert.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	if err != nil {
+		t.Fatalf("certificate verification failed: %v", err)
+	}
+}
+
+func TestSignCertificate_NoDomainsOrIPs(t *testing.T) {
+	caCert, err := GenerateCA("Test CA", 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	config := &SelfSignedConfig{}
+	_, err = SignCertificate(caCert, config)
+	if err == nil {
+		t.Fatal("expected error for empty domains and IPs")
+	}
+}
+
+func TestQuickSelfSigned_Default(t *testing.T) {
+	cert, err := QuickSelfSigned()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	block, _ := pem.Decode(cert.CertificatePEM)
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if x509Cert.Subject.CommonName != "localhost" {
+		t.Errorf("expected CN 'localhost', got %q", x509Cert.Subject.CommonName)
+	}
+}
+
+func TestQuickSelfSigned_CustomDomains(t *testing.T) {
+	cert, err := QuickSelfSigned("myapp.local", "api.myapp.local")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	block, _ := pem.Decode(cert.CertificatePEM)
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	if x509Cert.Subject.CommonName != "myapp.local" {
+		t.Errorf("expected CN 'myapp.local', got %q", x509Cert.Subject.CommonName)
+	}
+	if len(x509Cert.DNSNames) != 2 {
+		t.Errorf("expected 2 DNS names, got %d", len(x509Cert.DNSNames))
+	}
+}
+
+func TestGenerateSelfSigned_TLSCertificate(t *testing.T) {
+	cert, err := QuickSelfSigned("tls.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the certificate can be used as tls.Certificate
+	tlsCert, err := cert.TLSCertificate()
+	if err != nil {
+		t.Fatalf("failed to create TLS certificate: %v", err)
+	}
+	if tlsCert == nil {
+		t.Fatal("expected non-nil TLS certificate")
+	}
+}

--- a/internal/agent/config/validation_test.go
+++ b/internal/agent/config/validation_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	pkgerrors "github.com/piwi3910/novaedge/internal/pkg/errors"
+	pb "github.com/piwi3910/novaedge/internal/proto/gen"
+)
+
+func TestNewValidator(t *testing.T) {
+	v := NewValidator()
+	if v == nil {
+		t.Fatal("expected non-nil validator")
+	}
+}
+
+func TestValidateSnapshot_NilSnapshot(t *testing.T) {
+	v := NewValidator()
+
+	err := v.ValidateSnapshot(nil)
+	if err == nil {
+		t.Fatal("expected error for nil snapshot")
+	}
+
+	var validationErr *pkgerrors.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateSnapshot_NilConfigSnapshot(t *testing.T) {
+	v := NewValidator()
+
+	snapshot := &Snapshot{ConfigSnapshot: nil}
+	err := v.ValidateSnapshot(snapshot)
+	if err == nil {
+		t.Fatal("expected error for nil ConfigSnapshot")
+	}
+
+	var validationErr *pkgerrors.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateSnapshot_EmptyVersion(t *testing.T) {
+	v := NewValidator()
+
+	snapshot := &Snapshot{
+		ConfigSnapshot: &pb.ConfigSnapshot{
+			Version: "",
+		},
+	}
+	err := v.ValidateSnapshot(snapshot)
+	if err == nil {
+		t.Fatal("expected error for empty version")
+	}
+
+	var validationErr *pkgerrors.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateSnapshot_ValidSnapshot(t *testing.T) {
+	v := NewValidator()
+
+	snapshot := &Snapshot{
+		ConfigSnapshot: &pb.ConfigSnapshot{
+			Version: "v1",
+		},
+	}
+	err := v.ValidateSnapshot(snapshot)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateSnapshot_ValidSnapshotWithData(t *testing.T) {
+	v := NewValidator()
+
+	snapshot := &Snapshot{
+		ConfigSnapshot: &pb.ConfigSnapshot{
+			Version:        "v2",
+			GenerationTime: 1234567890,
+			Gateways:       []*pb.Gateway{},
+			Routes:         []*pb.Route{},
+			Clusters:       []*pb.Cluster{},
+		},
+	}
+	err := v.ValidateSnapshot(snapshot)
+	if err != nil {
+		t.Fatalf("expected no error for valid snapshot with data, got %v", err)
+	}
+}

--- a/internal/agent/config/watcher_test.go
+++ b/internal/agent/config/watcher_test.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewWatcher(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	w, err := NewWatcher(ctx, "node-1", "v1.0.0", "localhost:9090", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w == nil {
+		t.Fatal("expected non-nil watcher")
+	}
+	if w.nodeName != "node-1" {
+		t.Errorf("expected nodeName 'node-1', got %q", w.nodeName)
+	}
+	if w.agentVersion != "v1.0.0" {
+		t.Errorf("expected agentVersion 'v1.0.0', got %q", w.agentVersion)
+	}
+	if w.controllerAddr != "localhost:9090" {
+		t.Errorf("expected controllerAddr 'localhost:9090', got %q", w.controllerAddr)
+	}
+	if w.tlsEnabled {
+		t.Error("expected TLS to be disabled by default")
+	}
+}
+
+func TestNewWatcherWithTLS_Success(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	tlsConfig := &TLSConfig{
+		CertFile: "/etc/certs/tls.crt",
+		KeyFile:  "/etc/certs/tls.key",
+		CAFile:   "/etc/certs/ca.crt",
+	}
+
+	w, err := NewWatcherWithTLS(ctx, "node-1", "v1.0.0", "localhost:9090", tlsConfig, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w == nil {
+		t.Fatal("expected non-nil watcher")
+	}
+	if !w.tlsEnabled {
+		t.Error("expected TLS to be enabled")
+	}
+	if w.tlsCertFile != "/etc/certs/tls.crt" {
+		t.Errorf("expected cert file path, got %q", w.tlsCertFile)
+	}
+}
+
+func TestNewWatcherWithTLS_NilConfig(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	_, err := NewWatcherWithTLS(ctx, "node-1", "v1.0.0", "localhost:9090", nil, logger)
+	if err == nil {
+		t.Fatal("expected error for nil TLS config")
+	}
+}
+
+func TestNewWatcherWithTLS_IncompleteCert(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	tlsConfig := &TLSConfig{
+		CertFile: "/etc/certs/tls.crt",
+		KeyFile:  "",
+		CAFile:   "/etc/certs/ca.crt",
+	}
+
+	_, err := NewWatcherWithTLS(ctx, "node-1", "v1.0.0", "localhost:9090", tlsConfig, logger)
+	if err == nil {
+		t.Fatal("expected error for incomplete TLS config")
+	}
+}
+
+func TestNewRemoteWatcher_Success(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	tlsConfig := &TLSConfig{
+		CertFile: "/etc/certs/tls.crt",
+		KeyFile:  "/etc/certs/tls.key",
+		CAFile:   "/etc/certs/ca.crt",
+	}
+	clusterConfig := &ClusterConfig{
+		Name:   "cluster-west",
+		Region: "us-west-2",
+		Zone:   "us-west-2a",
+		Labels: map[string]string{"env": "prod"},
+	}
+
+	w, err := NewRemoteWatcher(ctx, "node-1", "v1.0.0", "hub:9090", tlsConfig, clusterConfig, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w == nil {
+		t.Fatal("expected non-nil watcher")
+	}
+	if !w.IsRemote() {
+		t.Error("expected IsRemote to return true")
+	}
+	if w.GetClusterName() != "cluster-west" {
+		t.Errorf("expected cluster name 'cluster-west', got %q", w.GetClusterName())
+	}
+	if w.clusterRegion != "us-west-2" {
+		t.Errorf("expected region 'us-west-2', got %q", w.clusterRegion)
+	}
+}
+
+func TestNewRemoteWatcher_NilTLSConfig(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	clusterConfig := &ClusterConfig{Name: "cluster-west"}
+
+	_, err := NewRemoteWatcher(ctx, "node-1", "v1.0.0", "hub:9090", nil, clusterConfig, logger)
+	if err == nil {
+		t.Fatal("expected error for nil TLS config")
+	}
+}
+
+func TestNewRemoteWatcher_NilClusterConfig(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	tlsConfig := &TLSConfig{
+		CertFile: "/etc/certs/tls.crt",
+		KeyFile:  "/etc/certs/tls.key",
+		CAFile:   "/etc/certs/ca.crt",
+	}
+
+	_, err := NewRemoteWatcher(ctx, "node-1", "v1.0.0", "hub:9090", tlsConfig, nil, logger)
+	if err == nil {
+		t.Fatal("expected error for nil cluster config")
+	}
+}
+
+func TestNewRemoteWatcher_EmptyClusterName(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	tlsConfig := &TLSConfig{
+		CertFile: "/etc/certs/tls.crt",
+		KeyFile:  "/etc/certs/tls.key",
+		CAFile:   "/etc/certs/ca.crt",
+	}
+	clusterConfig := &ClusterConfig{Name: ""}
+
+	_, err := NewRemoteWatcher(ctx, "node-1", "v1.0.0", "hub:9090", tlsConfig, clusterConfig, logger)
+	if err == nil {
+		t.Fatal("expected error for empty cluster name")
+	}
+}
+
+func TestWatcher_IsRemote_LocalAgent(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	w, err := NewWatcher(ctx, "node-1", "v1.0.0", "localhost:9090", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.IsRemote() {
+		t.Error("expected IsRemote to return false for local agent")
+	}
+	if w.GetClusterName() != "" {
+		t.Errorf("expected empty cluster name for local agent, got %q", w.GetClusterName())
+	}
+}

--- a/internal/agent/grpc/handler_test.go
+++ b/internal/agent/grpc/handler_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewGRPCHandler(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	if h == nil {
+		t.Fatal("expected non-nil handler")
+	}
+}
+
+func TestPrepareGRPCRequest_PreservesHeaders(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	req, _ := http.NewRequest("POST", "http://backend/test.Service/Method", nil)
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("grpc-encoding", "gzip")
+	req.Header.Set("grpc-accept-encoding", "gzip,identity")
+	req.Header.Set("grpc-timeout", "5S")
+	req.Header.Set("grpc-user-agent", "grpc-go/1.50.0")
+	req.Header.Set("grpc-trace-bin", "abc123")
+
+	prepared := h.PrepareGRPCRequest(req)
+
+	if prepared.Header.Get("Content-Type") != "application/grpc" {
+		t.Errorf("expected Content-Type 'application/grpc', got %q", prepared.Header.Get("Content-Type"))
+	}
+	if prepared.Header.Get("grpc-encoding") != "gzip" {
+		t.Errorf("expected grpc-encoding 'gzip', got %q", prepared.Header.Get("grpc-encoding"))
+	}
+	if prepared.Header.Get("grpc-accept-encoding") != "gzip,identity" {
+		t.Errorf("expected grpc-accept-encoding 'gzip,identity', got %q", prepared.Header.Get("grpc-accept-encoding"))
+	}
+	if prepared.Header.Get("grpc-timeout") != "5S" {
+		t.Errorf("expected grpc-timeout '5S', got %q", prepared.Header.Get("grpc-timeout"))
+	}
+}
+
+func TestPrepareGRPCRequest_ClonesRequest(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	req, _ := http.NewRequest("POST", "http://backend/test.Service/Method", nil)
+	req.Header.Set("Content-Type", "application/grpc")
+
+	prepared := h.PrepareGRPCRequest(req)
+
+	// Verify it's a clone, not the same object
+	if prepared == req {
+		t.Error("PrepareGRPCRequest should return a clone, not the original")
+	}
+}
+
+func TestHandleGRPCResponse_CopiesHeaders(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	recorder := httptest.NewRecorder()
+
+	backendResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/grpc"},
+			"Grpc-Status":  []string{"0"},
+			"Grpc-Message": []string{""},
+		},
+		Body: io.NopCloser(bytes.NewBufferString("response body")),
+	}
+
+	err := h.HandleGRPCResponse(recorder, backendResp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", result.StatusCode)
+	}
+	if recorder.Header().Get("Content-Type") != "application/grpc" {
+		t.Errorf("expected Content-Type 'application/grpc', got %q", recorder.Header().Get("Content-Type"))
+	}
+}
+
+func TestHandleGRPCResponse_CopiesTrailers(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	recorder := httptest.NewRecorder()
+
+	backendResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+		Trailer: http.Header{
+			"Grpc-Status":  []string{"0"},
+			"Grpc-Message": []string{"OK"},
+		},
+	}
+
+	err := h.HandleGRPCResponse(recorder, backendResp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateGRPCRequest_ValidPOST(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	req, _ := http.NewRequest("POST", "/test.Service/Method", nil)
+	req.Header.Set("Content-Type", "application/grpc")
+
+	err := h.ValidateGRPCRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error for valid gRPC request: %v", err)
+	}
+}
+
+func TestValidateGRPCRequest_NonPOST_NoError(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	req, _ := http.NewRequest("GET", "/test.Service/Method", nil)
+	req.Header.Set("Content-Type", "application/grpc")
+
+	// ValidateGRPCRequest does not return an error for invalid methods; it logs a warning
+	err := h.ValidateGRPCRequest(req)
+	if err != nil {
+		t.Fatalf("ValidateGRPCRequest should not error, just warn: %v", err)
+	}
+}
+
+func TestGetGRPCMetadata(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	req, _ := http.NewRequest("POST", "/test.Service/Method", nil)
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("Authorization", "Bearer token123")
+	req.Header.Set("X-Custom-Header", "custom-value")
+
+	metadata := h.GetGRPCMetadata(req)
+
+	if _, ok := metadata["Content-Type"]; !ok {
+		t.Error("expected Content-Type in metadata")
+	}
+	if _, ok := metadata["Authorization"]; !ok {
+		t.Error("expected Authorization in metadata")
+	}
+	if _, ok := metadata["X-Custom-Header"]; !ok {
+		t.Error("expected X-Custom-Header in metadata")
+	}
+}
+
+func TestIsGRPCStreaming_Chunked(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	req, _ := http.NewRequest("POST", "/test.Service/StreamMethod", nil)
+	req.Header.Set("Transfer-Encoding", "chunked")
+
+	if !h.IsGRPCStreaming(req) {
+		t.Error("expected streaming detection for chunked transfer encoding")
+	}
+}
+
+func TestIsGRPCStreaming_NoContentLength(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	req, _ := http.NewRequest("POST", "/test.Service/StreamMethod", nil)
+	// No Content-Length and no Transfer-Encoding
+
+	if !h.IsGRPCStreaming(req) {
+		t.Error("expected streaming detection when no Content-Length is set")
+	}
+}
+
+func TestIsGRPCStreaming_WithContentLength(t *testing.T) {
+	logger := zap.NewNop()
+	h := NewGRPCHandler(logger)
+
+	req, _ := http.NewRequest("POST", "/test.Service/UnaryMethod", nil)
+	req.Header.Set("Content-Length", "100")
+
+	if h.IsGRPCStreaming(req) {
+		t.Error("should not detect streaming when Content-Length is set")
+	}
+}
+
+func TestExtractGRPCServiceMethod_Valid(t *testing.T) {
+	tests := []struct {
+		path            string
+		expectedService string
+		expectedMethod  string
+		expectedOk      bool
+	}{
+		{"/grpc.health.v1.Health/Check", "grpc.health.v1.Health", "Check", true},
+		{"/my.package.Service/Method", "my.package.Service", "Method", true},
+		{"/Service/Method", "Service", "Method", true},
+	}
+
+	for _, tt := range tests {
+		service, method, ok := ExtractGRPCServiceMethod(tt.path)
+		if ok != tt.expectedOk {
+			t.Errorf("path %q: expected ok=%v, got %v", tt.path, tt.expectedOk, ok)
+		}
+		if service != tt.expectedService {
+			t.Errorf("path %q: expected service=%q, got %q", tt.path, tt.expectedService, service)
+		}
+		if method != tt.expectedMethod {
+			t.Errorf("path %q: expected method=%q, got %q", tt.path, tt.expectedMethod, method)
+		}
+	}
+}
+
+func TestExtractGRPCServiceMethod_Invalid(t *testing.T) {
+	tests := []struct {
+		path string
+	}{
+		{""},
+		{"noLeadingSlash/Method"},
+		{"/noMethod"},
+	}
+
+	for _, tt := range tests {
+		_, _, ok := ExtractGRPCServiceMethod(tt.path)
+		if ok {
+			t.Errorf("path %q: expected ok=false, got true", tt.path)
+		}
+	}
+}

--- a/internal/agent/health/checker_test.go
+++ b/internal/agent/health/checker_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	pb "github.com/piwi3910/novaedge/internal/proto/gen"
+)
+
+func newTestCluster(name, namespace string) *pb.Cluster {
+	return &pb.Cluster{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
+func newTestEndpoint(address string, port int32) *pb.Endpoint {
+	return &pb.Endpoint{
+		Address: address,
+		Port:    port,
+	}
+}
+
+func TestNewHealthChecker(t *testing.T) {
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	endpoints := []*pb.Endpoint{
+		newTestEndpoint("10.0.0.1", 8080),
+		newTestEndpoint("10.0.0.2", 8080),
+	}
+
+	hc := NewHealthChecker(cluster, endpoints, logger)
+
+	if hc == nil {
+		t.Fatal("expected non-nil health checker")
+	}
+	if hc.cluster != cluster {
+		t.Error("expected cluster to be set")
+	}
+	if len(hc.endpoints) != 2 {
+		t.Errorf("expected 2 endpoints, got %d", len(hc.endpoints))
+	}
+	if hc.httpClient == nil {
+		t.Error("expected non-nil http client")
+	}
+	if hc.httpClient.Timeout != DefaultHealthCheckTimeout {
+		t.Errorf("expected timeout %v, got %v", DefaultHealthCheckTimeout, hc.httpClient.Timeout)
+	}
+}
+
+func TestHealthChecker_IsHealthy_UnknownEndpoint(t *testing.T) {
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	endpoints := []*pb.Endpoint{}
+
+	hc := NewHealthChecker(cluster, endpoints, logger)
+
+	unknownEp := newTestEndpoint("10.0.0.99", 9090)
+	if !hc.IsHealthy(unknownEp) {
+		t.Error("unknown endpoints should be assumed healthy")
+	}
+}
+
+func TestHealthChecker_RecordFailure_ThresholdBehavior(t *testing.T) {
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	ep := newTestEndpoint("10.0.0.1", 8080)
+	endpoints := []*pb.Endpoint{ep}
+
+	hc := NewHealthChecker(cluster, endpoints, logger)
+
+	// Manually initialize results (simulating Start behavior without the goroutine)
+	key := endpointKey(ep)
+	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
+	hc.results[key] = &HealthResult{
+		Endpoint: ep,
+		Healthy:  true,
+	}
+	cb := NewCircuitBreaker(key, DefaultCircuitBreakerConfig(), logger)
+	cb.SetCluster(clusterKey)
+	hc.circuitBreakers[key] = cb
+
+	// Record failures below threshold
+	for i := uint32(0); i < DefaultUnhealthyThreshold-1; i++ {
+		hc.RecordFailure(ep)
+	}
+
+	// Should still be healthy (below threshold)
+	if !hc.results[key].Healthy {
+		t.Error("endpoint should still be healthy below failure threshold")
+	}
+
+	// One more failure to cross threshold
+	hc.RecordFailure(ep)
+
+	if hc.results[key].Healthy {
+		t.Error("endpoint should be unhealthy after crossing failure threshold")
+	}
+
+	if hc.results[key].ConsecutiveFailures != DefaultUnhealthyThreshold {
+		t.Errorf("expected %d consecutive failures, got %d",
+			DefaultUnhealthyThreshold, hc.results[key].ConsecutiveFailures)
+	}
+}
+
+func TestHealthChecker_RecordSuccess_ResetsFailures(t *testing.T) {
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	ep := newTestEndpoint("10.0.0.1", 8080)
+	endpoints := []*pb.Endpoint{ep}
+
+	hc := NewHealthChecker(cluster, endpoints, logger)
+
+	key := endpointKey(ep)
+	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
+	hc.results[key] = &HealthResult{
+		Endpoint: ep,
+		Healthy:  true,
+	}
+	cb := NewCircuitBreaker(key, DefaultCircuitBreakerConfig(), logger)
+	cb.SetCluster(clusterKey)
+	hc.circuitBreakers[key] = cb
+
+	// Record a failure then a success
+	hc.RecordFailure(ep)
+	hc.RecordSuccess(ep)
+
+	// The circuit breaker success doesn't reset the health result failure counter
+	// but the circuit breaker's internal state should be reset
+	cbState := cb.GetState()
+	if cbState != StateClosed {
+		t.Errorf("expected circuit breaker to be closed, got %v", cbState)
+	}
+}
+
+func TestHealthChecker_UpdateEndpoints_AddsNew(t *testing.T) {
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	ep1 := newTestEndpoint("10.0.0.1", 8080)
+	endpoints := []*pb.Endpoint{ep1}
+
+	hc := NewHealthChecker(cluster, endpoints, logger)
+
+	// Initialize ep1
+	key1 := endpointKey(ep1)
+	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
+	hc.results[key1] = &HealthResult{
+		Endpoint: ep1,
+		Healthy:  true,
+	}
+	cb := NewCircuitBreaker(key1, DefaultCircuitBreakerConfig(), logger)
+	cb.SetCluster(clusterKey)
+	hc.circuitBreakers[key1] = cb
+
+	// Add a new endpoint
+	ep2 := newTestEndpoint("10.0.0.2", 8080)
+	hc.UpdateEndpoints([]*pb.Endpoint{ep1, ep2})
+
+	if len(hc.endpoints) != 2 {
+		t.Errorf("expected 2 endpoints, got %d", len(hc.endpoints))
+	}
+
+	key2 := endpointKey(ep2)
+	if _, exists := hc.results[key2]; !exists {
+		t.Error("new endpoint should be added to results")
+	}
+	if _, exists := hc.circuitBreakers[key2]; !exists {
+		t.Error("new endpoint should have a circuit breaker")
+	}
+}
+
+func TestHealthChecker_UpdateEndpoints_RemovesOld(t *testing.T) {
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	ep1 := newTestEndpoint("10.0.0.1", 8080)
+	ep2 := newTestEndpoint("10.0.0.2", 8080)
+	endpoints := []*pb.Endpoint{ep1, ep2}
+
+	hc := NewHealthChecker(cluster, endpoints, logger)
+
+	// Initialize both endpoints
+	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
+	for _, ep := range endpoints {
+		key := endpointKey(ep)
+		hc.results[key] = &HealthResult{Endpoint: ep, Healthy: true}
+		cb := NewCircuitBreaker(key, DefaultCircuitBreakerConfig(), logger)
+		cb.SetCluster(clusterKey)
+		hc.circuitBreakers[key] = cb
+	}
+
+	// Remove ep2
+	hc.UpdateEndpoints([]*pb.Endpoint{ep1})
+
+	key2 := endpointKey(ep2)
+	if _, exists := hc.results[key2]; exists {
+		t.Error("removed endpoint should be deleted from results")
+	}
+	if _, exists := hc.circuitBreakers[key2]; exists {
+		t.Error("removed endpoint should have its circuit breaker deleted")
+	}
+}
+
+func TestHealthChecker_PerformHTTPCheck_Success(t *testing.T) {
+	// Start a test HTTP server that returns 200
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Extract host and port from server URL
+	addr := strings.TrimPrefix(server.URL, "http://")
+	parts := strings.Split(addr, ":")
+	host := parts[0]
+	var port int32
+	fmt.Sscanf(parts[1], "%d", &port)
+
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	ep := newTestEndpoint(host, port)
+
+	hc := NewHealthChecker(cluster, []*pb.Endpoint{ep}, logger)
+
+	healthy, err := hc.performHTTPCheck(ep)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !healthy {
+		t.Error("expected endpoint to be healthy with 200 response")
+	}
+}
+
+func TestHealthChecker_PerformHTTPCheck_ServerError(t *testing.T) {
+	// Start a test HTTP server that returns 500
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	addr := strings.TrimPrefix(server.URL, "http://")
+	parts := strings.Split(addr, ":")
+	host := parts[0]
+	var port int32
+	fmt.Sscanf(parts[1], "%d", &port)
+
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	ep := newTestEndpoint(host, port)
+
+	hc := NewHealthChecker(cluster, []*pb.Endpoint{ep}, logger)
+
+	healthy, err := hc.performHTTPCheck(ep)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if healthy {
+		t.Error("expected endpoint to be unhealthy with 500 response")
+	}
+}
+
+func TestHealthChecker_PerformHTTPCheck_ConnectionRefused(t *testing.T) {
+	logger := zap.NewNop()
+	cluster := newTestCluster("backend", "default")
+	// Use a port that is very unlikely to be in use
+	ep := newTestEndpoint("127.0.0.1", 19999)
+
+	hc := NewHealthChecker(cluster, []*pb.Endpoint{ep}, logger)
+	hc.httpClient.Timeout = 1 * time.Second
+
+	healthy, err := hc.performHTTPCheck(ep)
+	if err == nil {
+		t.Fatal("expected error for connection refused")
+	}
+	if healthy {
+		t.Error("expected endpoint to be unhealthy when connection refused")
+	}
+}
+
+func TestEndpointKey(t *testing.T) {
+	ep := newTestEndpoint("10.0.0.1", 8080)
+	key := endpointKey(ep)
+	expected := "10.0.0.1:8080"
+	if key != expected {
+		t.Errorf("expected key %q, got %q", expected, key)
+	}
+}

--- a/internal/agent/health/circuitbreaker_test.go
+++ b/internal/agent/health/circuitbreaker_test.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestCircuitBreakerState_String(t *testing.T) {
+	tests := []struct {
+		state    CircuitBreakerState
+		expected string
+	}{
+		{StateClosed, "closed"},
+		{StateOpen, "open"},
+		{StateHalfOpen, "half-open"},
+		{CircuitBreakerState(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		got := tt.state.String()
+		if got != tt.expected {
+			t.Errorf("state %d: expected %q, got %q", tt.state, tt.expected, got)
+		}
+	}
+}
+
+func TestDefaultCircuitBreakerConfig(t *testing.T) {
+	config := DefaultCircuitBreakerConfig()
+
+	if config.MaxRequests != 1 {
+		t.Errorf("expected MaxRequests=1, got %d", config.MaxRequests)
+	}
+	if config.Interval != 10*time.Second {
+		t.Errorf("expected Interval=10s, got %v", config.Interval)
+	}
+	if config.Timeout != 30*time.Second {
+		t.Errorf("expected Timeout=30s, got %v", config.Timeout)
+	}
+	if config.ConsecutiveErrors != 5 {
+		t.Errorf("expected ConsecutiveErrors=5, got %d", config.ConsecutiveErrors)
+	}
+}
+
+func TestNewCircuitBreaker(t *testing.T) {
+	logger := zap.NewNop()
+	config := DefaultCircuitBreakerConfig()
+
+	cb := NewCircuitBreaker("10.0.0.1:8080", config, logger)
+
+	if cb == nil {
+		t.Fatal("expected non-nil circuit breaker")
+	}
+	if cb.state != StateClosed {
+		t.Errorf("expected initial state Closed, got %v", cb.state)
+	}
+	if cb.endpoint != "10.0.0.1:8080" {
+		t.Errorf("expected endpoint '10.0.0.1:8080', got %q", cb.endpoint)
+	}
+}
+
+func TestCircuitBreaker_ClosedState_AllowsRequests(t *testing.T) {
+	logger := zap.NewNop()
+	cb := NewCircuitBreaker("ep", DefaultCircuitBreakerConfig(), logger)
+	cb.SetCluster("default/test")
+
+	if !cb.Allow() {
+		t.Error("closed circuit breaker should allow requests")
+	}
+	if cb.IsOpen() {
+		t.Error("circuit breaker should not be open initially")
+	}
+}
+
+func TestCircuitBreaker_ClosedToOpen_ConsecutiveFailures(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		MaxRequests:       1,
+		Interval:          10 * time.Second,
+		Timeout:           100 * time.Millisecond, // Short for testing
+		ConsecutiveErrors: 3,
+	}
+	cb := NewCircuitBreaker("ep", config, logger)
+	cb.SetCluster("default/test")
+
+	// Record consecutive failures below threshold
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.GetState() != StateClosed {
+		t.Error("should still be closed below threshold")
+	}
+
+	// Third failure should trip the circuit
+	cb.RecordFailure()
+	if cb.GetState() != StateOpen {
+		t.Errorf("expected open state after %d failures, got %v", config.ConsecutiveErrors, cb.GetState())
+	}
+	if !cb.IsOpen() {
+		t.Error("IsOpen should return true when state is open")
+	}
+}
+
+func TestCircuitBreaker_OpenState_RejectsRequests(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		MaxRequests:       1,
+		Interval:          10 * time.Second,
+		Timeout:           1 * time.Hour, // Long timeout so it stays open
+		ConsecutiveErrors: 1,
+	}
+	cb := NewCircuitBreaker("ep", config, logger)
+	cb.SetCluster("default/test")
+
+	cb.RecordFailure()
+
+	if cb.GetState() != StateOpen {
+		t.Fatal("expected open state")
+	}
+	if cb.Allow() {
+		t.Error("open circuit breaker should reject requests")
+	}
+}
+
+func TestCircuitBreaker_OpenToHalfOpen_AfterTimeout(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		MaxRequests:       1,
+		Interval:          10 * time.Second,
+		Timeout:           50 * time.Millisecond,
+		ConsecutiveErrors: 1,
+	}
+	cb := NewCircuitBreaker("ep", config, logger)
+	cb.SetCluster("default/test")
+
+	// Trip the circuit
+	cb.RecordFailure()
+	if cb.GetState() != StateOpen {
+		t.Fatal("expected open state")
+	}
+
+	// Wait for timeout to elapse
+	time.Sleep(100 * time.Millisecond)
+
+	// Next Allow() should transition to half-open
+	allowed := cb.Allow()
+	if !allowed {
+		t.Error("should allow request after timeout (transition to half-open)")
+	}
+	if cb.GetState() != StateHalfOpen {
+		t.Errorf("expected half-open state, got %v", cb.GetState())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenToClosed_OnSuccess(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		MaxRequests:       1,
+		Interval:          10 * time.Second,
+		Timeout:           50 * time.Millisecond,
+		ConsecutiveErrors: 1,
+	}
+	cb := NewCircuitBreaker("ep", config, logger)
+	cb.SetCluster("default/test")
+
+	// Trip the circuit
+	cb.RecordFailure()
+	time.Sleep(100 * time.Millisecond)
+	cb.Allow() // Transitions to half-open
+
+	if cb.GetState() != StateHalfOpen {
+		t.Fatal("expected half-open state")
+	}
+
+	// Record success in half-open state
+	cb.RecordSuccess()
+	if cb.GetState() != StateClosed {
+		t.Errorf("expected closed state after success in half-open, got %v", cb.GetState())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenToOpen_OnFailure(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		MaxRequests:       1,
+		Interval:          10 * time.Second,
+		Timeout:           50 * time.Millisecond,
+		ConsecutiveErrors: 1,
+	}
+	cb := NewCircuitBreaker("ep", config, logger)
+	cb.SetCluster("default/test")
+
+	// Trip the circuit
+	cb.RecordFailure()
+	time.Sleep(100 * time.Millisecond)
+	cb.Allow() // Transitions to half-open
+
+	if cb.GetState() != StateHalfOpen {
+		t.Fatal("expected half-open state")
+	}
+
+	// Record failure in half-open state
+	cb.RecordFailure()
+	if cb.GetState() != StateOpen {
+		t.Errorf("expected open state after failure in half-open, got %v", cb.GetState())
+	}
+}
+
+func TestCircuitBreaker_HalfOpen_LimitsRequests(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		MaxRequests:       2,
+		Interval:          10 * time.Second,
+		Timeout:           50 * time.Millisecond,
+		ConsecutiveErrors: 1,
+	}
+	cb := NewCircuitBreaker("ep", config, logger)
+	cb.SetCluster("default/test")
+
+	// Trip the circuit
+	cb.RecordFailure()
+	time.Sleep(100 * time.Millisecond)
+
+	// First call transitions from open to half-open (does not count toward MaxRequests)
+	if !cb.Allow() {
+		t.Error("transition request should be allowed")
+	}
+	if cb.GetState() != StateHalfOpen {
+		t.Fatal("expected half-open state after timeout")
+	}
+
+	// Second and third calls count toward MaxRequests=2
+	if !cb.Allow() {
+		t.Error("first counted request in half-open should be allowed")
+	}
+	if !cb.Allow() {
+		t.Error("second counted request in half-open should be allowed (MaxRequests=2)")
+	}
+	// Fourth call should be rejected (exceeded MaxRequests)
+	if cb.Allow() {
+		t.Error("request beyond MaxRequests in half-open should be rejected")
+	}
+}
+
+func TestCircuitBreaker_Reset(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		MaxRequests:       1,
+		Interval:          10 * time.Second,
+		Timeout:           1 * time.Hour,
+		ConsecutiveErrors: 1,
+	}
+	cb := NewCircuitBreaker("ep", config, logger)
+	cb.SetCluster("default/test")
+
+	// Trip the circuit
+	cb.RecordFailure()
+	if cb.GetState() != StateOpen {
+		t.Fatal("expected open state")
+	}
+
+	// Reset
+	cb.Reset()
+	if cb.GetState() != StateClosed {
+		t.Errorf("expected closed state after reset, got %v", cb.GetState())
+	}
+	if !cb.Allow() {
+		t.Error("should allow requests after reset")
+	}
+}
+
+func TestCircuitBreaker_SuccessResetsFailureCount(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		MaxRequests:       1,
+		Interval:          10 * time.Second,
+		Timeout:           30 * time.Second,
+		ConsecutiveErrors: 5,
+	}
+	cb := NewCircuitBreaker("ep", config, logger)
+	cb.SetCluster("default/test")
+
+	// Record some failures but not enough to trip
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// A success should reset the counter
+	cb.RecordSuccess()
+
+	// Now we need 5 more failures to trip
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.GetState() != StateClosed {
+		t.Error("should still be closed, success reset the failure count")
+	}
+
+	// Fifth failure after reset should trip it
+	cb.RecordFailure()
+	if cb.GetState() != StateOpen {
+		t.Error("should be open after 5 consecutive failures")
+	}
+}
+
+func TestCircuitBreaker_GetStats(t *testing.T) {
+	logger := zap.NewNop()
+	cb := NewCircuitBreaker("10.0.0.1:8080", DefaultCircuitBreakerConfig(), logger)
+	cb.SetCluster("default/test")
+
+	stats := cb.GetStats()
+
+	if stats["state"] != "closed" {
+		t.Errorf("expected state 'closed', got %v", stats["state"])
+	}
+	if stats["endpoint"] != "10.0.0.1:8080" {
+		t.Errorf("expected endpoint '10.0.0.1:8080', got %v", stats["endpoint"])
+	}
+	if stats["consecutive_failures"].(uint32) != 0 {
+		t.Errorf("expected 0 consecutive failures, got %v", stats["consecutive_failures"])
+	}
+	if stats["consecutive_successes"].(uint32) != 0 {
+		t.Errorf("expected 0 consecutive successes, got %v", stats["consecutive_successes"])
+	}
+}
+
+func TestCircuitBreaker_SetCluster(t *testing.T) {
+	logger := zap.NewNop()
+	cb := NewCircuitBreaker("ep", DefaultCircuitBreakerConfig(), logger)
+
+	cb.SetCluster("prod/myservice")
+
+	if cb.cluster != "prod/myservice" {
+		t.Errorf("expected cluster 'prod/myservice', got %q", cb.cluster)
+	}
+}

--- a/internal/agent/protocol/detection_test.go
+++ b/internal/agent/protocol/detection_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIsGRPCRequest_HTTP2WithGRPCContentType(t *testing.T) {
+	req, _ := http.NewRequest("POST", "/test.Service/Method", nil)
+	req.ProtoMajor = 2
+	req.Header.Set("Content-Type", "application/grpc")
+
+	if !IsGRPCRequest(req) {
+		t.Error("expected HTTP/2 request with application/grpc to be detected as gRPC")
+	}
+}
+
+func TestIsGRPCRequest_HTTP2WithGRPCProto(t *testing.T) {
+	req, _ := http.NewRequest("POST", "/test.Service/Method", nil)
+	req.ProtoMajor = 2
+	req.Header.Set("Content-Type", "application/grpc+proto")
+
+	if !IsGRPCRequest(req) {
+		t.Error("expected HTTP/2 request with application/grpc+proto to be detected as gRPC")
+	}
+}
+
+func TestIsGRPCRequest_HTTP1_NotGRPC(t *testing.T) {
+	req, _ := http.NewRequest("POST", "/test.Service/Method", nil)
+	req.ProtoMajor = 1
+	req.Header.Set("Content-Type", "application/grpc")
+
+	if IsGRPCRequest(req) {
+		t.Error("HTTP/1.1 request should not be detected as gRPC even with grpc content type")
+	}
+}
+
+func TestIsGRPCRequest_HTTP2WithJSONContentType(t *testing.T) {
+	req, _ := http.NewRequest("POST", "/api/endpoint", nil)
+	req.ProtoMajor = 2
+	req.Header.Set("Content-Type", "application/json")
+
+	if IsGRPCRequest(req) {
+		t.Error("HTTP/2 request with application/json should not be detected as gRPC")
+	}
+}
+
+func TestIsGRPCRequest_HTTP2NoContentType(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/healthz", nil)
+	req.ProtoMajor = 2
+
+	if IsGRPCRequest(req) {
+		t.Error("HTTP/2 request without content type should not be detected as gRPC")
+	}
+}
+
+func TestIsWebSocketUpgrade_Valid(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/ws", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "upgrade")
+
+	if !IsWebSocketUpgrade(req) {
+		t.Error("expected WebSocket upgrade to be detected")
+	}
+}
+
+func TestIsWebSocketUpgrade_CaseInsensitiveConnection(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/ws", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+
+	if !IsWebSocketUpgrade(req) {
+		t.Error("expected WebSocket upgrade with mixed case Connection header to be detected")
+	}
+}
+
+func TestIsWebSocketUpgrade_NoUpgradeHeader(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/ws", nil)
+	req.Header.Set("Connection", "upgrade")
+
+	if IsWebSocketUpgrade(req) {
+		t.Error("should not detect WebSocket without Upgrade header")
+	}
+}
+
+func TestIsWebSocketUpgrade_NoConnectionHeader(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/ws", nil)
+	req.Header.Set("Upgrade", "websocket")
+
+	if IsWebSocketUpgrade(req) {
+		t.Error("should not detect WebSocket without Connection header")
+	}
+}
+
+func TestIsWebSocketUpgrade_WrongUpgradeValue(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/ws", nil)
+	req.Header.Set("Upgrade", "h2c")
+	req.Header.Set("Connection", "upgrade")
+
+	if IsWebSocketUpgrade(req) {
+		t.Error("should not detect WebSocket with non-websocket Upgrade header")
+	}
+}
+
+func TestIsWebSocketUpgrade_NormalHTTPRequest(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/api/data", nil)
+
+	if IsWebSocketUpgrade(req) {
+		t.Error("normal HTTP request should not be detected as WebSocket upgrade")
+	}
+}

--- a/internal/observability/tracing_test.go
+++ b/internal/observability/tracing_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewTracerProvider_Disabled(t *testing.T) {
+	logger := zap.NewNop()
+	config := TracingConfig{
+		Enabled: false,
+	}
+
+	tp, err := NewTracerProvider(context.Background(), config, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tp == nil {
+		t.Fatal("expected non-nil tracer provider even when disabled")
+	}
+	if tp.IsEnabled() {
+		t.Error("expected IsEnabled to return false when tracing is disabled")
+	}
+}
+
+func TestTracerProvider_Shutdown_WhenDisabled(t *testing.T) {
+	logger := zap.NewNop()
+	config := TracingConfig{
+		Enabled: false,
+	}
+
+	tp, err := NewTracerProvider(context.Background(), config, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Shutdown should be a no-op when disabled
+	err = tp.Shutdown(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error on shutdown when disabled, got %v", err)
+	}
+}
+
+func TestTracerProvider_Tracer_WhenDisabled(t *testing.T) {
+	logger := zap.NewNop()
+	config := TracingConfig{
+		Enabled: false,
+	}
+
+	tp, err := NewTracerProvider(context.Background(), config, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should return a nop tracer when disabled (from global otel)
+	tracer := tp.Tracer("test-scope")
+	if tracer == nil {
+		t.Fatal("expected non-nil tracer even when disabled")
+	}
+}
+
+func TestTracingConfig_Fields(t *testing.T) {
+	config := TracingConfig{
+		Enabled:        true,
+		Endpoint:       "localhost:4317",
+		SampleRate:     0.5,
+		ServiceName:    "novaedge-agent",
+		ServiceVersion: "v1.0.0",
+	}
+
+	if !config.Enabled {
+		t.Error("expected Enabled to be true")
+	}
+	if config.Endpoint != "localhost:4317" {
+		t.Errorf("expected endpoint 'localhost:4317', got %q", config.Endpoint)
+	}
+	if config.SampleRate != 0.5 {
+		t.Errorf("expected sample rate 0.5, got %f", config.SampleRate)
+	}
+	if config.ServiceName != "novaedge-agent" {
+		t.Errorf("expected service name 'novaedge-agent', got %q", config.ServiceName)
+	}
+	if config.ServiceVersion != "v1.0.0" {
+		t.Errorf("expected service version 'v1.0.0', got %q", config.ServiceVersion)
+	}
+}
+
+func TestTracerProvider_IsEnabled_Disabled(t *testing.T) {
+	tp := &TracerProvider{
+		provider: nil,
+		logger:   zap.NewNop(),
+	}
+
+	if tp.IsEnabled() {
+		t.Error("expected IsEnabled to return false when provider is nil")
+	}
+}

--- a/internal/pkg/errors/errors_test.go
+++ b/internal/pkg/errors/errors_test.go
@@ -1,0 +1,407 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// --- NetworkError Tests ---
+
+func TestNewNetworkError(t *testing.T) {
+	err := NewNetworkError("connection timeout")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if err.Message != "connection timeout" {
+		t.Errorf("expected message 'connection timeout', got %q", err.Message)
+	}
+	if err.Fields == nil {
+		t.Error("expected non-nil Fields map")
+	}
+}
+
+func TestNetworkError_Error_MessageOnly(t *testing.T) {
+	err := NewNetworkError("connection timeout")
+	if err.Error() != "connection timeout" {
+		t.Errorf("expected 'connection timeout', got %q", err.Error())
+	}
+}
+
+func TestNetworkError_Error_WithOpAndHost(t *testing.T) {
+	err := &NetworkError{
+		Op:      "dial",
+		Host:    "backend.example.com",
+		Port:    8080,
+		Message: "connection refused",
+	}
+	result := err.Error()
+	if !strings.Contains(result, "dial") {
+		t.Errorf("expected 'dial' in error, got %q", result)
+	}
+	if !strings.Contains(result, "backend.example.com:8080") {
+		t.Errorf("expected 'backend.example.com:8080' in error, got %q", result)
+	}
+	if !strings.Contains(result, "connection refused") {
+		t.Errorf("expected 'connection refused' in error, got %q", result)
+	}
+}
+
+func TestNetworkError_Error_HostWithoutPort(t *testing.T) {
+	err := &NetworkError{
+		Host:    "backend.example.com",
+		Message: "DNS failure",
+	}
+	result := err.Error()
+	if strings.Contains(result, ":0") {
+		t.Errorf("should not include port 0 in error: %q", result)
+	}
+}
+
+func TestNetworkError_Unwrap(t *testing.T) {
+	inner := fmt.Errorf("inner error")
+	err := &NetworkError{
+		Message: "outer",
+		Err:     inner,
+	}
+
+	if !errors.Is(err, inner) {
+		t.Error("expected Unwrap to return inner error")
+	}
+}
+
+func TestNetworkError_WithField(t *testing.T) {
+	err := NewNetworkError("timeout").
+		WithField("host", "10.0.0.1").
+		WithField("port", 8080)
+
+	if err.Fields["host"] != "10.0.0.1" {
+		t.Errorf("expected field 'host' to be '10.0.0.1', got %v", err.Fields["host"])
+	}
+	if err.Fields["port"] != 8080 {
+		t.Errorf("expected field 'port' to be 8080, got %v", err.Fields["port"])
+	}
+}
+
+func TestNetworkError_WithFields(t *testing.T) {
+	err := NewNetworkError("timeout").
+		WithFields(map[string]interface{}{
+			"host":    "10.0.0.1",
+			"port":    8080,
+			"attempt": 3,
+		})
+
+	if len(err.Fields) != 3 {
+		t.Errorf("expected 3 fields, got %d", len(err.Fields))
+	}
+}
+
+// --- ConfigError Tests ---
+
+func TestNewConfigError(t *testing.T) {
+	err := NewConfigError("invalid configuration")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if err.Message != "invalid configuration" {
+		t.Errorf("expected message 'invalid configuration', got %q", err.Message)
+	}
+}
+
+func TestConfigError_Error_WithFieldAndValue(t *testing.T) {
+	err := &ConfigError{
+		Field:   "maxRetries",
+		Value:   -1,
+		Message: "must be positive",
+	}
+	result := err.Error()
+	if !strings.Contains(result, "maxRetries") {
+		t.Errorf("expected field name in error: %q", result)
+	}
+	if !strings.Contains(result, "must be positive") {
+		t.Errorf("expected message in error: %q", result)
+	}
+	if !strings.Contains(result, "-1") {
+		t.Errorf("expected value in error: %q", result)
+	}
+}
+
+func TestConfigError_Unwrap(t *testing.T) {
+	inner := fmt.Errorf("parse error")
+	err := &ConfigError{
+		Message: "config",
+		Err:     inner,
+	}
+
+	if !errors.Is(err, inner) {
+		t.Error("expected Unwrap to return inner error")
+	}
+}
+
+func TestConfigError_WithField(t *testing.T) {
+	err := NewConfigError("bad config").
+		WithField("file", "config.yaml")
+
+	if err.Fields["file"] != "config.yaml" {
+		t.Errorf("expected field 'file' to be 'config.yaml', got %v", err.Fields["file"])
+	}
+}
+
+func TestConfigError_WithFields(t *testing.T) {
+	err := NewConfigError("bad config").
+		WithFields(map[string]interface{}{
+			"file": "config.yaml",
+			"line": 42,
+		})
+
+	if len(err.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(err.Fields))
+	}
+}
+
+// --- ValidationError Tests ---
+
+func TestNewValidationError(t *testing.T) {
+	err := NewValidationError("validation failed")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if err.Message != "validation failed" {
+		t.Errorf("expected message 'validation failed', got %q", err.Message)
+	}
+	if err.Children == nil {
+		t.Error("expected non-nil Children slice")
+	}
+}
+
+func TestValidationError_Error_WithFieldAndRule(t *testing.T) {
+	err := &ValidationError{
+		Field:   "email",
+		Rule:    "required",
+		Message: "field is required",
+	}
+	result := err.Error()
+	if !strings.Contains(result, "email") {
+		t.Errorf("expected field name in error: %q", result)
+	}
+	if !strings.Contains(result, "required") {
+		t.Errorf("expected rule in error: %q", result)
+	}
+}
+
+func TestValidationError_AddChild(t *testing.T) {
+	parent := NewValidationError("parent error")
+	child1 := NewValidationError("child 1")
+	child2 := NewValidationError("child 2")
+
+	parent.AddChild(child1).AddChild(child2)
+
+	if len(parent.Children) != 2 {
+		t.Errorf("expected 2 children, got %d", len(parent.Children))
+	}
+
+	// Error message should include children
+	result := parent.Error()
+	if !strings.Contains(result, "child 1") {
+		t.Errorf("expected child error in parent message: %q", result)
+	}
+	if !strings.Contains(result, "child 2") {
+		t.Errorf("expected child error in parent message: %q", result)
+	}
+}
+
+func TestValidationError_Unwrap(t *testing.T) {
+	inner := fmt.Errorf("format error")
+	err := &ValidationError{
+		Message: "validation",
+		Err:     inner,
+	}
+
+	if !errors.Is(err, inner) {
+		t.Error("expected Unwrap to return inner error")
+	}
+}
+
+func TestValidationError_WithField(t *testing.T) {
+	err := NewValidationError("bad input").
+		WithField("field", "username")
+
+	if err.Fields["field"] != "username" {
+		t.Errorf("expected field 'field' to be 'username', got %v", err.Fields["field"])
+	}
+}
+
+func TestValidationError_WithFields(t *testing.T) {
+	err := NewValidationError("bad input").
+		WithFields(map[string]interface{}{
+			"field": "username",
+			"rule":  "min_length",
+		})
+
+	if len(err.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(err.Fields))
+	}
+}
+
+// --- TLSError Tests ---
+
+func TestNewTLSError(t *testing.T) {
+	err := NewTLSError("handshake failed")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if err.Message != "handshake failed" {
+		t.Errorf("expected message 'handshake failed', got %q", err.Message)
+	}
+}
+
+func TestTLSError_Error_WithOpAndHost(t *testing.T) {
+	err := &TLSError{
+		Op:      "handshake",
+		Host:    "secure.example.com",
+		Message: "certificate expired",
+	}
+	result := err.Error()
+	if !strings.Contains(result, "handshake") {
+		t.Errorf("expected 'handshake' in error: %q", result)
+	}
+	if !strings.Contains(result, "secure.example.com") {
+		t.Errorf("expected host in error: %q", result)
+	}
+	if !strings.Contains(result, "certificate expired") {
+		t.Errorf("expected message in error: %q", result)
+	}
+}
+
+func TestTLSError_Unwrap(t *testing.T) {
+	inner := fmt.Errorf("x509: certificate signed by unknown authority")
+	err := &TLSError{
+		Message: "TLS error",
+		Err:     inner,
+	}
+
+	if !errors.Is(err, inner) {
+		t.Error("expected Unwrap to return inner error")
+	}
+}
+
+func TestTLSError_WithField(t *testing.T) {
+	err := NewTLSError("bad cert").
+		WithField("sni", "example.com")
+
+	if err.Fields["sni"] != "example.com" {
+		t.Errorf("expected field 'sni' to be 'example.com', got %v", err.Fields["sni"])
+	}
+}
+
+func TestTLSError_WithFields(t *testing.T) {
+	err := NewTLSError("bad cert").
+		WithFields(map[string]interface{}{
+			"sni":    "example.com",
+			"cipher": "TLS_AES_128_GCM_SHA256",
+		})
+
+	if len(err.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(err.Fields))
+	}
+}
+
+// --- Standard Error Variables Tests ---
+
+func TestStandardErrorVariables(t *testing.T) {
+	// Verify all standard errors are properly defined
+	standardErrors := []struct {
+		name string
+		err  error
+	}{
+		{"ErrInvalidConfig", ErrInvalidConfig},
+		{"ErrMissingConfig", ErrMissingConfig},
+		{"ErrConfigParse", ErrConfigParse},
+		{"ErrConfigValidation", ErrConfigValidation},
+		{"ErrConnectionFailed", ErrConnectionFailed},
+		{"ErrConnectionTimeout", ErrConnectionTimeout},
+		{"ErrConnectionRefused", ErrConnectionRefused},
+		{"ErrDNSResolution", ErrDNSResolution},
+		{"ErrNetworkUnreachable", ErrNetworkUnreachable},
+		{"ErrTLSHandshake", ErrTLSHandshake},
+		{"ErrTLSCertificate", ErrTLSCertificate},
+		{"ErrTLSVerification", ErrTLSVerification},
+		{"ErrInvalidCipherSuite", ErrInvalidCipherSuite},
+		{"ErrValidationFailed", ErrValidationFailed},
+		{"ErrInvalidInput", ErrInvalidInput},
+		{"ErrInvalidFormat", ErrInvalidFormat},
+		{"ErrMissingField", ErrMissingField},
+		{"ErrNotFound", ErrNotFound},
+		{"ErrAlreadyExists", ErrAlreadyExists},
+		{"ErrTimeout", ErrTimeout},
+		{"ErrCancelled", ErrCancelled},
+	}
+
+	for _, tt := range standardErrors {
+		if tt.err == nil {
+			t.Errorf("%s should not be nil", tt.name)
+		}
+		if tt.err.Error() == "" {
+			t.Errorf("%s should have a non-empty message", tt.name)
+		}
+	}
+}
+
+func TestErrorTypeAssertion(t *testing.T) {
+	// Test that errors.As works with our custom types
+	var netErr *NetworkError
+	err := &NetworkError{Message: "connection failed"}
+	if !errors.As(err, &netErr) {
+		t.Error("errors.As should work with NetworkError")
+	}
+
+	var cfgErr *ConfigError
+	err2 := &ConfigError{Message: "bad config"}
+	if !errors.As(err2, &cfgErr) {
+		t.Error("errors.As should work with ConfigError")
+	}
+
+	var valErr *ValidationError
+	err3 := &ValidationError{Message: "invalid"}
+	if !errors.As(err3, &valErr) {
+		t.Error("errors.As should work with ValidationError")
+	}
+
+	var tlsErr *TLSError
+	err4 := &TLSError{Message: "TLS failure"}
+	if !errors.As(err4, &tlsErr) {
+		t.Error("errors.As should work with TLSError")
+	}
+}
+
+func TestWrappedErrorChain(t *testing.T) {
+	// Test error wrapping chain
+	base := ErrConnectionTimeout
+	wrapped := fmt.Errorf("failed to connect: %w", base)
+	netErr := &NetworkError{
+		Message: "upstream failed",
+		Err:     wrapped,
+	}
+
+	// Should be able to unwrap to find the base error
+	if !errors.Is(netErr, base) {
+		t.Error("should be able to find base error through chain")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive unit tests for 10 previously untested packages across the NovaEdge codebase
- All 10 test files contain 3-5+ test functions covering success, error, and edge cases
- Total of 2,421 lines of test code added with zero regressions

## Packages Tested

| Package | File | Tests |
|---------|------|-------|
| `internal/agent/health` | `checker_test.go` | Health check execution, HTTP check success/failure/refused, endpoint updates, failure thresholds |
| `internal/agent/health` | `circuitbreaker_test.go` | State transitions (closed->open->half-open->closed), request limiting, reset, stats |
| `internal/agent/config` | `validation_test.go` | Nil snapshot, nil ConfigSnapshot, empty version, valid snapshots |
| `internal/agent/config` | `watcher_test.go` | Watcher creation, TLS config validation, remote cluster config, IsRemote |
| `internal/agent/grpc` | `handler_test.go` | Header preservation, request cloning, response forwarding, streaming detection, service/method extraction |
| `internal/agent/protocol` | `detection_test.go` | gRPC detection (HTTP/2 + content-type), WebSocket upgrade detection, edge cases |
| `internal/acme` | `client_test.go` | Client creation, nil validation, defaults, uninitialized operations, certificate parsing |
| `internal/acme` | `selfsigned_test.go` | Self-signed cert generation (EC256/EC384/RSA2048/RSA4096), CA generation, cert signing, chain verification |
| `internal/pkg/errors` | `errors_test.go` | All 4 error types (Network, Config, Validation, TLS), wrapping, unwrapping, fields, error chains |
| `internal/observability` | `tracing_test.go` | Disabled tracer provider, shutdown, tracer retrieval, config fields |

## Test plan
- [x] All new tests pass locally (`go test ./... -count=1`)
- [x] No regressions in existing tests
- [x] Tests exercise real code paths without mock data or mock functions

Resolves #36