### PR TITLE
Fix all errcheck lint violations

### DIFF
--- a/cmd/novactl/cmd/agent_query.go
+++ b/cmd/novactl/cmd/agent_query.go
@@ -78,7 +78,7 @@ func runAgentConfig(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create agent client: %w", err)
 	}
-	defer agentClient.Close()
+	defer func() { _ = agentClient.Close() }()
 
 	// Get configuration
 	agentConfig, err := agentClient.GetConfig(ctx)
@@ -114,27 +114,27 @@ func runAgentConfig(cmd *cobra.Command, args []string) error {
 	if len(agentConfig.Gateways) > 0 {
 		fmt.Printf("\nGateways:\n")
 		w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tNAMESPACE\tVIP\tLISTENERS")
+		_, _ = fmt.Fprintln(w, "NAME\tNAMESPACE\tVIP\tLISTENERS")
 		for _, gw := range agentConfig.Gateways {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%d\n",
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\n",
 				gw.Name, gw.Namespace, gw.VIPRef, len(gw.Listeners))
 		}
-		w.Flush()
+		_ = w.Flush()
 	}
 
 	if len(agentConfig.VIPs) > 0 {
 		fmt.Printf("\nVIP Assignments:\n")
 		w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tADDRESS\tMODE\tACTIVE\tPORTS")
+		_, _ = fmt.Fprintln(w, "NAME\tADDRESS\tMODE\tACTIVE\tPORTS")
 		for _, vip := range agentConfig.VIPs {
 			active := "No"
 			if vip.IsActive {
 				active = "Yes"
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%v\n",
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%v\n",
 				vip.Name, vip.Address, vip.Mode, active, vip.Ports)
 		}
-		w.Flush()
+		_ = w.Flush()
 	}
 
 	return nil
@@ -178,7 +178,7 @@ func runAgentBackends(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create agent client: %w", err)
 	}
-	defer agentClient.Close()
+	defer func() { _ = agentClient.Close() }()
 
 	// Get backend health
 	backends, err := agentClient.GetBackendHealth(ctx)
@@ -204,15 +204,15 @@ func runAgentBackends(cmd *cobra.Command, args []string) error {
 
 		if len(backend.Endpoints) > 0 {
 			w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-			fmt.Fprintln(w, "  ADDRESS\tPORT\tSTATUS")
+			_, _ = fmt.Fprintln(w, "  ADDRESS\tPORT\tSTATUS")
 			for _, ep := range backend.Endpoints {
 				status := "Not Ready"
 				if ep.Ready {
 					status = "Ready"
 				}
-				fmt.Fprintf(w, "  %s\t%d\t%s\n", ep.Address, ep.Port, status)
+				_, _ = fmt.Fprintf(w, "  %s\t%d\t%s\n", ep.Address, ep.Port, status)
 			}
-			w.Flush()
+			_ = w.Flush()
 		}
 		fmt.Println()
 	}
@@ -258,7 +258,7 @@ func runAgentVIPs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create agent client: %w", err)
 	}
-	defer agentClient.Close()
+	defer func() { _ = agentClient.Close() }()
 
 	// Get VIPs
 	vips, err := agentClient.GetVIPs(ctx)
@@ -278,18 +278,18 @@ func runAgentVIPs(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Active VIPs:\n\n")
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tADDRESS\tMODE\tACTIVE\tPORTS")
+	_, _ = fmt.Fprintln(w, "NAME\tADDRESS\tMODE\tACTIVE\tPORTS")
 
 	for _, vip := range vips {
 		active := "No"
 		if vip.IsActive {
 			active = "Yes"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%v\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%v\n",
 			vip.Name, vip.Address, vip.Mode, active, vip.Ports)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 
 	return nil
 }

--- a/cmd/novactl/cmd/agents.go
+++ b/cmd/novactl/cmd/agents.go
@@ -63,7 +63,7 @@ func runAgentsList(cmd *cobra.Command, args []string) error {
 
 	// Print table
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	fmt.Fprintln(w, "NODE\tSTATUS\tRESTARTS\tAGE")
+	_, _ = fmt.Fprintln(w, "NODE\tSTATUS\tRESTARTS\tAGE")
 
 	for _, pod := range pods.Items {
 		node := pod.Spec.NodeName
@@ -74,10 +74,10 @@ func runAgentsList(cmd *cobra.Command, args []string) error {
 		}
 		age := formatAgentAge(pod.CreationTimestamp)
 
-		fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", node, status, restarts, age)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", node, status, restarts, age)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	return nil
 }
 

--- a/cmd/novactl/cmd/apply.go
+++ b/cmd/novactl/cmd/apply.go
@@ -27,7 +27,7 @@ func newApplyCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&filename, "filename", "f", "", "File or directory containing resource definitions")
-	cmd.MarkFlagRequired("filename")
+	cobra.CheckErr(cmd.MarkFlagRequired("filename"))
 
 	return cmd
 }

--- a/cmd/novactl/cmd/debug.go
+++ b/cmd/novactl/cmd/debug.go
@@ -197,7 +197,7 @@ func runDebugBackends(cmd *cobra.Command, args []string) error {
 	if len(endpoints) > 0 {
 		fmt.Printf("\nEndpoints (%d):\n", len(endpoints))
 		w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-		fmt.Fprintln(w, "ADDRESS\tPORT\tHEALTHY\tLAST CHECK")
+		_, _ = fmt.Fprintln(w, "ADDRESS\tPORT\tHEALTHY\tLAST CHECK")
 
 		for _, ep := range endpoints {
 			epMap, ok := ep.(map[string]interface{})
@@ -215,9 +215,9 @@ func runDebugBackends(cmd *cobra.Command, args []string) error {
 				healthStatus = "Yes"
 			}
 
-			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", address, port, healthStatus, lastCheck)
+			_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", address, port, healthStatus, lastCheck)
 		}
-		w.Flush()
+		_ = w.Flush()
 	} else {
 		fmt.Println("\nNo endpoints available")
 	}

--- a/cmd/novactl/cmd/federation.go
+++ b/cmd/novactl/cmd/federation.go
@@ -217,9 +217,9 @@ func listFederations(ctx context.Context, k8sClient client.Client, ns string) er
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	if ns == "" {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tFEDERATION ID\tLOCAL MEMBER\tPHASE\tAGE")
+		_, _ = fmt.Fprintln(w, "NAMESPACE\tNAME\tFEDERATION ID\tLOCAL MEMBER\tPHASE\tAGE")
 	} else {
-		fmt.Fprintln(w, "NAME\tFEDERATION ID\tLOCAL MEMBER\tPHASE\tAGE")
+		_, _ = fmt.Fprintln(w, "NAME\tFEDERATION ID\tLOCAL MEMBER\tPHASE\tAGE")
 	}
 
 	for _, fed := range fedList.Items {
@@ -230,7 +230,7 @@ func listFederations(ctx context.Context, k8sClient client.Client, ns string) er
 		}
 
 		if ns == "" {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 				fed.Namespace,
 				fed.Name,
 				fed.Spec.FederationID,
@@ -239,7 +239,7 @@ func listFederations(ctx context.Context, k8sClient client.Client, ns string) er
 				age,
 			)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 				fed.Name,
 				fed.Spec.FederationID,
 				fed.Spec.LocalMember.Name,
@@ -337,7 +337,7 @@ func showFederationDetails(ctx context.Context, k8sClient client.Client, name, n
 	if len(fed.Status.Members) > 0 {
 		fmt.Println("Member Status:")
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "  NAME\tHEALTHY\tLAST SEEN\tSYNC LAG\tAGENTS\tERROR")
+		_, _ = fmt.Fprintln(w, "  NAME\tHEALTHY\tLAST SEEN\tSYNC LAG\tAGENTS\tERROR")
 		for _, member := range fed.Status.Members {
 			lastSeen := "Never"
 			if member.LastSeen != nil {
@@ -351,7 +351,7 @@ func showFederationDetails(ctx context.Context, k8sClient client.Client, name, n
 			if len(errStr) > 40 {
 				errStr = errStr[:37] + "..."
 			}
-			fmt.Fprintf(w, "  %s\t%v\t%s\t%s\t%d\t%s\n",
+			_, _ = fmt.Fprintf(w, "  %s\t%v\t%s\t%s\t%d\t%s\n",
 				member.Name,
 				member.Healthy,
 				lastSeen,
@@ -360,7 +360,7 @@ func showFederationDetails(ctx context.Context, k8sClient client.Client, name, n
 				errStr,
 			)
 		}
-		w.Flush()
+		_ = w.Flush()
 		fmt.Println()
 	}
 

--- a/cmd/novactl/cmd/logs.go
+++ b/cmd/novactl/cmd/logs.go
@@ -158,7 +158,7 @@ func streamPodLogs(ctx context.Context, c *client.Client, namespace, podName, co
 	if err != nil {
 		return fmt.Errorf("failed to stream logs: %w", err)
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	// Copy stream to stdout
 	reader := bufio.NewReader(stream)

--- a/cmd/novactl/cmd/metrics.go
+++ b/cmd/novactl/cmd/metrics.go
@@ -96,7 +96,7 @@ func runMetricsBackends(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Backend Health Metrics:\n\n")
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tTOTAL\tHEALTHY\tUNHEALTHY\tHEALTH %")
+	_, _ = fmt.Fprintln(w, "NAME\tTOTAL\tHEALTHY\tUNHEALTHY\tHEALTH %")
 
 	for _, backend := range backends.Items {
 		name := backend.GetName()
@@ -123,10 +123,10 @@ func runMetricsBackends(cmd *cobra.Command, args []string) error {
 			healthPct = (healthy * 100) / total
 		}
 
-		fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d%%\n", name, total, healthy, unhealthy, healthPct)
+		_, _ = fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d%%\n", name, total, healthy, unhealthy, healthPct)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	return nil
 }
 
@@ -166,7 +166,7 @@ func runMetricsVIPs(cmd *cobra.Command, args []string) error {
 	fmt.Printf("VIP Status:\n\n")
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tIP\tMODE\tASSIGNED NODE\tSTATUS\tLAST TRANSITION")
+	_, _ = fmt.Fprintln(w, "NAME\tIP\tMODE\tASSIGNED NODE\tSTATUS\tLAST TRANSITION")
 
 	for _, vip := range vips.Items {
 		name := vip.GetName()
@@ -187,10 +187,10 @@ func runMetricsVIPs(cmd *cobra.Command, args []string) error {
 			vipStatus = "Unknown"
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			name, ip, mode, assignedNode, vipStatus, lastTransition)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	return nil
 }

--- a/cmd/novactl/cmd/metrics_query.go
+++ b/cmd/novactl/cmd/metrics_query.go
@@ -197,13 +197,13 @@ func runMetricsTopBackends(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Top %d Backends by Request Rate (5m avg):\n\n", len(metrics))
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	fmt.Fprintln(w, "BACKEND\tNAMESPACE\tREQUESTS/SEC")
+	_, _ = fmt.Fprintln(w, "BACKEND\tNAMESPACE\tREQUESTS/SEC")
 
 	for _, m := range metrics {
-		fmt.Fprintf(w, "%s\t%s\t%.2f\n", m.Backend, m.Namespace, m.RPS)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%.2f\n", m.Backend, m.Namespace, m.RPS)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 
 	return nil
 }
@@ -282,17 +282,17 @@ func runMetricsTopRoutes(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Top %d Routes by Latency:\n\n", len(metrics))
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	fmt.Fprintln(w, "ROUTE\tNAMESPACE\tAVG LATENCY")
+	_, _ = fmt.Fprintln(w, "ROUTE\tNAMESPACE\tAVG LATENCY")
 
 	for _, m := range metrics {
-		fmt.Fprintf(w, "%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n",
 			m.Route,
 			m.Namespace,
 			prometheus.FormatDuration(m.Latency),
 		)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 
 	return nil
 }
@@ -407,7 +407,7 @@ func displayJSON(result *prometheus.QueryResult) error {
 
 func displayYAML(result *prometheus.QueryResult) error {
 	encoder := yaml.NewEncoder(os.Stdout)
-	defer encoder.Close()
+	defer func() { _ = encoder.Close() }()
 	return encoder.Encode(result)
 }
 
@@ -440,17 +440,17 @@ func displayTable(result *prometheus.QueryResult, query string) error {
 
 	// Print header
 	for _, label := range labels {
-		fmt.Fprintf(w, "%s\t", label)
+		_, _ = fmt.Fprintf(w, "%s\t", label)
 	}
-	fmt.Fprintln(w, "VALUE")
+	_, _ = fmt.Fprintln(w, "VALUE")
 
 	// Print rows
 	for _, r := range result.Data.Result {
 		for _, label := range labels {
 			if val, ok := r.Metric[label]; ok {
-				fmt.Fprintf(w, "%s\t", val)
+				_, _ = fmt.Fprintf(w, "%s\t", val)
 			} else {
-				fmt.Fprint(w, "-\t")
+				_, _ = fmt.Fprint(w, "-\t")
 			}
 		}
 
@@ -459,20 +459,20 @@ func displayTable(result *prometheus.QueryResult, query string) error {
 			value, err := prometheus.ValueAsFloat(r)
 			if err == nil {
 				// Try to format based on query
-				fmt.Fprintf(w, "%s\n", prometheus.FormatValue(query, value))
+				_, _ = fmt.Fprintf(w, "%s\n", prometheus.FormatValue(query, value))
 			} else {
-				fmt.Fprintf(w, "%v\n", r.Value[1])
+				_, _ = fmt.Fprintf(w, "%v\n", r.Value[1])
 			}
 		} else if len(r.Values) > 0 {
 			// For range queries, show the latest value
 			lastValue := r.Values[len(r.Values)-1]
 			if len(lastValue) > 1 {
-				fmt.Fprintf(w, "%v (latest)\n", lastValue[1])
+				_, _ = fmt.Fprintf(w, "%v (latest)\n", lastValue[1])
 			}
 		}
 	}
 
-	w.Flush()
+	_ = w.Flush()
 
 	return nil
 }

--- a/cmd/novactl/cmd/trace.go
+++ b/cmd/novactl/cmd/trace.go
@@ -98,10 +98,10 @@ func runTraceList(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Recent Traces (last %s):\n\n", traceLookback)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	fmt.Fprintln(w, "TRACE ID\tOPERATION\tSERVICE\tDURATION\tSPANS\tSTART TIME")
+	_, _ = fmt.Fprintln(w, "TRACE ID\tOPERATION\tSERVICE\tDURATION\tSPANS\tSTART TIME")
 
 	for _, t := range traces {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n",
 			truncateID(t.TraceID),
 			truncateString(t.OperationName, 30),
 			truncateString(t.ServiceName, 20),
@@ -111,7 +111,7 @@ func runTraceList(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 
 	fmt.Printf("\nUse 'novactl trace get <trace-id>' to view details\n")
 
@@ -272,10 +272,10 @@ func runTraceSearch(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Found %d trace(s):\n\n", len(traces))
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	fmt.Fprintln(w, "TRACE ID\tOPERATION\tSERVICE\tDURATION\tSPANS\tSTART TIME")
+	_, _ = fmt.Fprintln(w, "TRACE ID\tOPERATION\tSERVICE\tDURATION\tSPANS\tSTART TIME")
 
 	for _, t := range traces {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n",
 			truncateID(t.TraceID),
 			truncateString(t.OperationName, 30),
 			truncateString(t.ServiceName, 20),
@@ -285,7 +285,7 @@ func runTraceSearch(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 
 	fmt.Printf("\nUse 'novactl trace get <trace-id>' to view details\n")
 

--- a/cmd/novactl/pkg/printer/printer.go
+++ b/cmd/novactl/pkg/printer/printer.go
@@ -40,7 +40,7 @@ func NewPrinter(format OutputFormat, writer io.Writer) *Printer {
 // PrintResourceList prints a list of resources
 func (p *Printer) PrintResourceList(resourceType string, items []unstructured.Unstructured) error {
 	if len(items) == 0 {
-		fmt.Fprintf(p.Writer, "No %s found.\n", resourceType)
+		_, _ = fmt.Fprintf(p.Writer, "No %s found.\n", resourceType)
 		return nil
 	}
 
@@ -82,20 +82,20 @@ func (p *Printer) printJSON(items []unstructured.Unstructured) error {
 func (p *Printer) printYAML(items []unstructured.Unstructured) error {
 	for i, item := range items {
 		if i > 0 {
-			fmt.Fprintln(p.Writer, "---")
+			_, _ = fmt.Fprintln(p.Writer, "---")
 		}
 		data, err := yaml.Marshal(item.Object)
 		if err != nil {
 			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
-		fmt.Fprint(p.Writer, string(data))
+		_, _ = fmt.Fprint(p.Writer, string(data))
 	}
 	return nil
 }
 
 func (p *Printer) printTable(resourceType string, items []unstructured.Unstructured) error {
 	w := tabwriter.NewWriter(p.Writer, 0, 8, 2, ' ', 0)
-	defer w.Flush()
+	defer func() { _ = w.Flush() }()
 
 	// Print header based on resource type
 	switch strings.ToLower(resourceType) {
@@ -117,7 +117,7 @@ func (p *Printer) printTable(resourceType string, items []unstructured.Unstructu
 }
 
 func (p *Printer) printGatewayTable(w *tabwriter.Writer, items []unstructured.Unstructured) {
-	fmt.Fprintln(w, "NAME\tLISTENERS\tAGE")
+	_, _ = fmt.Fprintln(w, "NAME\tLISTENERS\tAGE")
 	for _, item := range items {
 		name := item.GetName()
 		age := formatAge(item.GetCreationTimestamp().Time)
@@ -126,12 +126,12 @@ func (p *Printer) printGatewayTable(w *tabwriter.Writer, items []unstructured.Un
 		listeners, _, _ := unstructured.NestedSlice(spec, "listeners")
 		listenerCount := len(listeners)
 
-		fmt.Fprintf(w, "%s\t%d\t%s\n", name, listenerCount, age)
+		_, _ = fmt.Fprintf(w, "%s\t%d\t%s\n", name, listenerCount, age)
 	}
 }
 
 func (p *Printer) printRouteTable(w *tabwriter.Writer, items []unstructured.Unstructured) {
-	fmt.Fprintln(w, "NAME\tHOSTNAMES\tBACKENDS\tAGE")
+	_, _ = fmt.Fprintln(w, "NAME\tHOSTNAMES\tBACKENDS\tAGE")
 	for _, item := range items {
 		name := item.GetName()
 		age := formatAge(item.GetCreationTimestamp().Time)
@@ -146,12 +146,12 @@ func (p *Printer) printRouteTable(w *tabwriter.Writer, items []unstructured.Unst
 		backends, _, _ := unstructured.NestedSlice(spec, "backends")
 		backendCount := len(backends)
 
-		fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", name, hostnameStr, backendCount, age)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", name, hostnameStr, backendCount, age)
 	}
 }
 
 func (p *Printer) printBackendTable(w *tabwriter.Writer, items []unstructured.Unstructured) {
-	fmt.Fprintln(w, "NAME\tENDPOINTS\tHEALTHY\tAGE")
+	_, _ = fmt.Fprintln(w, "NAME\tENDPOINTS\tHEALTHY\tAGE")
 	for _, item := range items {
 		name := item.GetName()
 		age := formatAge(item.GetCreationTimestamp().Time)
@@ -173,12 +173,12 @@ func (p *Printer) printBackendTable(w *tabwriter.Writer, items []unstructured.Un
 			}
 		}
 
-		fmt.Fprintf(w, "%s\t%d\t%d\t%s\n", name, endpointCount, healthyCount, age)
+		_, _ = fmt.Fprintf(w, "%s\t%d\t%d\t%s\n", name, endpointCount, healthyCount, age)
 	}
 }
 
 func (p *Printer) printPolicyTable(w *tabwriter.Writer, items []unstructured.Unstructured) {
-	fmt.Fprintln(w, "NAME\tTYPE\tTARGET\tAGE")
+	_, _ = fmt.Fprintln(w, "NAME\tTYPE\tTARGET\tAGE")
 	for _, item := range items {
 		name := item.GetName()
 		age := formatAge(item.GetCreationTimestamp().Time)
@@ -200,12 +200,12 @@ func (p *Printer) printPolicyTable(w *tabwriter.Writer, items []unstructured.Uns
 		targetName, _, _ := unstructured.NestedString(targetRef, "name")
 		target := fmt.Sprintf("%s/%s", targetKind, targetName)
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, policyType, target, age)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, policyType, target, age)
 	}
 }
 
 func (p *Printer) printVIPTable(w *tabwriter.Writer, items []unstructured.Unstructured) {
-	fmt.Fprintln(w, "NAME\tIP\tMODE\tNODE\tSTATUS\tAGE")
+	_, _ = fmt.Fprintln(w, "NAME\tIP\tMODE\tNODE\tSTATUS\tAGE")
 	for _, item := range items {
 		name := item.GetName()
 		age := formatAge(item.GetCreationTimestamp().Time)
@@ -218,17 +218,17 @@ func (p *Printer) printVIPTable(w *tabwriter.Writer, items []unstructured.Unstru
 		assignedNode, _, _ := unstructured.NestedString(status, "assignedNode")
 		vipStatus, _, _ := unstructured.NestedString(status, "status")
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", name, ip, mode, assignedNode, vipStatus, age)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", name, ip, mode, assignedNode, vipStatus, age)
 	}
 }
 
 func (p *Printer) printGenericTable(w *tabwriter.Writer, items []unstructured.Unstructured) {
-	fmt.Fprintln(w, "NAME\tKIND\tAGE")
+	_, _ = fmt.Fprintln(w, "NAME\tKIND\tAGE")
 	for _, item := range items {
 		name := item.GetName()
 		kind := item.GetKind()
 		age := formatAge(item.GetCreationTimestamp().Time)
-		fmt.Fprintf(w, "%s\t%s\t%s\n", name, kind, age)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", name, kind, age)
 	}
 }
 

--- a/cmd/novactl/pkg/prometheus/client.go
+++ b/cmd/novactl/pkg/prometheus/client.go
@@ -87,7 +87,7 @@ func (c *Client) QueryAt(ctx context.Context, query string, t time.Time) (*Query
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -133,7 +133,7 @@ func (c *Client) QueryRange(ctx context.Context, params RangeQueryParams) (*Quer
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -165,7 +165,7 @@ func (c *Client) GetLabels(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get labels: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var result struct {
 		Status string   `json:"status"`
@@ -192,7 +192,7 @@ func (c *Client) GetLabelValues(ctx context.Context, label string) ([]string, er
 	if err != nil {
 		return nil, fmt.Errorf("failed to get label values: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var result struct {
 		Status string   `json:"status"`
@@ -228,7 +228,7 @@ func (c *Client) GetSeries(ctx context.Context, matchers []string, start, end ti
 	if err != nil {
 		return nil, fmt.Errorf("failed to get series: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var result struct {
 		Status string              `json:"status"`

--- a/cmd/novactl/pkg/trace/client.go
+++ b/cmd/novactl/pkg/trace/client.go
@@ -95,7 +95,7 @@ func (c *TraceClient) ListTraces(ctx context.Context, limit int, lookback time.D
 	if err != nil {
 		return nil, fmt.Errorf("failed to query traces: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -129,7 +129,7 @@ func (c *TraceClient) GetTrace(ctx context.Context, traceID string) (*Trace, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to get trace: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("trace %s not found", traceID)
@@ -213,7 +213,7 @@ func (c *TraceClient) SearchTraces(ctx context.Context, params TraceSearchParams
 	if err != nil {
 		return nil, fmt.Errorf("failed to search traces: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -247,7 +247,7 @@ func (c *TraceClient) GetServices(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get services: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -281,7 +281,7 @@ func (c *TraceClient) GetOperations(ctx context.Context, serviceName string) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operations: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/cmd/novactl/pkg/webui/server.go
+++ b/cmd/novactl/pkg/webui/server.go
@@ -267,7 +267,7 @@ func spaHandler(fsys http.FileSystem) http.Handler {
 
 		// Check if it's a directory
 		stat, err := f.Stat()
-		f.Close()
+		_ = f.Close()
 		if err == nil && stat.IsDir() {
 			// Try to serve index.html from the directory
 			indexPath := strings.TrimSuffix(path, "/") + "/index.html"
@@ -278,7 +278,7 @@ func spaHandler(fsys http.FileSystem) http.Handler {
 				fileServer.ServeHTTP(w, r)
 				return
 			}
-			indexFile.Close()
+			_ = indexFile.Close()
 		}
 
 		// Serve the file

--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -90,7 +90,7 @@ func main() {
 
 	// Initialize logger
 	logger := initLogger(logLevel)
-	defer logger.Sync()
+	defer func() { _ = logger.Sync() }()
 
 	logger.Info("Starting NovaEdge agent",
 		zap.String("node", nodeName),

--- a/cmd/novaedge-standalone/main.go
+++ b/cmd/novaedge-standalone/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// Setup logger
 	logger := setupLogger(logLevel)
-	defer logger.Sync()
+	defer func() { _ = logger.Sync() }()
 
 	logger.Info("Starting NovaEdge Standalone Load Balancer",
 		zap.String("version", version),

--- a/internal/acme/provider.go
+++ b/internal/acme/provider.go
@@ -113,7 +113,7 @@ func (p *HTTP01Provider) Handler() http.Handler {
 		)
 
 		w.Header().Set("Content-Type", "text/plain")
-		fmt.Fprint(w, keyAuth)
+		_, _ = fmt.Fprint(w, keyAuth)
 	})
 }
 

--- a/internal/agent/config/failover.go
+++ b/internal/agent/config/failover.go
@@ -450,7 +450,7 @@ func (w *FailoverWatcher) handleRecoveryCheck() error {
 
 	// Close secondary connection
 	if w.activeConn != nil {
-		w.activeConn.Close()
+		_ = w.activeConn.Close()
 		w.activeConn = nil
 	}
 
@@ -555,7 +555,7 @@ func (w *FailoverWatcher) connectAndStream(ctrl *ControllerEndpoint) error {
 	// Store connection
 	w.stateMu.Lock()
 	if w.activeConn != nil {
-		w.activeConn.Close()
+		_ = w.activeConn.Close()
 	}
 	w.activeConn = conn
 	w.activeCtrl = ctrl
@@ -676,7 +676,7 @@ func (w *FailoverWatcher) pingController(ctrl *ControllerEndpoint) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	client := pb.NewConfigServiceClient(conn)
 
@@ -848,7 +848,7 @@ func (w *FailoverWatcher) cleanup() {
 		w.healthCancel()
 	}
 	if w.activeConn != nil {
-		w.activeConn.Close()
+		_ = w.activeConn.Close()
 	}
 }
 

--- a/internal/agent/config/watcher.go
+++ b/internal/agent/config/watcher.go
@@ -144,7 +144,7 @@ func (w *Watcher) Start(applyFunc ApplyFunc) error {
 	if err != nil {
 		return fmt.Errorf("failed to connect to controller: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Create config service client
 	client := pb.NewConfigServiceClient(conn)

--- a/internal/agent/health/checker.go
+++ b/internal/agent/health/checker.go
@@ -370,7 +370,7 @@ func (hc *HealthChecker) performHTTPCheck(ep *pb.Endpoint) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Consider 200-299 as healthy
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {

--- a/internal/agent/policy/cors_test.go
+++ b/internal/agent/policy/cors_test.go
@@ -196,7 +196,7 @@ func TestHandleCORS(t *testing.T) {
 	// Create test handler
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, _ = w.Write([]byte("OK"))
 	})
 
 	t.Run("no Origin header", func(t *testing.T) {

--- a/internal/agent/policy/ipfilter_test.go
+++ b/internal/agent/policy/ipfilter_test.go
@@ -71,7 +71,9 @@ func TestSetGlobalTrustedProxies(t *testing.T) {
 
 func TestIsGlobalTrustedProxy(t *testing.T) {
 	// Setup
-	SetGlobalTrustedProxies([]string{"10.0.0.0/8", "192.168.1.1"})
+	if err := SetGlobalTrustedProxies([]string{"10.0.0.0/8", "192.168.1.1"}); err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		trustedProxyCIDRs = nil
 	}()
@@ -115,7 +117,9 @@ func TestIsGlobalTrustedProxy(t *testing.T) {
 
 func TestExtractClientIPPackageLevel(t *testing.T) {
 	// Setup
-	SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
+	if err := SetGlobalTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		trustedProxyCIDRs = nil
 	}()
@@ -135,7 +139,9 @@ func TestExtractClientIPPackageLevel(t *testing.T) {
 	})
 
 	t.Run("through trusted proxy with X-Forwarded-For", func(t *testing.T) {
-		SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
+		if err := SetGlobalTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.RemoteAddr = "10.0.0.1:12345"
@@ -148,7 +154,9 @@ func TestExtractClientIPPackageLevel(t *testing.T) {
 	})
 
 	t.Run("through untrusted proxy ignores X-Forwarded-For", func(t *testing.T) {
-		SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
+		if err := SetGlobalTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.RemoteAddr = "8.8.8.8:12345"
@@ -161,7 +169,9 @@ func TestExtractClientIPPackageLevel(t *testing.T) {
 	})
 
 	t.Run("X-Real-IP fallback", func(t *testing.T) {
-		SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
+		if err := SetGlobalTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.RemoteAddr = "10.0.0.1:12345"
@@ -312,7 +322,7 @@ func TestIPFilterAllow(t *testing.T) {
 func TestHandleIPFilter(t *testing.T) {
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, _ = w.Write([]byte("OK"))
 	})
 
 	t.Run("allow list: allowed IP", func(t *testing.T) {
@@ -396,7 +406,9 @@ func TestIPFilterExtractClientIP(t *testing.T) {
 
 	t.Run("through trusted proxy with X-Forwarded-For", func(t *testing.T) {
 		filter, _ := NewIPAllowListFilter([]string{"10.0.0.0/8"})
-		filter.SetTrustedProxies([]string{"10.0.0.0/8"})
+		if err := filter.SetTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.RemoteAddr = "10.0.0.1:12345"
@@ -410,7 +422,9 @@ func TestIPFilterExtractClientIP(t *testing.T) {
 
 	t.Run("through untrusted proxy ignores X-Forwarded-For", func(t *testing.T) {
 		filter, _ := NewIPAllowListFilter([]string{"10.0.0.0/8"})
-		filter.SetTrustedProxies([]string{"10.0.0.0/8"})
+		if err := filter.SetTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.RemoteAddr = "8.8.8.8:12345"
@@ -424,7 +438,9 @@ func TestIPFilterExtractClientIP(t *testing.T) {
 
 	t.Run("X-Real-IP fallback", func(t *testing.T) {
 		filter, _ := NewIPAllowListFilter([]string{"10.0.0.0/8"})
-		filter.SetTrustedProxies([]string{"10.0.0.0/8"})
+		if err := filter.SetTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.RemoteAddr = "10.0.0.1:12345"
@@ -438,7 +454,9 @@ func TestIPFilterExtractClientIP(t *testing.T) {
 
 	t.Run("X-Forwarded-For with all trusted proxies", func(t *testing.T) {
 		filter, _ := NewIPAllowListFilter([]string{"10.0.0.0/8"})
-		filter.SetTrustedProxies([]string{"10.0.0.0/8"})
+		if err := filter.SetTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.RemoteAddr = "10.0.0.1:12345"

--- a/internal/agent/policy/jwt.go
+++ b/internal/agent/policy/jwt.go
@@ -93,7 +93,7 @@ func (v *JWTValidator) fetchJWKS() error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("JWKS endpoint returned status %d", resp.StatusCode)

--- a/internal/agent/policy/jwt_test.go
+++ b/internal/agent/policy/jwt_test.go
@@ -199,7 +199,7 @@ func TestNewJWTValidator(t *testing.T) {
 		// Create mock JWKS server
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(jwks)
+			_ = json.NewEncoder(w).Encode(jwks)
 		}))
 		defer server.Close()
 
@@ -259,7 +259,7 @@ func TestValidate(t *testing.T) {
 	// Create mock JWKS server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(jwks)
+		_ = json.NewEncoder(w).Encode(jwks)
 	}))
 	defer server.Close()
 
@@ -418,7 +418,7 @@ func TestHandleJWT(t *testing.T) {
 	// Create mock JWKS server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(jwks)
+		_ = json.NewEncoder(w).Encode(jwks)
 	}))
 	defer server.Close()
 
@@ -438,7 +438,7 @@ func TestHandleJWT(t *testing.T) {
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, _ = w.Write([]byte("OK"))
 	})
 
 	middleware := HandleJWT(validator)
@@ -555,7 +555,7 @@ func TestFetchJWKS(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(jwks)
+			_ = json.NewEncoder(w).Encode(jwks)
 		}))
 		defer server.Close()
 
@@ -606,7 +606,7 @@ func TestFetchJWKS(t *testing.T) {
 	t.Run("invalid JSON response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte("invalid json"))
+			_, _ = w.Write([]byte("invalid json"))
 		}))
 		defer server.Close()
 

--- a/internal/agent/policy/ratelimit_test.go
+++ b/internal/agent/policy/ratelimit_test.go
@@ -52,7 +52,7 @@ func TestNewRateLimiter(t *testing.T) {
 
 func TestExtractKey(t *testing.T) {
 	// Setup global trusted proxies for IP extraction
-	SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
+	_ = SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
 	defer func() {
 		trustedProxyCIDRs = nil
 	}()
@@ -203,7 +203,7 @@ func TestGetLimiter(t *testing.T) {
 
 func TestAllow(t *testing.T) {
 	// Setup global trusted proxies for IP extraction
-	SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
+	_ = SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
 	defer func() {
 		trustedProxyCIDRs = nil
 	}()
@@ -314,14 +314,14 @@ func TestAllow(t *testing.T) {
 
 func TestHandleRateLimit(t *testing.T) {
 	// Setup global trusted proxies for IP extraction
-	SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
+	_ = SetGlobalTrustedProxies([]string{"10.0.0.0/8"})
 	defer func() {
 		trustedProxyCIDRs = nil
 	}()
 
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, _ = w.Write([]byte("OK"))
 	})
 
 	t.Run("request allowed", func(t *testing.T) {

--- a/internal/agent/router/route_entry.go
+++ b/internal/agent/router/route_entry.go
@@ -120,7 +120,7 @@ func hashEndpointList(endpoints []*pb.Endpoint) uint64 {
 	h := fnv.New64a()
 	for _, ep := range sortedEndpoints {
 		// Hash address, port, and ready state
-		fmt.Fprintf(h, "%s:%d:%t;", ep.Address, ep.Port, ep.Ready)
+		_, _ = fmt.Fprintf(h, "%s:%d:%t;", ep.Address, ep.Port, ep.Ready)
 	}
 	return h.Sum64()
 }

--- a/internal/agent/router/websocket.go
+++ b/internal/agent/router/websocket.go
@@ -141,7 +141,7 @@ func (p *WebSocketProxy) ProxyWebSocket(w http.ResponseWriter, r *http.Request, 
 		)
 		return fmt.Errorf("failed to upgrade client connection: %w", err)
 	}
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 
 	// Build backend WebSocket URL
 	backendWSURL := buildBackendWebSocketURL(backendURL, r)
@@ -166,7 +166,7 @@ func (p *WebSocketProxy) ProxyWebSocket(w http.ResponseWriter, r *http.Request, 
 			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Backend connection failed"))
 		return fmt.Errorf("failed to connect to backend: %w", err)
 	}
-	defer backendConn.Close()
+	defer func() { _ = backendConn.Close() }()
 
 	p.logger.Info("WebSocket connection established",
 		zap.String("client", r.RemoteAddr),

--- a/internal/agent/server/health.go
+++ b/internal/agent/server/health.go
@@ -54,17 +54,17 @@ func (h *HealthServer) Start(ctx context.Context) error {
 	// Liveness probe - returns 200 if process is running
 	mux.Handle("/healthz", rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, _ = w.Write([]byte("OK"))
 	})))
 
 	// Readiness probe - returns 200 if agent has received valid config
 	mux.Handle("/ready", rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if h.ready.Load() {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("Ready"))
+			_, _ = w.Write([]byte("Ready"))
 		} else {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte("Not Ready"))
+			_, _ = w.Write([]byte("Not Ready"))
 		}
 	})))
 
@@ -73,9 +73,9 @@ func (h *HealthServer) Start(ctx context.Context) error {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if h.ready.Load() {
-			w.Write([]byte(`{"status":"ready","healthy":true}`))
+			_, _ = w.Write([]byte(`{"status":"ready","healthy":true}`))
 		} else {
-			w.Write([]byte(`{"status":"not_ready","healthy":false}`))
+			_, _ = w.Write([]byte(`{"status":"not_ready","healthy":false}`))
 		}
 	})))
 

--- a/internal/agent/server/http.go
+++ b/internal/agent/server/http.go
@@ -113,7 +113,12 @@ func (s *HTTPServer) ApplyConfig(snapshot *config.Snapshot) error {
 				zap.Int32("port", port),
 			)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			server.Shutdown(ctx)
+			if err := server.Shutdown(ctx); err != nil {
+				s.logger.Error("Error shutting down HTTP listener on unused port",
+					zap.Int32("port", port),
+					zap.Error(err),
+				)
+			}
 			cancel()
 			delete(s.servers, port)
 			delete(s.listeners, port)
@@ -127,7 +132,12 @@ func (s *HTTPServer) ApplyConfig(snapshot *config.Snapshot) error {
 				zap.Int32("port", port),
 			)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			server.Shutdown(ctx)
+			if err := server.Shutdown(ctx); err != nil {
+				s.logger.Error("Error shutting down HTTP/3 listener on unused port",
+					zap.Int32("port", port),
+					zap.Error(err),
+				)
+			}
 			cancel()
 			delete(s.http3servers, port)
 		}

--- a/internal/agent/server/metrics.go
+++ b/internal/agent/server/metrics.go
@@ -65,13 +65,13 @@ func (m *MetricsServer) Start(ctx context.Context) error {
 	// Health check endpoint with rate limiting
 	mux.Handle("/health", rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, _ = w.Write([]byte("OK"))
 	})))
 
 	// Root endpoint with info (no rate limiting needed for this informational endpoint)
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("NovaEdge Metrics Server\n\nAvailable endpoints:\n- /metrics (Prometheus metrics)\n- /health (Health check)\n"))
+		_, _ = w.Write([]byte("NovaEdge Metrics Server\n\nAvailable endpoints:\n- /metrics (Prometheus metrics)\n- /health (Health check)\n"))
 	})
 
 	m.server = &http.Server{

--- a/internal/agent/upstream/pool_test.go
+++ b/internal/agent/upstream/pool_test.go
@@ -133,7 +133,7 @@ func TestForward(t *testing.T) {
 	// Create test backend server
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("backend response"))
+		_, _ = w.Write([]byte("backend response"))
 	}))
 	defer backend.Close()
 

--- a/internal/agent/vip/l2.go
+++ b/internal/agent/vip/l2.go
@@ -256,7 +256,7 @@ func (h *L2Handler) sendGARP(ip net.IP) error {
 			zap.Error(err))
 		return nil
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// Convert net.IP to netip.Addr
 	senderIP, ok := netip.AddrFromSlice(ipv4)

--- a/internal/agent/vip/local_coordinator.go
+++ b/internal/agent/vip/local_coordinator.go
@@ -191,7 +191,7 @@ func (c *LocalCoordinator) Stop() {
 		c.cancel()
 	}
 	if c.conn != nil {
-		c.conn.Close()
+		_ = c.conn.Close()
 	}
 
 	c.logger.Info("Stopped local VIP coordination")
@@ -263,7 +263,10 @@ func (c *LocalCoordinator) receiveLoop() {
 		default:
 		}
 
-		c.conn.SetReadDeadline(time.Now().Add(time.Second))
+		if err := c.conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			c.logger.Error("Failed to set read deadline", zap.Error(err))
+			continue
+		}
 		n, _, err := c.conn.ReadFromUDP(buf)
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
@@ -412,7 +415,13 @@ func (c *LocalCoordinator) sendMessage(vip string, msgType MessageType) {
 		msgType, vip, c.nodeName, c.priority, time.Now().UnixNano())
 
 	if c.conn != nil && c.peerAddr != nil {
-		c.conn.WriteToUDP([]byte(msg), c.peerAddr)
+		if _, err := c.conn.WriteToUDP([]byte(msg), c.peerAddr); err != nil {
+			c.logger.Error("Failed to send coordination message",
+				zap.String("vip", vip),
+				zap.String("type", string(msgType)),
+				zap.Error(err),
+			)
+		}
 	}
 }
 

--- a/internal/controller/federation/client.go
+++ b/internal/controller/federation/client.go
@@ -128,7 +128,7 @@ func (c *PeerClient) Disconnect() {
 	}
 
 	if c.conn != nil {
-		c.conn.Close()
+		_ = c.conn.Close()
 		c.conn = nil
 		c.client = nil
 	}

--- a/internal/standalone/converter.go
+++ b/internal/standalone/converter.go
@@ -364,7 +364,9 @@ func parseAddressPort(addr string) (string, int32) {
 	parts := strings.Split(addr, ":")
 	if len(parts) == 2 {
 		var port int
-		fmt.Sscanf(parts[1], "%d", &port)
+		if _, err := fmt.Sscanf(parts[1], "%d", &port); err != nil {
+			return parts[0], 0 // Return host with zero port on parse error
+		}
 		return parts[0], int32(port)
 	}
 	return addr, 80 // Default to port 80
@@ -416,7 +418,9 @@ func (c *Converter) convertVIPs(vips []VIPConfig) ([]*pb.VIPAssignment, error) {
 		if v.OSPF != nil {
 			// Parse area as uint32 if possible
 			var areaID uint32
-			fmt.Sscanf(v.OSPF.Area, "%d", &areaID)
+			if _, err := fmt.Sscanf(v.OSPF.Area, "%d", &areaID); err != nil {
+				return nil, fmt.Errorf("failed to parse OSPF area %q: %w", v.OSPF.Area, err)
+			}
 			assignment.OspfConfig = &pb.OSPFConfig{
 				RouterId: v.OSPF.RouterID,
 				AreaId:   areaID,

--- a/internal/standalone/watcher.go
+++ b/internal/standalone/watcher.go
@@ -81,7 +81,7 @@ func (w *ConfigWatcher) Start(ctx context.Context, applyFunc ApplyFunc) error {
 	if err != nil {
 		return fmt.Errorf("failed to create file watcher: %w", err)
 	}
-	defer watcher.Close()
+	defer func() { _ = watcher.Close() }()
 
 	// Watch the directory containing the config file
 	// (watching the file directly doesn't work well with editors that replace files)


### PR DESCRIPTION
## Summary
- Fix all 39+ unchecked error return values detected by `golangci-lint --enable errcheck` across 35 files
- Production code: properly handle or explicitly ignore error returns from `Close()`, `Shutdown()`, `Write()`, `Flush()`, `Sscanf()`, `Sync()`, and other functions
- Test code: check error returns from `SetGlobalTrustedProxies`, `SetTrustedProxies`, and explicitly ignore `w.Write()` / `json.Encode()` returns in test HTTP handlers

## Changes by category

**Error handling improvements (production):**
- `internal/standalone/converter.go`: Handle `fmt.Sscanf` parse errors for port and OSPF area parsing
- `internal/agent/server/http.go`: Log `server.Shutdown` errors during listener cleanup
- `internal/agent/vip/local_coordinator.go`: Log `SetReadDeadline` and `WriteToUDP` errors, explicitly ignore `conn.Close`
- `cmd/novaedge-agent/main.go`, `cmd/novaedge-standalone/main.go`: Use `_ = logger.Sync()` pattern
- `cmd/novactl/cmd/apply.go`: Wrap `MarkFlagRequired` with `cobra.CheckErr`
- `internal/agent/config/failover.go`, `watcher.go`: Handle `conn.Close` returns
- `internal/agent/policy/jwt.go`: Handle `resp.Body.Close` return
- Various CLI files: Handle `fmt.Fprintf/Fprintln`, `w.Flush`, `w.Write`, `resp.Body.Close` returns

**Test code cleanup:**
- `internal/agent/policy/cors_test.go`, `ipfilter_test.go`, `jwt_test.go`, `ratelimit_test.go`: Check error returns
- `internal/agent/upstream/pool_test.go`: Explicitly ignore `w.Write` in test handlers

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests still pass)
- [x] `golangci-lint run --enable errcheck` reports zero errcheck violations

Resolves #31