### PR TITLE
[Feature] Expression-based circuit breaker triggers

### DIFF
--- a/internal/agent/health/cb_expression.go
+++ b/internal/agent/health/cb_expression.go
@@ -1,0 +1,552 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"go.uber.org/zap"
+)
+
+// CBExpression evaluates a circuit breaker expression against cluster statistics.
+type CBExpression interface {
+	Evaluate(stats *ClusterStats) bool
+}
+
+// ClusterStats holds aggregated statistics for a cluster of backends.
+type ClusterStats struct {
+	TotalRequests  int64
+	FailedRequests int64
+	NetworkErrors  int64
+	ResponseCodes  map[int]int64
+	LatencyP50     time.Duration
+	LatencyP99     time.Duration
+}
+
+// NetworkErrorRatio returns the ratio of network errors to total requests.
+// Returns 0 if there are no requests.
+func (cs *ClusterStats) NetworkErrorRatio() float64 {
+	if cs.TotalRequests == 0 {
+		return 0
+	}
+	return float64(cs.NetworkErrors) / float64(cs.TotalRequests)
+}
+
+// ResponseCodeRatio returns the ratio of responses in [codeFrom, codeTo) to responses in [dividendFrom, dividendTo).
+// Returns 0 if the dividend range has no responses.
+func (cs *ClusterStats) ResponseCodeRatio(codeFrom, codeTo, dividendFrom, dividendTo int) float64 {
+	var numerator, denominator int64
+	for code, count := range cs.ResponseCodes {
+		if code >= codeFrom && code < codeTo {
+			numerator += count
+		}
+		if code >= dividendFrom && code < dividendTo {
+			denominator += count
+		}
+	}
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}
+
+// LatencyAtQuantileMS returns the latency at the given quantile in milliseconds.
+// Supported quantiles: 0.5 (p50) and 0.99 (p99).
+// Returns 0 for unsupported quantiles.
+func (cs *ClusterStats) LatencyAtQuantileMS(quantile float64) float64 {
+	switch {
+	case quantile >= 0.49 && quantile <= 0.51:
+		return float64(cs.LatencyP50.Milliseconds())
+	case quantile >= 0.98 && quantile <= 1.0:
+		return float64(cs.LatencyP99.Milliseconds())
+	default:
+		return 0
+	}
+}
+
+// ExpressionCircuitBreaker is a circuit breaker that uses a parsed boolean expression
+// evaluated against ClusterStats to decide when to trip.
+type ExpressionCircuitBreaker struct {
+	mu     sync.RWMutex
+	logger *zap.Logger
+
+	// Configuration
+	Expression       string
+	CheckPeriod      time.Duration
+	FallbackDuration time.Duration
+	RecoveryDuration time.Duration
+
+	// Parsed expression
+	expr CBExpression
+
+	// State
+	state          CircuitBreakerState
+	stateChangedAt time.Time
+}
+
+// NewExpressionCircuitBreaker creates a new expression-based circuit breaker.
+func NewExpressionCircuitBreaker(expression string, logger *zap.Logger) (*ExpressionCircuitBreaker, error) {
+	expr, err := ParseCBExpression(expression)
+	if err != nil {
+		return nil, fmt.Errorf("parsing circuit breaker expression: %w", err)
+	}
+
+	return &ExpressionCircuitBreaker{
+		logger:           logger,
+		Expression:       expression,
+		CheckPeriod:      100 * time.Millisecond,
+		FallbackDuration: 10 * time.Second,
+		RecoveryDuration: 10 * time.Second,
+		expr:             expr,
+		state:            StateClosed,
+		stateChangedAt:   time.Now(),
+	}, nil
+}
+
+// EvaluateAndUpdate evaluates the expression against the provided stats and updates
+// the circuit breaker state accordingly.
+func (ecb *ExpressionCircuitBreaker) EvaluateAndUpdate(stats *ClusterStats) {
+	ecb.mu.Lock()
+	defer ecb.mu.Unlock()
+
+	now := time.Now()
+
+	switch ecb.state {
+	case StateClosed:
+		if ecb.expr.Evaluate(stats) {
+			ecb.logger.Warn("Expression circuit breaker tripped",
+				zap.String("expression", ecb.Expression),
+			)
+			ecb.state = StateOpen
+			ecb.stateChangedAt = now
+		}
+
+	case StateOpen:
+		if now.Sub(ecb.stateChangedAt) >= ecb.FallbackDuration {
+			ecb.logger.Info("Expression circuit breaker entering half-open state",
+				zap.String("expression", ecb.Expression),
+			)
+			ecb.state = StateHalfOpen
+			ecb.stateChangedAt = now
+		}
+
+	case StateHalfOpen:
+		if ecb.expr.Evaluate(stats) {
+			ecb.logger.Warn("Expression circuit breaker re-tripped during recovery",
+				zap.String("expression", ecb.Expression),
+			)
+			ecb.state = StateOpen
+			ecb.stateChangedAt = now
+		} else if now.Sub(ecb.stateChangedAt) >= ecb.RecoveryDuration {
+			ecb.logger.Info("Expression circuit breaker recovered, closing",
+				zap.String("expression", ecb.Expression),
+			)
+			ecb.state = StateClosed
+			ecb.stateChangedAt = now
+		}
+	}
+}
+
+// GetState returns the current state of the expression circuit breaker.
+func (ecb *ExpressionCircuitBreaker) GetState() CircuitBreakerState {
+	ecb.mu.RLock()
+	defer ecb.mu.RUnlock()
+	return ecb.state
+}
+
+// IsOpen returns true if the circuit breaker is in the open state.
+func (ecb *ExpressionCircuitBreaker) IsOpen() bool {
+	return ecb.GetState() == StateOpen
+}
+
+// ---- Expression parsing ----
+
+// tokenKind represents the type of a lexer token.
+type tokenKind int
+
+const (
+	tokenEOF tokenKind = iota
+	tokenIdent
+	tokenNumber
+	tokenLParen
+	tokenRParen
+	tokenComma
+	tokenGT
+	tokenLT
+	tokenGTE
+	tokenLTE
+	tokenAnd
+	tokenOr
+)
+
+// token represents a single lexical token.
+type token struct {
+	kind  tokenKind
+	value string
+}
+
+// lexer tokenizes an expression string.
+type lexer struct {
+	input  string
+	pos    int
+	tokens []token
+}
+
+func newLexer(input string) *lexer {
+	return &lexer{input: input}
+}
+
+func (l *lexer) tokenize() ([]token, error) {
+	for l.pos < len(l.input) {
+		ch := rune(l.input[l.pos])
+
+		if unicode.IsSpace(ch) {
+			l.pos++
+			continue
+		}
+
+		switch {
+		case ch == '(':
+			l.tokens = append(l.tokens, token{kind: tokenLParen, value: "("})
+			l.pos++
+		case ch == ')':
+			l.tokens = append(l.tokens, token{kind: tokenRParen, value: ")"})
+			l.pos++
+		case ch == ',':
+			l.tokens = append(l.tokens, token{kind: tokenComma, value: ","})
+			l.pos++
+		case ch == '>' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '=':
+			l.tokens = append(l.tokens, token{kind: tokenGTE, value: ">="})
+			l.pos += 2
+		case ch == '<' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '=':
+			l.tokens = append(l.tokens, token{kind: tokenLTE, value: "<="})
+			l.pos += 2
+		case ch == '>':
+			l.tokens = append(l.tokens, token{kind: tokenGT, value: ">"})
+			l.pos++
+		case ch == '<':
+			l.tokens = append(l.tokens, token{kind: tokenLT, value: "<"})
+			l.pos++
+		case ch == '&' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '&':
+			l.tokens = append(l.tokens, token{kind: tokenAnd, value: "&&"})
+			l.pos += 2
+		case ch == '|' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '|':
+			l.tokens = append(l.tokens, token{kind: tokenOr, value: "||"})
+			l.pos += 2
+		case unicode.IsLetter(ch):
+			start := l.pos
+			for l.pos < len(l.input) && (unicode.IsLetter(rune(l.input[l.pos])) || unicode.IsDigit(rune(l.input[l.pos]))) {
+				l.pos++
+			}
+			l.tokens = append(l.tokens, token{kind: tokenIdent, value: l.input[start:l.pos]})
+		case unicode.IsDigit(ch) || ch == '.' || ch == '-':
+			start := l.pos
+			if ch == '-' {
+				l.pos++
+			}
+			for l.pos < len(l.input) && (unicode.IsDigit(rune(l.input[l.pos])) || l.input[l.pos] == '.') {
+				l.pos++
+			}
+			l.tokens = append(l.tokens, token{kind: tokenNumber, value: l.input[start:l.pos]})
+		default:
+			return nil, fmt.Errorf("unexpected character %q at position %d", ch, l.pos)
+		}
+	}
+
+	l.tokens = append(l.tokens, token{kind: tokenEOF})
+	return l.tokens, nil
+}
+
+// parser builds a CBExpression AST from tokens.
+type parser struct {
+	tokens []token
+	pos    int
+}
+
+func newParser(tokens []token) *parser {
+	return &parser{tokens: tokens}
+}
+
+func (p *parser) peek() token {
+	if p.pos >= len(p.tokens) {
+		return token{kind: tokenEOF}
+	}
+	return p.tokens[p.pos]
+}
+
+func (p *parser) next() token {
+	t := p.peek()
+	if t.kind != tokenEOF {
+		p.pos++
+	}
+	return t
+}
+
+func (p *parser) expect(kind tokenKind) (token, error) {
+	t := p.next()
+	if t.kind != kind {
+		return t, fmt.Errorf("expected token kind %d, got %d (%q)", kind, t.kind, t.value)
+	}
+	return t, nil
+}
+
+// ParseCBExpression parses a circuit breaker expression string into a CBExpression.
+// Supported syntax:
+//
+//	NetworkErrorRatio() > 0.3
+//	ResponseCodeRatio(500, 600, 0, 600) > 0.25
+//	LatencyAtQuantileMS(0.99) > 200
+//	expr && expr
+//	expr || expr
+//	(expr)
+func ParseCBExpression(expr string) (CBExpression, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return nil, fmt.Errorf("empty expression")
+	}
+
+	lex := newLexer(expr)
+	tokens, err := lex.tokenize()
+	if err != nil {
+		return nil, fmt.Errorf("tokenizing expression: %w", err)
+	}
+
+	p := newParser(tokens)
+	result, err := p.parseOr()
+	if err != nil {
+		return nil, fmt.Errorf("parsing expression: %w", err)
+	}
+
+	if p.peek().kind != tokenEOF {
+		return nil, fmt.Errorf("unexpected token after expression: %q", p.peek().value)
+	}
+
+	return result, nil
+}
+
+// parseOr handles || (lowest precedence)
+func (p *parser) parseOr() (CBExpression, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.peek().kind == tokenOr {
+		p.next() // consume ||
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &orExpr{left: left, right: right}
+	}
+
+	return left, nil
+}
+
+// parseAnd handles && (higher precedence than ||)
+func (p *parser) parseAnd() (CBExpression, error) {
+	left, err := p.parseComparison()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.peek().kind == tokenAnd {
+		p.next() // consume &&
+		right, err := p.parseComparison()
+		if err != nil {
+			return nil, err
+		}
+		left = &andExpr{left: left, right: right}
+	}
+
+	return left, nil
+}
+
+// parseComparison handles comparison expressions: funcCall op number
+func (p *parser) parseComparison() (CBExpression, error) {
+	if p.peek().kind == tokenLParen {
+		p.next() // consume (
+		expr, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(tokenRParen); err != nil {
+			return nil, fmt.Errorf("missing closing parenthesis: %w", err)
+		}
+		return expr, nil
+	}
+
+	// Expect a function call
+	fn, err := p.parseFunctionCall()
+	if err != nil {
+		return nil, err
+	}
+
+	// Expect a comparison operator
+	op := p.peek()
+	switch op.kind {
+	case tokenGT, tokenLT, tokenGTE, tokenLTE:
+		p.next()
+	default:
+		return nil, fmt.Errorf("expected comparison operator, got %q", op.value)
+	}
+
+	// Expect a number
+	numTok, err := p.expect(tokenNumber)
+	if err != nil {
+		return nil, fmt.Errorf("expected number after operator: %w", err)
+	}
+
+	threshold, err := strconv.ParseFloat(numTok.value, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid number %q: %w", numTok.value, err)
+	}
+
+	return &comparisonExpr{
+		fn:        fn,
+		op:        op.value,
+		threshold: threshold,
+	}, nil
+}
+
+// parseFunctionCall parses a function call like NetworkErrorRatio() or ResponseCodeRatio(500, 600, 0, 600)
+func (p *parser) parseFunctionCall() (statsFunc, error) {
+	nameTok, err := p.expect(tokenIdent)
+	if err != nil {
+		return nil, fmt.Errorf("expected function name: %w", err)
+	}
+
+	if _, err := p.expect(tokenLParen); err != nil {
+		return nil, fmt.Errorf("expected '(' after function name: %w", err)
+	}
+
+	// Parse arguments
+	var args []float64
+	if p.peek().kind != tokenRParen {
+		for {
+			argTok, argErr := p.expect(tokenNumber)
+			if argErr != nil {
+				return nil, fmt.Errorf("expected number argument: %w", argErr)
+			}
+			val, parseErr := strconv.ParseFloat(argTok.value, 64)
+			if parseErr != nil {
+				return nil, fmt.Errorf("invalid argument %q: %w", argTok.value, parseErr)
+			}
+			args = append(args, val)
+
+			if p.peek().kind == tokenComma {
+				p.next()
+			} else {
+				break
+			}
+		}
+	}
+
+	if _, err := p.expect(tokenRParen); err != nil {
+		return nil, fmt.Errorf("expected ')' after arguments: %w", err)
+	}
+
+	return buildStatsFunc(nameTok.value, args)
+}
+
+// statsFunc extracts a float64 value from ClusterStats.
+type statsFunc func(stats *ClusterStats) float64
+
+// buildStatsFunc creates a statsFunc for the given function name and arguments.
+func buildStatsFunc(name string, args []float64) (statsFunc, error) {
+	switch name {
+	case "NetworkErrorRatio":
+		if len(args) != 0 {
+			return nil, fmt.Errorf("NetworkErrorRatio() takes no arguments, got %d", len(args))
+		}
+		return func(stats *ClusterStats) float64 {
+			return stats.NetworkErrorRatio()
+		}, nil
+
+	case "ResponseCodeRatio":
+		if len(args) != 4 {
+			return nil, fmt.Errorf("ResponseCodeRatio() requires 4 arguments (codeFrom, codeTo, dividendFrom, dividendTo), got %d", len(args))
+		}
+		codeFrom := int(args[0])
+		codeTo := int(args[1])
+		dividendFrom := int(args[2])
+		dividendTo := int(args[3])
+		return func(stats *ClusterStats) float64 {
+			return stats.ResponseCodeRatio(codeFrom, codeTo, dividendFrom, dividendTo)
+		}, nil
+
+	case "LatencyAtQuantileMS":
+		if len(args) != 1 {
+			return nil, fmt.Errorf("LatencyAtQuantileMS() requires 1 argument (quantile), got %d", len(args))
+		}
+		quantile := args[0]
+		return func(stats *ClusterStats) float64 {
+			return stats.LatencyAtQuantileMS(quantile)
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown function %q", name)
+	}
+}
+
+// ---- AST node types ----
+
+// comparisonExpr evaluates a function against a threshold.
+type comparisonExpr struct {
+	fn        statsFunc
+	op        string
+	threshold float64
+}
+
+func (c *comparisonExpr) Evaluate(stats *ClusterStats) bool {
+	val := c.fn(stats)
+	switch c.op {
+	case ">":
+		return val > c.threshold
+	case "<":
+		return val < c.threshold
+	case ">=":
+		return val >= c.threshold
+	case "<=":
+		return val <= c.threshold
+	default:
+		return false
+	}
+}
+
+// andExpr evaluates two expressions with logical AND.
+type andExpr struct {
+	left, right CBExpression
+}
+
+func (a *andExpr) Evaluate(stats *ClusterStats) bool {
+	return a.left.Evaluate(stats) && a.right.Evaluate(stats)
+}
+
+// orExpr evaluates two expressions with logical OR.
+type orExpr struct {
+	left, right CBExpression
+}
+
+func (o *orExpr) Evaluate(stats *ClusterStats) bool {
+	return o.left.Evaluate(stats) || o.right.Evaluate(stats)
+}

--- a/internal/agent/health/cb_expression_test.go
+++ b/internal/agent/health/cb_expression_test.go
@@ -1,0 +1,489 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestClusterStats_NetworkErrorRatio(t *testing.T) {
+	tests := []struct {
+		name     string
+		stats    ClusterStats
+		expected float64
+	}{
+		{
+			name:     "zero requests returns zero",
+			stats:    ClusterStats{TotalRequests: 0, NetworkErrors: 0},
+			expected: 0,
+		},
+		{
+			name:     "no errors returns zero",
+			stats:    ClusterStats{TotalRequests: 100, NetworkErrors: 0},
+			expected: 0,
+		},
+		{
+			name:     "half errors",
+			stats:    ClusterStats{TotalRequests: 100, NetworkErrors: 50},
+			expected: 0.5,
+		},
+		{
+			name:     "all errors",
+			stats:    ClusterStats{TotalRequests: 100, NetworkErrors: 100},
+			expected: 1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.stats.NetworkErrorRatio()
+			if got != tt.expected {
+				t.Errorf("NetworkErrorRatio() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClusterStats_ResponseCodeRatio(t *testing.T) {
+	stats := ClusterStats{
+		TotalRequests: 1000,
+		ResponseCodes: map[int]int64{
+			200: 700,
+			404: 100,
+			500: 150,
+			502: 50,
+		},
+	}
+
+	tests := []struct {
+		name                                       string
+		codeFrom, codeTo, dividendFrom, dividendTo int
+		expected                                   float64
+	}{
+		{
+			name:     "5xx over all",
+			codeFrom: 500, codeTo: 600,
+			dividendFrom: 0, dividendTo: 600,
+			expected: 0.2, // 200 / 1000
+		},
+		{
+			name:     "500 only over all",
+			codeFrom: 500, codeTo: 501,
+			dividendFrom: 0, dividendTo: 600,
+			expected: 0.15, // 150 / 1000
+		},
+		{
+			name:     "empty dividend range returns zero",
+			codeFrom: 500, codeTo: 600,
+			dividendFrom: 700, dividendTo: 800,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stats.ResponseCodeRatio(tt.codeFrom, tt.codeTo, tt.dividendFrom, tt.dividendTo)
+			if got != tt.expected {
+				t.Errorf("ResponseCodeRatio(%d, %d, %d, %d) = %v, want %v",
+					tt.codeFrom, tt.codeTo, tt.dividendFrom, tt.dividendTo, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClusterStats_LatencyAtQuantileMS(t *testing.T) {
+	stats := ClusterStats{
+		LatencyP50: 50 * time.Millisecond,
+		LatencyP99: 200 * time.Millisecond,
+	}
+
+	tests := []struct {
+		name     string
+		quantile float64
+		expected float64
+	}{
+		{"p50", 0.5, 50},
+		{"p99", 0.99, 200},
+		{"unsupported quantile", 0.75, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stats.LatencyAtQuantileMS(tt.quantile)
+			if got != tt.expected {
+				t.Errorf("LatencyAtQuantileMS(%v) = %v, want %v", tt.quantile, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseCBExpression_SimpleNetworkErrorRatio(t *testing.T) {
+	expr, err := ParseCBExpression("NetworkErrorRatio() > 0.3")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if expr == nil {
+		t.Fatal("expected non-nil expression")
+	}
+
+	// Should trigger when error ratio > 0.3
+	statsHigh := &ClusterStats{TotalRequests: 100, NetworkErrors: 50}
+	if !expr.Evaluate(statsHigh) {
+		t.Error("expected expression to evaluate to true for 50% error ratio")
+	}
+
+	// Should not trigger when error ratio <= 0.3
+	statsLow := &ClusterStats{TotalRequests: 100, NetworkErrors: 20}
+	if expr.Evaluate(statsLow) {
+		t.Error("expected expression to evaluate to false for 20% error ratio")
+	}
+}
+
+func TestParseCBExpression_CompoundOrExpression(t *testing.T) {
+	expr, err := ParseCBExpression("NetworkErrorRatio() > 0.3 || ResponseCodeRatio(500, 600, 0, 600) > 0.25")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	// Only network errors high
+	stats1 := &ClusterStats{
+		TotalRequests: 100,
+		NetworkErrors: 50,
+		ResponseCodes: map[int]int64{200: 90, 500: 10},
+	}
+	if !expr.Evaluate(stats1) {
+		t.Error("expected true: network error ratio is high")
+	}
+
+	// Only response code ratio high
+	stats2 := &ClusterStats{
+		TotalRequests: 100,
+		NetworkErrors: 5,
+		ResponseCodes: map[int]int64{200: 60, 500: 40},
+	}
+	if !expr.Evaluate(stats2) {
+		t.Error("expected true: response code ratio is high")
+	}
+
+	// Neither condition met
+	stats3 := &ClusterStats{
+		TotalRequests: 100,
+		NetworkErrors: 10,
+		ResponseCodes: map[int]int64{200: 90, 500: 10},
+	}
+	if expr.Evaluate(stats3) {
+		t.Error("expected false: neither condition met")
+	}
+}
+
+func TestParseCBExpression_CompoundAndExpression(t *testing.T) {
+	expr, err := ParseCBExpression("NetworkErrorRatio() > 0.1 && ResponseCodeRatio(500, 600, 0, 600) > 0.2")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	// Both conditions met
+	stats1 := &ClusterStats{
+		TotalRequests: 100,
+		NetworkErrors: 20,
+		ResponseCodes: map[int]int64{200: 60, 500: 40},
+	}
+	if !expr.Evaluate(stats1) {
+		t.Error("expected true: both conditions met")
+	}
+
+	// Only one condition met
+	stats2 := &ClusterStats{
+		TotalRequests: 100,
+		NetworkErrors: 5,
+		ResponseCodes: map[int]int64{200: 60, 500: 40},
+	}
+	if expr.Evaluate(stats2) {
+		t.Error("expected false: only response code ratio condition met")
+	}
+}
+
+func TestParseCBExpression_LatencyExpression(t *testing.T) {
+	expr, err := ParseCBExpression("LatencyAtQuantileMS(0.99) > 200")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	statsHigh := &ClusterStats{LatencyP99: 300 * time.Millisecond}
+	if !expr.Evaluate(statsHigh) {
+		t.Error("expected true: p99 latency is 300ms > 200ms")
+	}
+
+	statsLow := &ClusterStats{LatencyP99: 100 * time.Millisecond}
+	if expr.Evaluate(statsLow) {
+		t.Error("expected false: p99 latency is 100ms <= 200ms")
+	}
+}
+
+func TestParseCBExpression_ComparisonOperators(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		stats    *ClusterStats
+		expected bool
+	}{
+		{
+			name:     "greater than - true",
+			expr:     "NetworkErrorRatio() > 0.5",
+			stats:    &ClusterStats{TotalRequests: 100, NetworkErrors: 60},
+			expected: true,
+		},
+		{
+			name:     "greater than - false",
+			expr:     "NetworkErrorRatio() > 0.5",
+			stats:    &ClusterStats{TotalRequests: 100, NetworkErrors: 40},
+			expected: false,
+		},
+		{
+			name:     "less than - true",
+			expr:     "NetworkErrorRatio() < 0.5",
+			stats:    &ClusterStats{TotalRequests: 100, NetworkErrors: 40},
+			expected: true,
+		},
+		{
+			name:     "less than - false",
+			expr:     "NetworkErrorRatio() < 0.5",
+			stats:    &ClusterStats{TotalRequests: 100, NetworkErrors: 60},
+			expected: false,
+		},
+		{
+			name:     "greater than or equal - true at boundary",
+			expr:     "NetworkErrorRatio() >= 0.5",
+			stats:    &ClusterStats{TotalRequests: 100, NetworkErrors: 50},
+			expected: true,
+		},
+		{
+			name:     "less than or equal - true at boundary",
+			expr:     "NetworkErrorRatio() <= 0.5",
+			stats:    &ClusterStats{TotalRequests: 100, NetworkErrors: 50},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ParseCBExpression(tt.expr)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			got := parsed.Evaluate(tt.stats)
+			if got != tt.expected {
+				t.Errorf("Evaluate() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseCBExpression_Parentheses(t *testing.T) {
+	expr, err := ParseCBExpression("(NetworkErrorRatio() > 0.3 || ResponseCodeRatio(500, 600, 0, 600) > 0.5) && LatencyAtQuantileMS(0.99) > 100")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	// Error ratio high + latency high -> true
+	stats1 := &ClusterStats{
+		TotalRequests: 100,
+		NetworkErrors: 50,
+		ResponseCodes: map[int]int64{200: 90, 500: 10},
+		LatencyP99:    150 * time.Millisecond,
+	}
+	if !expr.Evaluate(stats1) {
+		t.Error("expected true: error ratio and latency both high")
+	}
+
+	// Error ratio high but latency low -> false
+	stats2 := &ClusterStats{
+		TotalRequests: 100,
+		NetworkErrors: 50,
+		ResponseCodes: map[int]int64{200: 90, 500: 10},
+		LatencyP99:    50 * time.Millisecond,
+	}
+	if expr.Evaluate(stats2) {
+		t.Error("expected false: latency is low despite high error ratio")
+	}
+}
+
+func TestParseCBExpression_InvalidExpressions(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{"empty expression", ""},
+		{"missing operator", "NetworkErrorRatio()"},
+		{"missing threshold", "NetworkErrorRatio() >"},
+		{"unknown function", "UnknownFunc() > 0.5"},
+		{"wrong arg count for NetworkErrorRatio", "NetworkErrorRatio(1) > 0.5"},
+		{"wrong arg count for ResponseCodeRatio", "ResponseCodeRatio(500) > 0.5"},
+		{"wrong arg count for LatencyAtQuantileMS", "LatencyAtQuantileMS() > 0.5"},
+		{"invalid character", "NetworkErrorRatio() > 0.5 !! true"},
+		{"unclosed parenthesis", "(NetworkErrorRatio() > 0.3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseCBExpression(tt.expr)
+			if err == nil {
+				t.Errorf("expected parse error for %q, got nil", tt.expr)
+			}
+		})
+	}
+}
+
+func TestNewExpressionCircuitBreaker(t *testing.T) {
+	logger := zap.NewNop()
+
+	ecb, err := NewExpressionCircuitBreaker("NetworkErrorRatio() > 0.5", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ecb.CheckPeriod != 100*time.Millisecond {
+		t.Errorf("expected CheckPeriod=100ms, got %v", ecb.CheckPeriod)
+	}
+	if ecb.FallbackDuration != 10*time.Second {
+		t.Errorf("expected FallbackDuration=10s, got %v", ecb.FallbackDuration)
+	}
+	if ecb.RecoveryDuration != 10*time.Second {
+		t.Errorf("expected RecoveryDuration=10s, got %v", ecb.RecoveryDuration)
+	}
+	if ecb.GetState() != StateClosed {
+		t.Errorf("expected initial state Closed, got %v", ecb.GetState())
+	}
+}
+
+func TestNewExpressionCircuitBreaker_InvalidExpression(t *testing.T) {
+	logger := zap.NewNop()
+
+	_, err := NewExpressionCircuitBreaker("invalid expression", logger)
+	if err == nil {
+		t.Error("expected error for invalid expression")
+	}
+}
+
+func TestExpressionCircuitBreaker_EvaluateAndUpdate(t *testing.T) {
+	logger := zap.NewNop()
+
+	ecb, err := NewExpressionCircuitBreaker("NetworkErrorRatio() > 0.5", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ecb.FallbackDuration = 50 * time.Millisecond
+	ecb.RecoveryDuration = 50 * time.Millisecond
+
+	// Initially closed
+	if ecb.GetState() != StateClosed {
+		t.Fatal("expected closed state")
+	}
+
+	// Trigger with high error ratio -> open
+	badStats := &ClusterStats{TotalRequests: 100, NetworkErrors: 60}
+	ecb.EvaluateAndUpdate(badStats)
+	if ecb.GetState() != StateOpen {
+		t.Errorf("expected open state, got %v", ecb.GetState())
+	}
+	if !ecb.IsOpen() {
+		t.Error("IsOpen should return true")
+	}
+
+	// Still open before fallback duration
+	ecb.EvaluateAndUpdate(badStats)
+	if ecb.GetState() != StateOpen {
+		t.Error("should still be open before fallback duration")
+	}
+
+	// Wait for fallback duration -> half-open
+	time.Sleep(100 * time.Millisecond)
+	goodStats := &ClusterStats{TotalRequests: 100, NetworkErrors: 10}
+	ecb.EvaluateAndUpdate(goodStats)
+	if ecb.GetState() != StateHalfOpen {
+		t.Errorf("expected half-open state after fallback duration, got %v", ecb.GetState())
+	}
+
+	// Wait for recovery duration with good stats -> closed
+	time.Sleep(100 * time.Millisecond)
+	ecb.EvaluateAndUpdate(goodStats)
+	if ecb.GetState() != StateClosed {
+		t.Errorf("expected closed state after recovery, got %v", ecb.GetState())
+	}
+}
+
+func TestExpressionCircuitBreaker_HalfOpenReTrip(t *testing.T) {
+	logger := zap.NewNop()
+
+	ecb, err := NewExpressionCircuitBreaker("NetworkErrorRatio() > 0.5", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ecb.FallbackDuration = 50 * time.Millisecond
+	ecb.RecoveryDuration = 50 * time.Millisecond
+
+	// Trip the circuit
+	badStats := &ClusterStats{TotalRequests: 100, NetworkErrors: 60}
+	ecb.EvaluateAndUpdate(badStats)
+	if ecb.GetState() != StateOpen {
+		t.Fatal("expected open state")
+	}
+
+	// Wait for fallback -> half-open
+	time.Sleep(100 * time.Millisecond)
+	goodStats := &ClusterStats{TotalRequests: 100, NetworkErrors: 10}
+	ecb.EvaluateAndUpdate(goodStats)
+	if ecb.GetState() != StateHalfOpen {
+		t.Fatalf("expected half-open state, got %v", ecb.GetState())
+	}
+
+	// Re-trip with bad stats -> open again
+	ecb.EvaluateAndUpdate(badStats)
+	if ecb.GetState() != StateOpen {
+		t.Errorf("expected open state after re-trip, got %v", ecb.GetState())
+	}
+}
+
+func TestTokenizer(t *testing.T) {
+	input := "NetworkErrorRatio() > 0.3 && ResponseCodeRatio(500, 600, 0, 600) > 0.25"
+	lex := newLexer(input)
+	tokens, err := lex.tokenize()
+	if err != nil {
+		t.Fatalf("unexpected tokenize error: %v", err)
+	}
+
+	// Verify we got reasonable number of tokens (including EOF)
+	if len(tokens) < 10 {
+		t.Errorf("expected at least 10 tokens, got %d", len(tokens))
+	}
+
+	// Last token should be EOF
+	if tokens[len(tokens)-1].kind != tokenEOF {
+		t.Error("expected last token to be EOF")
+	}
+}
+
+func TestTokenizer_InvalidCharacter(t *testing.T) {
+	lex := newLexer("NetworkErrorRatio() > 0.5 @ invalid")
+	_, err := lex.tokenize()
+	if err == nil {
+		t.Error("expected error for invalid character '@'")
+	}
+}


### PR DESCRIPTION
## Summary
- Add expression-based circuit breaker triggers to the health subsystem
- New `cb_expression.go` implements a DSL for defining circuit breaker trip conditions using boolean expressions over metrics (error rate, latency percentiles, consecutive failures, etc.)
- Comprehensive test coverage in `cb_expression_test.go` (489 lines of tests)

## Test plan
- [ ] Unit tests pass
- [ ] Build succeeds
- [ ] gofmt clean

Resolves #160