### PR TITLE
[Performance] Cache Alt-Svc header atomically for lock-free reads (#133)

### DIFF
--- a/internal/agent/server/http.go
+++ b/internal/agent/server/http.go
@@ -42,6 +42,7 @@ type HTTPServer struct {
 	inFlightRequests sync.WaitGroup // Track in-flight requests for graceful shutdown
 	shuttingDown     atomic.Bool    // Flag to indicate shutdown in progress
 	ocspStapler      *OCSPStapler   // OCSP stapling manager
+	cachedAltSvc     atomic.Value   // stores string - cached Alt-Svc header value
 }
 
 // NewHTTPServer creates a new HTTP server
@@ -182,6 +183,9 @@ func (s *HTTPServer) ApplyConfig(ctx context.Context, snapshot *config.Snapshot)
 	}
 
 	s.listeners = newListeners
+
+	// Update cached Alt-Svc header value for lock-free reads
+	s.updateAltSvcCache()
 
 	s.logger.Info("HTTP server configuration applied successfully",
 		zap.Int("active_http_listeners", len(s.servers)),
@@ -340,6 +344,7 @@ func (s *HTTPServer) Shutdown(ctx context.Context) error {
 
 	s.servers = make(map[int32]*http.Server)
 	s.http3servers = make(map[int32]*HTTP3Server)
+	s.updateAltSvcCache()
 
 	if shutdownErr != nil {
 		return shutdownErr

--- a/internal/agent/server/listener.go
+++ b/internal/agent/server/listener.go
@@ -172,21 +172,33 @@ func (s *HTTPServer) enableAltSvcAdvertising(_ int32) {
 	// The Alt-Svc header is added in the ServeHTTP method via addAltSvcHeader
 }
 
-// addAltSvcHeader adds the Alt-Svc header to advertise HTTP/3 availability
+// addAltSvcHeader adds the Alt-Svc header to advertise HTTP/3 availability.
+// Uses atomic.Value for lock-free reads on the hot path.
 func (s *HTTPServer) addAltSvcHeader(w http.ResponseWriter, _ *http.Request) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	// Check if there's an HTTP/3 server on any port
-	for port, h3srv := range s.http3servers {
-		// Use SetQuicHeaders if available for standard-compliant Alt-Svc
-		if err := h3srv.SetQuicHeaders(w.Header()); err != nil {
-			// Fallback to manual header
-			altSvc := fmt.Sprintf("h3=\":%d\"; ma=%d", port, HTTP3AltSvcMaxAge)
-			w.Header().Set("Alt-Svc", altSvc)
-		}
-		break // Only advertise one HTTP/3 endpoint for now
+	if altSvc, ok := s.cachedAltSvc.Load().(string); ok && altSvc != "" {
+		w.Header().Set("Alt-Svc", altSvc)
 	}
+}
+
+// updateAltSvcCache rebuilds the cached Alt-Svc header value from current HTTP/3 servers.
+// Must be called under s.mu lock whenever http3servers changes.
+func (s *HTTPServer) updateAltSvcCache() {
+	for port, h3srv := range s.http3servers {
+		// Try to get the header from the QUIC server
+		tempHeader := make(http.Header)
+		if err := h3srv.SetQuicHeaders(tempHeader); err == nil {
+			if altSvc := tempHeader.Get("Alt-Svc"); altSvc != "" {
+				s.cachedAltSvc.Store(altSvc)
+				return
+			}
+		}
+		// Fallback to manual header
+		altSvc := fmt.Sprintf("h3=\":%d\"; ma=%d", port, HTTP3AltSvcMaxAge)
+		s.cachedAltSvc.Store(altSvc)
+		return
+	}
+	// No HTTP/3 servers, clear cache
+	s.cachedAltSvc.Store("")
 }
 
 // startWithProxyProtocol starts a server with PROXY protocol listener wrapping


### PR DESCRIPTION
## Summary
- Cache Alt-Svc header value using atomic.Value to eliminate per-request RLock
- Update cache atomically when HTTP/3 server configuration changes
- Zero mutex overhead in the per-request ServeHTTP path

## Issues Addressed
- Resolves #133 - Alt-Svc header cached atomically

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Full build succeeds (`go build ./...`)
- [x] Cache updated in both ApplyConfig and Shutdown paths