### PR TITLE
[Performance] LB algorithm optimizations (#135, #137)

### DIFF
--- a/internal/agent/lb/ewma.go
+++ b/internal/agent/lb/ewma.go
@@ -28,8 +28,10 @@ import (
 // EWMA implements Exponentially Weighted Moving Average load balancing
 // Selects endpoints based on weighted average response times
 type EWMA struct {
-	mu        sync.RWMutex
-	endpoints []*pb.Endpoint
+	mu               sync.RWMutex
+	endpoints        []*pb.Endpoint
+	healthyEndpoints []*pb.Endpoint          // cached healthy list
+	endpointKeys     map[*pb.Endpoint]string // cached keys
 
 	// EWMA scores per endpoint (lower is better)
 	scores map[string]*int64 // Stored as nanoseconds * 1000 for precision
@@ -66,12 +68,15 @@ func NewEWMA(endpoints []*pb.Endpoint) *EWMA {
 		}
 	}
 
-	return &EWMA{
+	e := &EWMA{
 		endpoints:      endpoints,
 		scores:         scores,
 		activeRequests: activeRequests,
 		decay:          0.9, // 90% weight to historical data
 	}
+	e.buildKeyCache()
+	e.rebuildHealthy()
+	return e
 }
 
 // Select chooses an endpoint with the lowest EWMA score
@@ -94,7 +99,7 @@ func (e *EWMA) Select() *pb.Endpoint {
 	bestScore := int64(math.MaxInt64)
 
 	for _, ep := range healthy {
-		key := endpointKey(ep)
+		key := e.cachedKey(ep)
 		ewmaScore := atomic.LoadInt64(e.scores[key])
 		activeCount := atomic.LoadInt64(e.activeRequests[key])
 
@@ -144,6 +149,8 @@ func (e *EWMA) UpdateEndpoints(endpoints []*pb.Endpoint) {
 
 	e.scores = newScores
 	e.activeRequests = newActiveRequests
+	e.buildKeyCache()
+	e.rebuildHealthy()
 }
 
 // RecordLatency updates the EWMA score for an endpoint based on observed latency
@@ -152,8 +159,8 @@ func (e *EWMA) RecordLatency(endpoint *pb.Endpoint, latency time.Duration) {
 		return
 	}
 
-	key := endpointKey(endpoint)
 	e.mu.RLock()
+	key := e.cachedKey(endpoint)
 	scorePtr := e.scores[key]
 	e.mu.RUnlock()
 
@@ -180,8 +187,8 @@ func (e *EWMA) IncrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	key := endpointKey(endpoint)
 	e.mu.RLock()
+	key := e.cachedKey(endpoint)
 	counter := e.activeRequests[key]
 	e.mu.RUnlock()
 	if counter != nil {
@@ -194,8 +201,8 @@ func (e *EWMA) DecrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	key := endpointKey(endpoint)
 	e.mu.RLock()
+	key := e.cachedKey(endpoint)
 	counter := e.activeRequests[key]
 	e.mu.RUnlock()
 	if counter != nil {
@@ -208,8 +215,8 @@ func (e *EWMA) GetScore(endpoint *pb.Endpoint) float64 {
 	if endpoint == nil {
 		return 0
 	}
-	key := endpointKey(endpoint)
 	e.mu.RLock()
+	key := e.cachedKey(endpoint)
 	scorePtr := e.scores[key]
 	e.mu.RUnlock()
 	if scorePtr != nil {
@@ -219,12 +226,36 @@ func (e *EWMA) GetScore(endpoint *pb.Endpoint) float64 {
 	return 0
 }
 
-func (e *EWMA) getHealthyEndpoints() []*pb.Endpoint {
+// rebuildHealthy filters and caches the list of healthy endpoints.
+// Must be called with e.mu held (write lock).
+func (e *EWMA) rebuildHealthy() {
 	healthy := make([]*pb.Endpoint, 0, len(e.endpoints))
 	for _, ep := range e.endpoints {
 		if ep.Ready {
 			healthy = append(healthy, ep)
 		}
 	}
-	return healthy
+	e.healthyEndpoints = healthy
+}
+
+func (e *EWMA) getHealthyEndpoints() []*pb.Endpoint {
+	return e.healthyEndpoints
+}
+
+// buildKeyCache pre-computes endpoint keys for all endpoints.
+// Must be called with e.mu held (write lock).
+func (e *EWMA) buildKeyCache() {
+	e.endpointKeys = make(map[*pb.Endpoint]string, len(e.endpoints))
+	for _, ep := range e.endpoints {
+		e.endpointKeys[ep] = endpointKey(ep)
+	}
+}
+
+// cachedKey returns the cached key for an endpoint, falling back to computing it
+// if the pointer is not in the cache.
+func (e *EWMA) cachedKey(ep *pb.Endpoint) string {
+	if key, ok := e.endpointKeys[ep]; ok {
+		return key
+	}
+	return endpointKey(ep)
 }

--- a/internal/agent/lb/leastconn.go
+++ b/internal/agent/lb/leastconn.go
@@ -30,8 +30,10 @@ import (
 // endpoint with the fewest active connections. When multiple endpoints have
 // the same number of connections, one is chosen at random to avoid bias.
 type LeastConn struct {
-	mu        sync.RWMutex
-	endpoints []*pb.Endpoint
+	mu               sync.RWMutex
+	endpoints        []*pb.Endpoint
+	healthyEndpoints []*pb.Endpoint          // cached healthy list
+	endpointKeys     map[*pb.Endpoint]string // cached keys
 	// activeConns tracks active connection count per endpoint key ("address:port")
 	activeConns map[string]*int64
 }
@@ -47,10 +49,13 @@ func NewLeastConn(endpoints []*pb.Endpoint) *LeastConn {
 		}
 	}
 
-	return &LeastConn{
+	lc := &LeastConn{
 		endpoints:   endpoints,
 		activeConns: activeConns,
 	}
+	lc.buildKeyCache()
+	lc.rebuildHealthy()
+	return lc
 }
 
 // Select chooses the endpoint with the fewest active connections.
@@ -72,7 +77,7 @@ func (lc *LeastConn) Select() *pb.Endpoint {
 	// Find the minimum active connection count
 	minConns := int64(math.MaxInt64)
 	for _, ep := range healthy {
-		key := endpointKey(ep)
+		key := lc.cachedKey(ep)
 		if counter, ok := lc.activeConns[key]; ok {
 			count := atomic.LoadInt64(counter)
 			if count < minConns {
@@ -84,7 +89,7 @@ func (lc *LeastConn) Select() *pb.Endpoint {
 	// Collect all endpoints with the minimum count
 	candidates := make([]*pb.Endpoint, 0, len(healthy))
 	for _, ep := range healthy {
-		key := endpointKey(ep)
+		key := lc.cachedKey(ep)
 		if counter, ok := lc.activeConns[key]; ok {
 			if atomic.LoadInt64(counter) == minConns {
 				candidates = append(candidates, ep)
@@ -125,6 +130,8 @@ func (lc *LeastConn) UpdateEndpoints(endpoints []*pb.Endpoint) {
 		}
 	}
 	lc.activeConns = newActiveConns
+	lc.buildKeyCache()
+	lc.rebuildHealthy()
 }
 
 // IncrementActive increments the active connection count for an endpoint.
@@ -133,8 +140,8 @@ func (lc *LeastConn) IncrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	key := endpointKey(endpoint)
 	lc.mu.RLock()
+	key := lc.cachedKey(endpoint)
 	counter := lc.activeConns[key]
 	lc.mu.RUnlock()
 	if counter != nil {
@@ -148,8 +155,8 @@ func (lc *LeastConn) DecrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	key := endpointKey(endpoint)
 	lc.mu.RLock()
+	key := lc.cachedKey(endpoint)
 	counter := lc.activeConns[key]
 	lc.mu.RUnlock()
 	if counter != nil {
@@ -162,8 +169,8 @@ func (lc *LeastConn) GetActiveCount(endpoint *pb.Endpoint) int64 {
 	if endpoint == nil {
 		return 0
 	}
-	key := endpointKey(endpoint)
 	lc.mu.RLock()
+	key := lc.cachedKey(endpoint)
 	counter := lc.activeConns[key]
 	lc.mu.RUnlock()
 	if counter != nil {
@@ -172,12 +179,36 @@ func (lc *LeastConn) GetActiveCount(endpoint *pb.Endpoint) int64 {
 	return 0
 }
 
-func (lc *LeastConn) getHealthyEndpoints() []*pb.Endpoint {
+// rebuildHealthy filters and caches the list of healthy endpoints.
+// Must be called with lc.mu held (write lock).
+func (lc *LeastConn) rebuildHealthy() {
 	healthy := make([]*pb.Endpoint, 0, len(lc.endpoints))
 	for _, ep := range lc.endpoints {
 		if ep.Ready {
 			healthy = append(healthy, ep)
 		}
 	}
-	return healthy
+	lc.healthyEndpoints = healthy
+}
+
+func (lc *LeastConn) getHealthyEndpoints() []*pb.Endpoint {
+	return lc.healthyEndpoints
+}
+
+// buildKeyCache pre-computes endpoint keys for all endpoints.
+// Must be called with lc.mu held (write lock).
+func (lc *LeastConn) buildKeyCache() {
+	lc.endpointKeys = make(map[*pb.Endpoint]string, len(lc.endpoints))
+	for _, ep := range lc.endpoints {
+		lc.endpointKeys[ep] = endpointKey(ep)
+	}
+}
+
+// cachedKey returns the cached key for an endpoint, falling back to computing it
+// if the pointer is not in the cache.
+func (lc *LeastConn) cachedKey(ep *pb.Endpoint) string {
+	if key, ok := lc.endpointKeys[ep]; ok {
+		return key
+	}
+	return endpointKey(ep)
 }

--- a/internal/agent/lb/p2c.go
+++ b/internal/agent/lb/p2c.go
@@ -28,10 +28,11 @@ import (
 // P2C implements Power of Two Choices load balancing
 // Selects the best of two randomly chosen endpoints based on active requests
 type P2C struct {
-	mu        sync.RWMutex
-	endpoints []*pb.Endpoint
-	// Track active requests per endpoint
-	activeRequests map[string]*int64
+	mu               sync.RWMutex
+	endpoints        []*pb.Endpoint
+	healthyEndpoints []*pb.Endpoint // cached healthy list
+	activeRequests   map[string]*int64
+	endpointKeys     map[*pb.Endpoint]string // cached keys
 }
 
 // NewP2C creates a new P2C load balancer
@@ -45,10 +46,13 @@ func NewP2C(endpoints []*pb.Endpoint) *P2C {
 		}
 	}
 
-	return &P2C{
+	p := &P2C{
 		endpoints:      endpoints,
 		activeRequests: activeRequests,
 	}
+	p.buildKeyCache()
+	p.rebuildHealthy()
+	return p
 }
 
 // Select chooses an endpoint using Power of Two Choices
@@ -78,8 +82,8 @@ func (p *P2C) Select() *pb.Endpoint {
 	ep2 := healthy[idx2]
 
 	// Choose the one with fewer active requests
-	count1 := atomic.LoadInt64(p.activeRequests[endpointKey(ep1)])
-	count2 := atomic.LoadInt64(p.activeRequests[endpointKey(ep2)])
+	count1 := atomic.LoadInt64(p.activeRequests[p.cachedKey(ep1)])
+	count2 := atomic.LoadInt64(p.activeRequests[p.cachedKey(ep2)])
 
 	if count1 <= count2 {
 		return ep1
@@ -109,6 +113,8 @@ func (p *P2C) UpdateEndpoints(endpoints []*pb.Endpoint) {
 		}
 	}
 	p.activeRequests = newActiveRequests
+	p.buildKeyCache()
+	p.rebuildHealthy()
 }
 
 // IncrementActive increments the active request count for an endpoint
@@ -116,8 +122,8 @@ func (p *P2C) IncrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	key := endpointKey(endpoint)
 	p.mu.RLock()
+	key := p.cachedKey(endpoint)
 	counter := p.activeRequests[key]
 	p.mu.RUnlock()
 	if counter != nil {
@@ -130,8 +136,8 @@ func (p *P2C) DecrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	key := endpointKey(endpoint)
 	p.mu.RLock()
+	key := p.cachedKey(endpoint)
 	counter := p.activeRequests[key]
 	p.mu.RUnlock()
 	if counter != nil {
@@ -144,8 +150,8 @@ func (p *P2C) GetActiveCount(endpoint *pb.Endpoint) int64 {
 	if endpoint == nil {
 		return 0
 	}
-	key := endpointKey(endpoint)
 	p.mu.RLock()
+	key := p.cachedKey(endpoint)
 	counter := p.activeRequests[key]
 	p.mu.RUnlock()
 	if counter != nil {
@@ -154,14 +160,38 @@ func (p *P2C) GetActiveCount(endpoint *pb.Endpoint) int64 {
 	return 0
 }
 
-func (p *P2C) getHealthyEndpoints() []*pb.Endpoint {
+// rebuildHealthy filters and caches the list of healthy endpoints.
+// Must be called with p.mu held (write lock).
+func (p *P2C) rebuildHealthy() {
 	healthy := make([]*pb.Endpoint, 0, len(p.endpoints))
 	for _, ep := range p.endpoints {
 		if ep.Ready {
 			healthy = append(healthy, ep)
 		}
 	}
-	return healthy
+	p.healthyEndpoints = healthy
+}
+
+func (p *P2C) getHealthyEndpoints() []*pb.Endpoint {
+	return p.healthyEndpoints
+}
+
+// buildKeyCache pre-computes endpoint keys for all endpoints.
+// Must be called with p.mu held (write lock).
+func (p *P2C) buildKeyCache() {
+	p.endpointKeys = make(map[*pb.Endpoint]string, len(p.endpoints))
+	for _, ep := range p.endpoints {
+		p.endpointKeys[ep] = endpointKey(ep)
+	}
+}
+
+// cachedKey returns the cached key for an endpoint, falling back to computing it
+// if the pointer is not in the cache.
+func (p *P2C) cachedKey(ep *pb.Endpoint) string {
+	if key, ok := p.endpointKeys[ep]; ok {
+		return key
+	}
+	return endpointKey(ep)
 }
 
 func endpointKey(ep *pb.Endpoint) string {


### PR DESCRIPTION
## Summary
- Pre-compute healthy endpoint lists in P2C, EWMA, and LeastConn to avoid per-Select allocation (#135)
- Cache endpoint keys on LB structs to avoid redundant string computation per request (#137)

## Issues Addressed
- Resolves #135 - Healthy endpoint lists pre-computed and cached on LB structs
- Resolves #137 - Endpoint keys cached via map on P2C, EWMA, LeastConn

## Test plan
- [x] All 30+ LB tests pass (`go test ./internal/agent/lb/ -v`)
- [x] Full build succeeds (`go build ./...`)
- [x] Thread-safe: rebuilds under write lock, reads under read lock