### PR TITLE
[Fix] Resolve 5 bugs: SecurityHeaders wiring, targetRef.Kind, samples, endpoint ports, LB map (#103, #104, #105, #106, #107)

### DIFF
--- a/cmd/novactl/pkg/printer/printer.go
+++ b/cmd/novactl/pkg/printer/printer.go
@@ -185,14 +185,10 @@ func (p *Printer) printPolicyTable(w *tabwriter.Writer, items []unstructured.Uns
 
 		spec, _, _ := unstructured.NestedMap(item.Object, "spec")
 
-		// Determine policy type
-		policyType := "unknown"
-		if _, found, _ := unstructured.NestedMap(spec, "rateLimit"); found {
-			policyType = "rateLimit"
-		} else if _, found, _ := unstructured.NestedMap(spec, "cors"); found {
-			policyType = "cors"
-		} else if _, found, _ := unstructured.NestedMap(spec, "tlsPolicy"); found {
-			policyType = "tls"
+		// Determine policy type from spec.type field
+		policyType, _, _ := unstructured.NestedString(spec, "type")
+		if policyType == "" {
+			policyType = "unknown"
 		}
 
 		targetRef, _, _ := unstructured.NestedMap(spec, "targetRef")

--- a/config/samples/proxypolicy_cors_sample.yaml
+++ b/config/samples/proxypolicy_cors_sample.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   type: CORS
   targetRef:
-    kind: ProxyGateway
-    name: external-gateway
+    kind: ProxyRoute
+    name: example-route
     namespace: default
   cors:
     allowOrigins:

--- a/config/samples/proxyroute_sample.yaml
+++ b/config/samples/proxyroute_sample.yaml
@@ -23,9 +23,7 @@ spec:
               value: "v1"
       backendRefs:
         - name: api-backend
-          weight: 80
-        - name: api-backend-canary
-          weight: 20
+          weight: 100
     - matches:
         - path:
             type: PathPrefix
@@ -36,4 +34,5 @@ spec:
             - name: X-Version
               value: "v2"
       backendRefs:
-        - name: api-backend-v2
+        - name: api-backend
+          weight: 100

--- a/internal/agent/router/middleware.go
+++ b/internal/agent/router/middleware.go
@@ -47,6 +47,12 @@ func (r *Router) createPolicyMiddleware(ctx context.Context, route *pb.Route, sn
 			continue
 		}
 
+		// Match by Kind: only apply policies that target ProxyRoute resources.
+		// Policies targeting ProxyGateway or ProxyBackend should not match routes.
+		if policyProto.TargetRef.Kind != "ProxyRoute" {
+			continue
+		}
+
 		targetRef := fmt.Sprintf("%s/%s", policyProto.TargetRef.Namespace, policyProto.TargetRef.Name)
 		if targetRef != routeRef {
 			continue
@@ -108,6 +114,15 @@ func (r *Router) createPolicyMiddleware(ctx context.Context, route *pb.Route, sn
 						zap.Error(err),
 					)
 				}
+			}
+
+		case pb.PolicyType_SECURITY_HEADERS:
+			if policyProto.SecurityHeaders != nil {
+				sh := policy.NewSecurityHeaders(policyProto.SecurityHeaders)
+				middlewares = append(middlewares, policyMiddleware{
+					name:    fmt.Sprintf("security-headers-%s", policyProto.Name),
+					handler: policy.HandleSecurityHeaders(sh),
+				})
 			}
 		}
 	}

--- a/internal/agent/router/middleware_test.go
+++ b/internal/agent/router/middleware_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/novaedge/internal/agent/config"
+	pb "github.com/piwi3910/novaedge/internal/proto/gen"
+)
+
+func TestCreatePolicyMiddleware_TargetRefKindFiltering(t *testing.T) {
+	logger := zap.NewNop()
+	r := NewRouter(logger)
+
+	route := &pb.Route{
+		Name:      "my-route",
+		Namespace: "default",
+	}
+
+	snapshot := &config.Snapshot{
+		ConfigSnapshot: &pb.ConfigSnapshot{
+			Policies: []*pb.Policy{
+				{
+					Name:      "gateway-rate-limit",
+					Namespace: "default",
+					Type:      pb.PolicyType_RATE_LIMIT,
+					TargetRef: &pb.TargetRef{
+						Kind:      "ProxyGateway",
+						Name:      "my-route",
+						Namespace: "default",
+					},
+					RateLimit: &pb.RateLimitConfig{
+						RequestsPerSecond: 100,
+						Burst:             50,
+					},
+				},
+				{
+					Name:      "route-rate-limit",
+					Namespace: "default",
+					Type:      pb.PolicyType_RATE_LIMIT,
+					TargetRef: &pb.TargetRef{
+						Kind:      "ProxyRoute",
+						Name:      "my-route",
+						Namespace: "default",
+					},
+					RateLimit: &pb.RateLimitConfig{
+						RequestsPerSecond: 50,
+						Burst:             25,
+					},
+				},
+			},
+		},
+	}
+
+	middlewares := r.createPolicyMiddleware(context.Background(), route, snapshot)
+
+	// Should only match the ProxyRoute policy, not the ProxyGateway one
+	if len(middlewares) != 1 {
+		t.Fatalf("Expected 1 middleware (only ProxyRoute target), got %d", len(middlewares))
+	}
+
+	if middlewares[0].name != "rate-limit-route-rate-limit" {
+		t.Errorf("Expected middleware name 'rate-limit-route-rate-limit', got %q", middlewares[0].name)
+	}
+}
+
+func TestCreatePolicyMiddleware_SecurityHeaders(t *testing.T) {
+	logger := zap.NewNop()
+	r := NewRouter(logger)
+
+	route := &pb.Route{
+		Name:      "api-route",
+		Namespace: "default",
+	}
+
+	snapshot := &config.Snapshot{
+		ConfigSnapshot: &pb.ConfigSnapshot{
+			Policies: []*pb.Policy{
+				{
+					Name:      "sec-headers",
+					Namespace: "default",
+					Type:      pb.PolicyType_SECURITY_HEADERS,
+					TargetRef: &pb.TargetRef{
+						Kind:      "ProxyRoute",
+						Name:      "api-route",
+						Namespace: "default",
+					},
+					SecurityHeaders: &pb.SecurityHeadersConfig{
+						Hsts: &pb.HSTSConfig{
+							Enabled:       true,
+							MaxAgeSeconds: 31536000,
+						},
+						XFrameOptions:       "DENY",
+						XContentTypeOptions: true,
+					},
+				},
+			},
+		},
+	}
+
+	middlewares := r.createPolicyMiddleware(context.Background(), route, snapshot)
+
+	if len(middlewares) != 1 {
+		t.Fatalf("Expected 1 middleware, got %d", len(middlewares))
+	}
+
+	if middlewares[0].name != "security-headers-sec-headers" {
+		t.Errorf("Expected middleware name 'security-headers-sec-headers', got %q", middlewares[0].name)
+	}
+
+	// Verify the middleware handler is not nil
+	if middlewares[0].handler == nil {
+		t.Error("Expected non-nil handler for security headers middleware")
+	}
+}
+
+func TestCreatePolicyMiddleware_NilTargetRef(t *testing.T) {
+	logger := zap.NewNop()
+	r := NewRouter(logger)
+
+	route := &pb.Route{
+		Name:      "my-route",
+		Namespace: "default",
+	}
+
+	snapshot := &config.Snapshot{
+		ConfigSnapshot: &pb.ConfigSnapshot{
+			Policies: []*pb.Policy{
+				{
+					Name:      "no-target",
+					Namespace: "default",
+					Type:      pb.PolicyType_RATE_LIMIT,
+					TargetRef: nil,
+					RateLimit: &pb.RateLimitConfig{
+						RequestsPerSecond: 100,
+					},
+				},
+			},
+		},
+	}
+
+	middlewares := r.createPolicyMiddleware(context.Background(), route, snapshot)
+
+	// Should skip policies with nil targetRef
+	if len(middlewares) != 0 {
+		t.Fatalf("Expected 0 middlewares for nil targetRef, got %d", len(middlewares))
+	}
+}
+
+func TestCreatePolicyMiddleware_NameMismatch(t *testing.T) {
+	logger := zap.NewNop()
+	r := NewRouter(logger)
+
+	route := &pb.Route{
+		Name:      "my-route",
+		Namespace: "default",
+	}
+
+	snapshot := &config.Snapshot{
+		ConfigSnapshot: &pb.ConfigSnapshot{
+			Policies: []*pb.Policy{
+				{
+					Name:      "other-policy",
+					Namespace: "default",
+					Type:      pb.PolicyType_CORS,
+					TargetRef: &pb.TargetRef{
+						Kind:      "ProxyRoute",
+						Name:      "other-route",
+						Namespace: "default",
+					},
+					Cors: &pb.CORSConfig{
+						AllowOrigins: []string{"*"},
+					},
+				},
+			},
+		},
+	}
+
+	middlewares := r.createPolicyMiddleware(context.Background(), route, snapshot)
+
+	if len(middlewares) != 0 {
+		t.Fatalf("Expected 0 middlewares for name mismatch, got %d", len(middlewares))
+	}
+}

--- a/internal/agent/router/route_entry.go
+++ b/internal/agent/router/route_entry.go
@@ -104,11 +104,18 @@ func selectWeightedBackend(backends []*pb.BackendRef) *pb.BackendRef {
 	return backends[0]
 }
 
-// hashEndpointList computes a hash of the endpoint list for versioning
-// This allows us to detect when endpoints change without storing the full list
-func hashEndpointList(endpoints []*pb.Endpoint) uint64 {
+// hashEndpointList computes a hash of the endpoint list and LB policy for versioning.
+// This allows us to detect when endpoints or the load balancing policy change
+// without storing the full list. Including the LB policy ensures that changing
+// from e.g. ROUND_ROBIN to EWMA forces load balancer recreation even if
+// the endpoint set is identical.
+func hashEndpointList(endpoints []*pb.Endpoint, lbPolicy pb.LoadBalancingPolicy) uint64 {
+	// Start with the LB policy so that a policy change alone triggers recreation
+	h := fnv.New64a()
+	_, _ = fmt.Fprintf(h, "lb:%d;", int32(lbPolicy))
+
 	if len(endpoints) == 0 {
-		return 0
+		return h.Sum64()
 	}
 
 	// Sort endpoints by address:port for consistent hashing
@@ -123,7 +130,6 @@ func hashEndpointList(endpoints []*pb.Endpoint) uint64 {
 	})
 
 	// Compute hash
-	h := fnv.New64a()
 	for _, ep := range sortedEndpoints {
 		// Hash address, port, and ready state
 		_, _ = fmt.Fprintf(h, "%s:%d:%t;", ep.Address, ep.Port, ep.Ready)

--- a/internal/agent/router/router.go
+++ b/internal/agent/router/router.go
@@ -176,7 +176,7 @@ func (r *Router) ApplyConfig(ctx context.Context, snapshot *config.Snapshot) err
 		}
 
 		// Check if endpoints changed by computing hash
-		endpointHash := hashEndpointList(endpointList.Endpoints)
+		endpointHash := hashEndpointList(endpointList.Endpoints, cluster.LbPolicy)
 		previousHash, exists := r.endpointVersions[clusterKey]
 
 		// Only recreate load balancer if endpoints actually changed

--- a/internal/agent/router/router_bench_test.go
+++ b/internal/agent/router/router_bench_test.go
@@ -160,7 +160,7 @@ func BenchmarkHashEndpointList(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_ = hashEndpointList(endpoints)
+		_ = hashEndpointList(endpoints, pb.LoadBalancingPolicy_ROUND_ROBIN)
 	}
 }
 

--- a/internal/agent/router/router_test.go
+++ b/internal/agent/router/router_test.go
@@ -165,3 +165,63 @@ func NewRegexMatcher(pattern string) (*RegexMatcher, error) {
 	}
 	return &RegexMatcher{Pattern: regex}, nil
 }
+
+func TestHashEndpointListIncludesLBPolicy(t *testing.T) {
+	endpoints := []*pb.Endpoint{
+		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: "10.0.0.2", Port: 8080, Ready: true},
+	}
+
+	hashRR := hashEndpointList(endpoints, pb.LoadBalancingPolicy_ROUND_ROBIN)
+	hashEWMA := hashEndpointList(endpoints, pb.LoadBalancingPolicy_EWMA)
+	hashP2C := hashEndpointList(endpoints, pb.LoadBalancingPolicy_P2C)
+
+	// Same endpoints with different LB policies must produce different hashes
+	if hashRR == hashEWMA {
+		t.Error("Expected different hashes for ROUND_ROBIN vs EWMA with same endpoints")
+	}
+	if hashRR == hashP2C {
+		t.Error("Expected different hashes for ROUND_ROBIN vs P2C with same endpoints")
+	}
+	if hashEWMA == hashP2C {
+		t.Error("Expected different hashes for EWMA vs P2C with same endpoints")
+	}
+
+	// Same endpoints and same policy must produce the same hash
+	hashRR2 := hashEndpointList(endpoints, pb.LoadBalancingPolicy_ROUND_ROBIN)
+	if hashRR != hashRR2 {
+		t.Error("Expected same hash for identical endpoints and policy")
+	}
+}
+
+func TestHashEndpointListDeterministic(t *testing.T) {
+	// Endpoints in different order should produce the same hash (sorted internally)
+	endpoints1 := []*pb.Endpoint{
+		{Address: "10.0.0.2", Port: 8080, Ready: true},
+		{Address: "10.0.0.1", Port: 8080, Ready: true},
+	}
+	endpoints2 := []*pb.Endpoint{
+		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: "10.0.0.2", Port: 8080, Ready: true},
+	}
+
+	hash1 := hashEndpointList(endpoints1, pb.LoadBalancingPolicy_ROUND_ROBIN)
+	hash2 := hashEndpointList(endpoints2, pb.LoadBalancingPolicy_ROUND_ROBIN)
+
+	if hash1 != hash2 {
+		t.Error("Expected same hash regardless of endpoint order")
+	}
+}
+
+func TestHashEndpointListEmpty(t *testing.T) {
+	hash := hashEndpointList(nil, pb.LoadBalancingPolicy_ROUND_ROBIN)
+	if hash == 0 {
+		t.Error("Expected non-zero hash even for empty endpoints (LB policy is hashed)")
+	}
+
+	// Different policies with empty endpoints should differ
+	hashEWMA := hashEndpointList(nil, pb.LoadBalancingPolicy_EWMA)
+	if hash == hashEWMA {
+		t.Error("Expected different hashes for different policies even with empty endpoints")
+	}
+}

--- a/internal/controller/snapshot/builder.go
+++ b/internal/controller/snapshot/builder.go
@@ -413,6 +413,29 @@ func (b *Builder) buildPolicies(ctx context.Context) ([]*pb.Policy, error) {
 			}
 		}
 
+		if p.Spec.SecurityHeaders != nil {
+			shConfig := &pb.SecurityHeadersConfig{
+				ContentSecurityPolicy:     p.Spec.SecurityHeaders.ContentSecurityPolicy,
+				XFrameOptions:             p.Spec.SecurityHeaders.XFrameOptions,
+				XContentTypeOptions:       p.Spec.SecurityHeaders.XContentTypeOptions,
+				XXssProtection:            p.Spec.SecurityHeaders.XXSSProtection,
+				ReferrerPolicy:            p.Spec.SecurityHeaders.ReferrerPolicy,
+				PermissionsPolicy:         p.Spec.SecurityHeaders.PermissionsPolicy,
+				CrossOriginEmbedderPolicy: p.Spec.SecurityHeaders.CrossOriginEmbedderPolicy,
+				CrossOriginOpenerPolicy:   p.Spec.SecurityHeaders.CrossOriginOpenerPolicy,
+				CrossOriginResourcePolicy: p.Spec.SecurityHeaders.CrossOriginResourcePolicy,
+			}
+			if p.Spec.SecurityHeaders.HSTS != nil {
+				shConfig.Hsts = &pb.HSTSConfig{
+					Enabled:           p.Spec.SecurityHeaders.HSTS.Enabled,
+					MaxAgeSeconds:     p.Spec.SecurityHeaders.HSTS.MaxAge,
+					IncludeSubdomains: p.Spec.SecurityHeaders.HSTS.IncludeSubDomains,
+					Preload:           p.Spec.SecurityHeaders.HSTS.Preload,
+				}
+			}
+			policy.SecurityHeaders = shConfig
+		}
+
 		policies = append(policies, policy)
 	}
 
@@ -432,13 +455,19 @@ func (b *Builder) resolveServiceEndpoints(ctx context.Context, serviceRef *novae
 		return nil, fmt.Errorf("failed to get service: %w", err)
 	}
 
-	// Resolve the target port name from the Service spec for the requested port.
+	// Resolve the target port name and numeric targetPort from the Service spec.
 	// EndpointSlices contain targetPort values (not Service ports), so we need
-	// to find which port name corresponds to the serviceRef.Port.
+	// to find the port name or numeric targetPort that corresponds to serviceRef.Port.
 	var targetPortName string
+	var targetPortNumber int32
 	for _, sp := range svc.Spec.Ports {
 		if sp.Port == serviceRef.Port {
 			targetPortName = sp.Name
+			// TargetPort can be a string (port name) or int (port number).
+			// When it is numeric, use it for direct matching against EndpointSlice ports.
+			if sp.TargetPort.IntValue() > 0 {
+				targetPortNumber = int32(sp.TargetPort.IntValue())
+			}
 			break
 		}
 	}
@@ -460,21 +489,34 @@ func (b *Builder) resolveServiceEndpoints(ctx context.Context, serviceRef *novae
 			}
 
 			// Find the matching port in the EndpointSlice.
-			// Match by port name (which links Service port to targetPort),
-			// or fall back to direct port number match for unnamed ports.
+			// Priority: 1) match by port name, 2) match by targetPort number,
+			// 3) fall back to service port number for unnamed single-port services.
 			var port int32
 			for _, p := range es.Ports {
 				if p.Port == nil {
 					continue
 				}
+				// Named port match: links Service port name to EndpointSlice port name
 				if targetPortName != "" && p.Name != nil && *p.Name == targetPortName {
 					port = *p.Port
 					break
 				}
-				if *p.Port == serviceRef.Port {
+				// Numeric targetPort match: the Service explicitly sets targetPort
+				if targetPortNumber > 0 && *p.Port == targetPortNumber {
 					port = *p.Port
 					break
 				}
+				// Fallback for unnamed ports: direct port number match
+				if targetPortName == "" && targetPortNumber == 0 && *p.Port == serviceRef.Port {
+					port = *p.Port
+					break
+				}
+			}
+			// Final fallback: if the EndpointSlice has exactly one port, use it.
+			// This handles the common case of a single-port Service where the port
+			// name is empty and targetPort differs from port.
+			if port == 0 && len(es.Ports) == 1 && es.Ports[0].Port != nil {
+				port = *es.Ports[0].Port
 			}
 
 			if port == 0 {

--- a/internal/controller/snapshot/builder_convert.go
+++ b/internal/controller/snapshot/builder_convert.go
@@ -115,6 +115,8 @@ func convertPolicyType(policyType novaedgev1alpha1.PolicyType) pb.PolicyType {
 		return pb.PolicyType_IP_DENY_LIST
 	case novaedgev1alpha1.PolicyTypeCORS:
 		return pb.PolicyType_CORS
+	case novaedgev1alpha1.PolicyTypeSecurityHeaders:
+		return pb.PolicyType_SECURITY_HEADERS
 	default:
 		return pb.PolicyType_POLICY_TYPE_UNSPECIFIED
 	}

--- a/internal/controller/snapshot/builder_convert_test.go
+++ b/internal/controller/snapshot/builder_convert_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"testing"
+
+	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
+	pb "github.com/piwi3910/novaedge/internal/proto/gen"
+)
+
+func TestConvertPolicyType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    novaedgev1alpha1.PolicyType
+		expected pb.PolicyType
+	}{
+		{
+			name:     "RateLimit",
+			input:    novaedgev1alpha1.PolicyTypeRateLimit,
+			expected: pb.PolicyType_RATE_LIMIT,
+		},
+		{
+			name:     "JWT",
+			input:    novaedgev1alpha1.PolicyTypeJWT,
+			expected: pb.PolicyType_JWT,
+		},
+		{
+			name:     "IPAllowList",
+			input:    novaedgev1alpha1.PolicyTypeIPAllowList,
+			expected: pb.PolicyType_IP_ALLOW_LIST,
+		},
+		{
+			name:     "IPDenyList",
+			input:    novaedgev1alpha1.PolicyTypeIPDenyList,
+			expected: pb.PolicyType_IP_DENY_LIST,
+		},
+		{
+			name:     "CORS",
+			input:    novaedgev1alpha1.PolicyTypeCORS,
+			expected: pb.PolicyType_CORS,
+		},
+		{
+			name:     "SecurityHeaders maps to SECURITY_HEADERS not UNSPECIFIED",
+			input:    novaedgev1alpha1.PolicyTypeSecurityHeaders,
+			expected: pb.PolicyType_SECURITY_HEADERS,
+		},
+		{
+			name:     "unknown type maps to UNSPECIFIED",
+			input:    novaedgev1alpha1.PolicyType("Unknown"),
+			expected: pb.PolicyType_POLICY_TYPE_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertPolicyType(tt.input)
+			if result != tt.expected {
+				t.Errorf("convertPolicyType(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/controller/snapshot/builder_test.go
+++ b/internal/controller/snapshot/builder_test.go
@@ -20,8 +20,11 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
@@ -226,5 +229,250 @@ func TestSnapshotCacheOperations(t *testing.T) {
 	cache.Clear()
 	if cache.GetCacheSize() != 0 {
 		t.Errorf("Expected cache size 0 after clear, got %d", cache.GetCacheSize())
+	}
+}
+
+func TestBuildPoliciesSecurityHeaders(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = novaedgev1alpha1.AddToScheme(scheme)
+
+	policy := &novaedgev1alpha1.ProxyPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sec-headers",
+			Namespace: "default",
+		},
+		Spec: novaedgev1alpha1.ProxyPolicySpec{
+			Type: novaedgev1alpha1.PolicyTypeSecurityHeaders,
+			TargetRef: novaedgev1alpha1.TargetRef{
+				Kind: "ProxyRoute",
+				Name: "test-route",
+			},
+			SecurityHeaders: &novaedgev1alpha1.SecurityHeadersConfig{
+				HSTS: &novaedgev1alpha1.HSTSConfig{
+					Enabled:           true,
+					MaxAge:            31536000,
+					IncludeSubDomains: true,
+					Preload:           true,
+				},
+				XFrameOptions:       "DENY",
+				XContentTypeOptions: true,
+				XXSSProtection:      "1; mode=block",
+				ReferrerPolicy:      "no-referrer",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		Build()
+
+	builder := NewBuilder(fakeClient)
+	snapshot, err := builder.BuildSnapshot(context.Background(), "test-node")
+	if err != nil {
+		t.Fatalf("Failed to build snapshot: %v", err)
+	}
+
+	if len(snapshot.Policies) != 1 {
+		t.Fatalf("Expected 1 policy, got %d", len(snapshot.Policies))
+	}
+
+	p := snapshot.Policies[0]
+
+	// Verify the policy type is correctly mapped (not UNSPECIFIED)
+	if p.Type != pb.PolicyType_SECURITY_HEADERS {
+		t.Errorf("Expected SECURITY_HEADERS, got %v", p.Type)
+	}
+
+	// Verify SecurityHeaders config is serialized
+	if p.SecurityHeaders == nil {
+		t.Fatal("SecurityHeaders config is nil")
+	}
+
+	if p.SecurityHeaders.Hsts == nil {
+		t.Fatal("HSTS config is nil")
+	}
+
+	if !p.SecurityHeaders.Hsts.Enabled {
+		t.Error("Expected HSTS enabled")
+	}
+
+	if p.SecurityHeaders.Hsts.MaxAgeSeconds != 31536000 {
+		t.Errorf("Expected MaxAgeSeconds 31536000, got %d", p.SecurityHeaders.Hsts.MaxAgeSeconds)
+	}
+
+	if !p.SecurityHeaders.Hsts.IncludeSubdomains {
+		t.Error("Expected IncludeSubdomains true")
+	}
+
+	if !p.SecurityHeaders.Hsts.Preload {
+		t.Error("Expected Preload true")
+	}
+
+	if p.SecurityHeaders.XFrameOptions != "DENY" {
+		t.Errorf("Expected XFrameOptions DENY, got %s", p.SecurityHeaders.XFrameOptions)
+	}
+
+	if !p.SecurityHeaders.XContentTypeOptions {
+		t.Error("Expected XContentTypeOptions true")
+	}
+
+	if p.SecurityHeaders.XXssProtection != "1; mode=block" {
+		t.Errorf("Expected XXssProtection '1; mode=block', got %s", p.SecurityHeaders.XXssProtection)
+	}
+
+	if p.SecurityHeaders.ReferrerPolicy != "no-referrer" {
+		t.Errorf("Expected ReferrerPolicy 'no-referrer', got %s", p.SecurityHeaders.ReferrerPolicy)
+	}
+}
+
+func TestResolveEndpointsTargetPort(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = novaedgev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	// Service with port 80 -> targetPort 8080
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-svc",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt32(8080),
+				},
+			},
+		},
+	}
+
+	ready := true
+	portName := "http"
+	port8080 := int32(8080)
+	es := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-svc-abc",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kubernetes.io/service-name": "my-svc",
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses:  []string{"10.0.0.1"},
+				Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Name: &portName,
+				Port: &port8080,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(svc, es).
+		Build()
+
+	builder := NewBuilder(fakeClient)
+	serviceRef := &novaedgev1alpha1.ServiceReference{
+		Name: "my-svc",
+		Port: 80, // Service port, NOT targetPort
+	}
+
+	result, err := builder.resolveServiceEndpoints(context.Background(), serviceRef, "default")
+	if err != nil {
+		t.Fatalf("resolveServiceEndpoints failed: %v", err)
+	}
+
+	if len(result.Endpoints) != 1 {
+		t.Fatalf("Expected 1 endpoint, got %d", len(result.Endpoints))
+	}
+
+	// The endpoint port should be 8080 (the targetPort), not 80 (the service port)
+	if result.Endpoints[0].Port != 8080 {
+		t.Errorf("Expected endpoint port 8080 (targetPort), got %d", result.Endpoints[0].Port)
+	}
+
+	if result.Endpoints[0].Address != "10.0.0.1" {
+		t.Errorf("Expected address 10.0.0.1, got %s", result.Endpoints[0].Address)
+	}
+}
+
+func TestResolveEndpointsUnnamedPort(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = novaedgev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	// Service with unnamed port: port 80 -> targetPort 8080
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unnamed-svc",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port:       80,
+					TargetPort: intstr.FromInt32(8080),
+				},
+			},
+		},
+	}
+
+	ready := true
+	port8080 := int32(8080)
+	es := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unnamed-svc-abc",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kubernetes.io/service-name": "unnamed-svc",
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses:  []string{"10.0.0.2"},
+				Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Port: &port8080,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(svc, es).
+		Build()
+
+	builder := NewBuilder(fakeClient)
+	serviceRef := &novaedgev1alpha1.ServiceReference{
+		Name: "unnamed-svc",
+		Port: 80,
+	}
+
+	result, err := builder.resolveServiceEndpoints(context.Background(), serviceRef, "default")
+	if err != nil {
+		t.Fatalf("resolveServiceEndpoints failed: %v", err)
+	}
+
+	if len(result.Endpoints) != 1 {
+		t.Fatalf("Expected 1 endpoint, got %d", len(result.Endpoints))
+	}
+
+	// Should resolve to 8080 via targetPort number matching or single-port fallback
+	if result.Endpoints[0].Port != 8080 {
+		t.Errorf("Expected endpoint port 8080 (targetPort), got %d", result.Endpoints[0].Port)
 	}
 }


### PR DESCRIPTION
## Summary

- **SecurityHeaders policy wired end-to-end (#103):** `convertPolicyType()` now maps `SecurityHeaders` to `SECURITY_HEADERS` (was `UNSPECIFIED`), `buildPolicies()` serializes the full SecurityHeaders config into proto, and the agent middleware chain has a new `SECURITY_HEADERS` case that invokes the existing `security_headers.go` implementation.
- **targetRef.Kind check in middleware matching (#104):** `createPolicyMiddleware()` now checks `targetRef.Kind == "ProxyRoute"` before matching, so a policy targeting a `ProxyGateway` no longer accidentally matches a `ProxyRoute` with the same name.
- **Sample CRD cross-references fixed (#105):** `proxyroute_sample.yaml` references only the existing `api-backend` (removed nonexistent `api-backend-canary` and `api-backend-v2`); `proxypolicy_cors_sample.yaml` targets `ProxyRoute/example-route` instead of `ProxyGateway/external-gateway`.
- **Endpoint port resolution for differing targetPort (#106):** `resolveServiceEndpoints()` now resolves the numeric `targetPort` from the Service spec and uses it for EndpointSlice port matching. Also adds a single-port fallback for unnamed services where targetPort differs from port.
- **LB policy included in endpoint hash (#107):** `hashEndpointList()` now incorporates the LB policy so that changing the load balancing algorithm (e.g. `ROUND_ROBIN` to `EWMA`) forces LB recreation even when endpoints are unchanged.
- **novactl printer fix:** Policy type detection now reads `spec.type` directly instead of heuristic nested-map checks, correctly displaying all policy types including SecurityHeaders.

## Test plan

- [x] Unit tests for `convertPolicyType()` covering all types including SecurityHeaders
- [x] Unit test for SecurityHeaders config serialization in `buildPolicies()`
- [x] Unit tests for endpoint port resolution with named and unnamed ports where service port != targetPort
- [x] Unit tests for middleware Kind filtering (ProxyGateway vs ProxyRoute)
- [x] Unit tests for SecurityHeaders middleware creation
- [x] Unit tests for `hashEndpointList` with LB policy parameter (determinism, policy-sensitivity)
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `gofmt -s` applied to all modified files

Resolves #103, Resolves #104, Resolves #105, Resolves #106, Resolves #107