### PR TITLE
[Feature] Distributed circuit breaker resource limits

### DIFF
--- a/internal/agent/health/resource_limits.go
+++ b/internal/agent/health/resource_limits.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"sync/atomic"
+
+	"github.com/piwi3910/novaedge/internal/agent/metrics"
+)
+
+const (
+	// DefaultMaxConnections is the default maximum number of active connections.
+	DefaultMaxConnections int64 = 1024
+
+	// DefaultMaxPendingRequests is the default maximum number of pending requests.
+	DefaultMaxPendingRequests int64 = 1024
+
+	// DefaultMaxRequests is the default maximum number of active requests.
+	DefaultMaxRequests int64 = 1024
+
+	// DefaultMaxRetries is the default maximum number of active retries.
+	DefaultMaxRetries int64 = 3
+)
+
+// ResourceLimitsConfig configures the resource limits for a circuit breaker.
+type ResourceLimitsConfig struct {
+	// MaxConnections is the maximum number of concurrent connections allowed.
+	MaxConnections int64
+	// MaxPendingRequests is the maximum number of pending requests allowed.
+	MaxPendingRequests int64
+	// MaxRequests is the maximum number of concurrent requests allowed.
+	MaxRequests int64
+	// MaxRetries is the maximum number of concurrent retries allowed.
+	MaxRetries int64
+}
+
+// DefaultResourceLimitsConfig returns a ResourceLimitsConfig with default values.
+func DefaultResourceLimitsConfig() ResourceLimitsConfig {
+	return ResourceLimitsConfig{
+		MaxConnections:     DefaultMaxConnections,
+		MaxPendingRequests: DefaultMaxPendingRequests,
+		MaxRequests:        DefaultMaxRequests,
+		MaxRetries:         DefaultMaxRetries,
+	}
+}
+
+// ResourceLimits tracks and enforces resource limits for a cluster using atomic
+// counters. Each TryAcquire method atomically increments the counter and checks
+// against the configured limit; if the limit is exceeded, it decrements back and
+// records an overflow event.
+type ResourceLimits struct {
+	config ResourceLimitsConfig
+
+	activeConnections atomic.Int64
+	pendingRequests   atomic.Int64
+	activeRequests    atomic.Int64
+	activeRetries     atomic.Int64
+
+	overflowConnections atomic.Int64
+	overflowPending     atomic.Int64
+	overflowRequests    atomic.Int64
+	overflowRetries     atomic.Int64
+
+	cluster string
+}
+
+// NewResourceLimits creates a new ResourceLimits with the given config and cluster name.
+func NewResourceLimits(config ResourceLimitsConfig, cluster string) *ResourceLimits {
+	return &ResourceLimits{
+		config:  config,
+		cluster: cluster,
+	}
+}
+
+// TryAcquireConnection attempts to acquire a connection slot. It returns true
+// if a slot was available, or false if the MaxConnections limit has been reached.
+func (rl *ResourceLimits) TryAcquireConnection() bool {
+	current := rl.activeConnections.Add(1)
+	if current > rl.config.MaxConnections {
+		rl.activeConnections.Add(-1)
+		rl.overflowConnections.Add(1)
+		metrics.RecordCircuitBreakerOverflow(rl.cluster, "connections")
+		return false
+	}
+	return true
+}
+
+// ReleaseConnection releases a previously acquired connection slot.
+func (rl *ResourceLimits) ReleaseConnection() {
+	rl.activeConnections.Add(-1)
+}
+
+// TryAcquirePendingRequest attempts to acquire a pending request slot. It returns
+// true if a slot was available, or false if the MaxPendingRequests limit has been reached.
+func (rl *ResourceLimits) TryAcquirePendingRequest() bool {
+	current := rl.pendingRequests.Add(1)
+	if current > rl.config.MaxPendingRequests {
+		rl.pendingRequests.Add(-1)
+		rl.overflowPending.Add(1)
+		metrics.RecordCircuitBreakerOverflow(rl.cluster, "pending")
+		return false
+	}
+	return true
+}
+
+// ReleasePendingRequest releases a previously acquired pending request slot.
+func (rl *ResourceLimits) ReleasePendingRequest() {
+	rl.pendingRequests.Add(-1)
+}
+
+// TryAcquireRequest attempts to acquire a request slot. It returns true if a
+// slot was available, or false if the MaxRequests limit has been reached.
+func (rl *ResourceLimits) TryAcquireRequest() bool {
+	current := rl.activeRequests.Add(1)
+	if current > rl.config.MaxRequests {
+		rl.activeRequests.Add(-1)
+		rl.overflowRequests.Add(1)
+		metrics.RecordCircuitBreakerOverflow(rl.cluster, "requests")
+		return false
+	}
+	return true
+}
+
+// ReleaseRequest releases a previously acquired request slot.
+func (rl *ResourceLimits) ReleaseRequest() {
+	rl.activeRequests.Add(-1)
+}
+
+// TryAcquireRetry attempts to acquire a retry slot. It returns true if a slot
+// was available, or false if the MaxRetries limit has been reached.
+func (rl *ResourceLimits) TryAcquireRetry() bool {
+	current := rl.activeRetries.Add(1)
+	if current > rl.config.MaxRetries {
+		rl.activeRetries.Add(-1)
+		rl.overflowRetries.Add(1)
+		metrics.RecordCircuitBreakerOverflow(rl.cluster, "retries")
+		return false
+	}
+	return true
+}
+
+// ReleaseRetry releases a previously acquired retry slot.
+func (rl *ResourceLimits) ReleaseRetry() {
+	rl.activeRetries.Add(-1)
+}
+
+// OverflowCounts returns the total number of overflow events for each limit type.
+func (rl *ResourceLimits) OverflowCounts() (connections, pending, requests, retries int64) {
+	return rl.overflowConnections.Load(),
+		rl.overflowPending.Load(),
+		rl.overflowRequests.Load(),
+		rl.overflowRetries.Load()
+}
+
+// ActiveCounts returns the current number of active resources for each limit type.
+func (rl *ResourceLimits) ActiveCounts() (connections, pending, requests, retries int64) {
+	return rl.activeConnections.Load(),
+		rl.pendingRequests.Load(),
+		rl.activeRequests.Load(),
+		rl.activeRetries.Load()
+}

--- a/internal/agent/health/resource_limits_test.go
+++ b/internal/agent/health/resource_limits_test.go
@@ -1,0 +1,400 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestDefaultResourceLimitsConfig(t *testing.T) {
+	cfg := DefaultResourceLimitsConfig()
+
+	if cfg.MaxConnections != DefaultMaxConnections {
+		t.Errorf("expected MaxConnections=%d, got %d", DefaultMaxConnections, cfg.MaxConnections)
+	}
+	if cfg.MaxPendingRequests != DefaultMaxPendingRequests {
+		t.Errorf("expected MaxPendingRequests=%d, got %d", DefaultMaxPendingRequests, cfg.MaxPendingRequests)
+	}
+	if cfg.MaxRequests != DefaultMaxRequests {
+		t.Errorf("expected MaxRequests=%d, got %d", DefaultMaxRequests, cfg.MaxRequests)
+	}
+	if cfg.MaxRetries != DefaultMaxRetries {
+		t.Errorf("expected MaxRetries=%d, got %d", DefaultMaxRetries, cfg.MaxRetries)
+	}
+}
+
+func TestResourceLimits_ConnectionLimit(t *testing.T) {
+	rl := NewResourceLimits(ResourceLimitsConfig{
+		MaxConnections:     2,
+		MaxPendingRequests: 1024,
+		MaxRequests:        1024,
+		MaxRetries:         3,
+	}, "test-cluster")
+
+	// Acquire up to the limit
+	if !rl.TryAcquireConnection() {
+		t.Error("first connection acquire should succeed")
+	}
+	if !rl.TryAcquireConnection() {
+		t.Error("second connection acquire should succeed")
+	}
+
+	// Exceed the limit
+	if rl.TryAcquireConnection() {
+		t.Error("third connection acquire should fail (limit is 2)")
+	}
+
+	// Verify overflow was recorded
+	connOverflow, _, _, _ := rl.OverflowCounts()
+	if connOverflow != 1 {
+		t.Errorf("expected 1 connection overflow, got %d", connOverflow)
+	}
+
+	// Release one and try again
+	rl.ReleaseConnection()
+	if !rl.TryAcquireConnection() {
+		t.Error("connection acquire should succeed after release")
+	}
+}
+
+func TestResourceLimits_PendingRequestLimit(t *testing.T) {
+	rl := NewResourceLimits(ResourceLimitsConfig{
+		MaxConnections:     1024,
+		MaxPendingRequests: 3,
+		MaxRequests:        1024,
+		MaxRetries:         3,
+	}, "test-cluster")
+
+	for i := int64(0); i < 3; i++ {
+		if !rl.TryAcquirePendingRequest() {
+			t.Errorf("pending request acquire #%d should succeed", i+1)
+		}
+	}
+
+	if rl.TryAcquirePendingRequest() {
+		t.Error("pending request acquire should fail when limit is reached")
+	}
+
+	_, pendingOverflow, _, _ := rl.OverflowCounts()
+	if pendingOverflow != 1 {
+		t.Errorf("expected 1 pending overflow, got %d", pendingOverflow)
+	}
+
+	rl.ReleasePendingRequest()
+	if !rl.TryAcquirePendingRequest() {
+		t.Error("pending request acquire should succeed after release")
+	}
+}
+
+func TestResourceLimits_RequestLimit(t *testing.T) {
+	rl := NewResourceLimits(ResourceLimitsConfig{
+		MaxConnections:     1024,
+		MaxPendingRequests: 1024,
+		MaxRequests:        1,
+		MaxRetries:         3,
+	}, "test-cluster")
+
+	if !rl.TryAcquireRequest() {
+		t.Error("first request acquire should succeed")
+	}
+	if rl.TryAcquireRequest() {
+		t.Error("second request acquire should fail (limit is 1)")
+	}
+
+	_, _, reqOverflow, _ := rl.OverflowCounts()
+	if reqOverflow != 1 {
+		t.Errorf("expected 1 request overflow, got %d", reqOverflow)
+	}
+
+	rl.ReleaseRequest()
+	if !rl.TryAcquireRequest() {
+		t.Error("request acquire should succeed after release")
+	}
+}
+
+func TestResourceLimits_RetryLimit(t *testing.T) {
+	rl := NewResourceLimits(ResourceLimitsConfig{
+		MaxConnections:     1024,
+		MaxPendingRequests: 1024,
+		MaxRequests:        1024,
+		MaxRetries:         2,
+	}, "test-cluster")
+
+	if !rl.TryAcquireRetry() {
+		t.Error("first retry acquire should succeed")
+	}
+	if !rl.TryAcquireRetry() {
+		t.Error("second retry acquire should succeed")
+	}
+	if rl.TryAcquireRetry() {
+		t.Error("third retry acquire should fail (limit is 2)")
+	}
+
+	_, _, _, retryOverflow := rl.OverflowCounts()
+	if retryOverflow != 1 {
+		t.Errorf("expected 1 retry overflow, got %d", retryOverflow)
+	}
+
+	rl.ReleaseRetry()
+	if !rl.TryAcquireRetry() {
+		t.Error("retry acquire should succeed after release")
+	}
+}
+
+func TestResourceLimits_AcquireReleaseCycle(t *testing.T) {
+	rl := NewResourceLimits(ResourceLimitsConfig{
+		MaxConnections:     1,
+		MaxPendingRequests: 1,
+		MaxRequests:        1,
+		MaxRetries:         1,
+	}, "test-cluster")
+
+	// Run multiple acquire/release cycles to verify counters stay correct
+	for i := 0; i < 100; i++ {
+		if !rl.TryAcquireConnection() {
+			t.Fatalf("connection acquire failed on cycle %d", i)
+		}
+		rl.ReleaseConnection()
+
+		if !rl.TryAcquirePendingRequest() {
+			t.Fatalf("pending request acquire failed on cycle %d", i)
+		}
+		rl.ReleasePendingRequest()
+
+		if !rl.TryAcquireRequest() {
+			t.Fatalf("request acquire failed on cycle %d", i)
+		}
+		rl.ReleaseRequest()
+
+		if !rl.TryAcquireRetry() {
+			t.Fatalf("retry acquire failed on cycle %d", i)
+		}
+		rl.ReleaseRetry()
+	}
+
+	// Verify no overflows occurred
+	connOv, pendOv, reqOv, retryOv := rl.OverflowCounts()
+	if connOv != 0 || pendOv != 0 || reqOv != 0 || retryOv != 0 {
+		t.Errorf("expected zero overflows, got conn=%d pending=%d req=%d retry=%d",
+			connOv, pendOv, reqOv, retryOv)
+	}
+
+	// Verify active counts are zero
+	connAct, pendAct, reqAct, retryAct := rl.ActiveCounts()
+	if connAct != 0 || pendAct != 0 || reqAct != 0 || retryAct != 0 {
+		t.Errorf("expected zero active counts, got conn=%d pending=%d req=%d retry=%d",
+			connAct, pendAct, reqAct, retryAct)
+	}
+}
+
+func TestResourceLimits_OverflowCountingAccurate(t *testing.T) {
+	rl := NewResourceLimits(ResourceLimitsConfig{
+		MaxConnections:     1,
+		MaxPendingRequests: 1,
+		MaxRequests:        1,
+		MaxRetries:         1,
+	}, "test-cluster")
+
+	// Acquire all slots
+	rl.TryAcquireConnection()
+	rl.TryAcquirePendingRequest()
+	rl.TryAcquireRequest()
+	rl.TryAcquireRetry()
+
+	// Attempt overflow multiple times
+	for i := 0; i < 5; i++ {
+		rl.TryAcquireConnection()
+		rl.TryAcquirePendingRequest()
+		rl.TryAcquireRequest()
+		rl.TryAcquireRetry()
+	}
+
+	connOv, pendOv, reqOv, retryOv := rl.OverflowCounts()
+	if connOv != 5 {
+		t.Errorf("expected 5 connection overflows, got %d", connOv)
+	}
+	if pendOv != 5 {
+		t.Errorf("expected 5 pending overflows, got %d", pendOv)
+	}
+	if reqOv != 5 {
+		t.Errorf("expected 5 request overflows, got %d", reqOv)
+	}
+	if retryOv != 5 {
+		t.Errorf("expected 5 retry overflows, got %d", retryOv)
+	}
+
+	// Verify active counts remain at 1 (not inflated by failed acquires)
+	connAct, pendAct, reqAct, retryAct := rl.ActiveCounts()
+	if connAct != 1 {
+		t.Errorf("expected 1 active connection, got %d", connAct)
+	}
+	if pendAct != 1 {
+		t.Errorf("expected 1 active pending request, got %d", pendAct)
+	}
+	if reqAct != 1 {
+		t.Errorf("expected 1 active request, got %d", reqAct)
+	}
+	if retryAct != 1 {
+		t.Errorf("expected 1 active retry, got %d", retryAct)
+	}
+}
+
+func TestResourceLimits_ConcurrentAccess(t *testing.T) {
+	const (
+		maxConns   int64 = 10
+		goroutines       = 50
+		iterations       = 100
+	)
+
+	rl := NewResourceLimits(ResourceLimitsConfig{
+		MaxConnections:     maxConns,
+		MaxPendingRequests: maxConns,
+		MaxRequests:        maxConns,
+		MaxRetries:         maxConns,
+	}, "concurrent-cluster")
+
+	var wg sync.WaitGroup
+
+	// Launch goroutines that all try to acquire and release connections
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if rl.TryAcquireConnection() {
+					// Verify we never exceed the limit
+					active := rl.activeConnections.Load()
+					if active > maxConns {
+						t.Errorf("active connections %d exceeded max %d", active, maxConns)
+					}
+					rl.ReleaseConnection()
+				}
+			}
+		}()
+	}
+
+	// Also test concurrent pending requests
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if rl.TryAcquirePendingRequest() {
+					rl.ReleasePendingRequest()
+				}
+			}
+		}()
+	}
+
+	// Also test concurrent requests
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if rl.TryAcquireRequest() {
+					rl.ReleaseRequest()
+				}
+			}
+		}()
+	}
+
+	// Also test concurrent retries
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if rl.TryAcquireRetry() {
+					rl.ReleaseRetry()
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// After all goroutines complete, active counts should be zero
+	connAct, pendAct, reqAct, retryAct := rl.ActiveCounts()
+	if connAct != 0 {
+		t.Errorf("expected 0 active connections after concurrent test, got %d", connAct)
+	}
+	if pendAct != 0 {
+		t.Errorf("expected 0 active pending requests after concurrent test, got %d", pendAct)
+	}
+	if reqAct != 0 {
+		t.Errorf("expected 0 active requests after concurrent test, got %d", reqAct)
+	}
+	if retryAct != 0 {
+		t.Errorf("expected 0 active retries after concurrent test, got %d", retryAct)
+	}
+
+	// There should be some overflows since goroutines > maxConns
+	connOv, pendOv, reqOv, retryOv := rl.OverflowCounts()
+	t.Logf("overflow counts: conn=%d pending=%d req=%d retry=%d", connOv, pendOv, reqOv, retryOv)
+	if connOv == 0 {
+		t.Log("warning: no connection overflows in concurrent test (possible but unlikely)")
+	}
+	if pendOv == 0 {
+		t.Log("warning: no pending request overflows in concurrent test (possible but unlikely)")
+	}
+	if reqOv == 0 {
+		t.Log("warning: no request overflows in concurrent test (possible but unlikely)")
+	}
+	if retryOv == 0 {
+		t.Log("warning: no retry overflows in concurrent test (possible but unlikely)")
+	}
+}
+
+func TestResourceLimits_ActiveCounts(t *testing.T) {
+	rl := NewResourceLimits(ResourceLimitsConfig{
+		MaxConnections:     10,
+		MaxPendingRequests: 10,
+		MaxRequests:        10,
+		MaxRetries:         10,
+	}, "test-cluster")
+
+	// Initially all zero
+	connAct, pendAct, reqAct, retryAct := rl.ActiveCounts()
+	if connAct != 0 || pendAct != 0 || reqAct != 0 || retryAct != 0 {
+		t.Error("expected all zero active counts initially")
+	}
+
+	// Acquire some resources
+	rl.TryAcquireConnection()
+	rl.TryAcquireConnection()
+	rl.TryAcquirePendingRequest()
+	rl.TryAcquireRequest()
+	rl.TryAcquireRequest()
+	rl.TryAcquireRequest()
+	rl.TryAcquireRetry()
+
+	connAct, pendAct, reqAct, retryAct = rl.ActiveCounts()
+	if connAct != 2 {
+		t.Errorf("expected 2 active connections, got %d", connAct)
+	}
+	if pendAct != 1 {
+		t.Errorf("expected 1 active pending request, got %d", pendAct)
+	}
+	if reqAct != 3 {
+		t.Errorf("expected 3 active requests, got %d", reqAct)
+	}
+	if retryAct != 1 {
+		t.Errorf("expected 1 active retry, got %d", retryAct)
+	}
+}

--- a/internal/agent/metrics/endpoint_metrics.go
+++ b/internal/agent/metrics/endpoint_metrics.go
@@ -122,6 +122,15 @@ var (
 		[]string{"cluster"},
 	)
 
+	// CircuitBreakerOverflowTotal tracks circuit breaker resource limit overflows
+	CircuitBreakerOverflowTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "novaedge_circuit_breaker_overflow_total",
+			Help: "Total number of circuit breaker resource limit overflows",
+		},
+		[]string{"cluster", "type"}, // type: connections, pending, requests, retries
+	)
+
 	// Load Balancer Metrics
 
 	// LoadBalancerSelections tracks load balancer endpoint selections
@@ -230,6 +239,11 @@ func RecordEndpointEjection(cluster, endpoint, reason string) {
 // SetEndpointsEjected sets the current number of ejected endpoints for a cluster.
 func SetEndpointsEjected(cluster string, count int) {
 	EndpointsEjected.WithLabelValues(cluster).Set(float64(count))
+}
+
+// RecordCircuitBreakerOverflow records a circuit breaker resource limit overflow event.
+func RecordCircuitBreakerOverflow(cluster, limitType string) {
+	CircuitBreakerOverflowTotal.WithLabelValues(cluster, limitType).Inc()
 }
 
 // RecordLoadBalancerSelection records a load balancer selection


### PR DESCRIPTION
## Summary
- Add `ResourceLimiter` in `internal/agent/health/` enforcing per-cluster resource limits using atomic counters
- Track max connections, pending requests, active requests, and retries per backend
- Overflow events exposed as Prometheus metrics via new counters in `internal/agent/metrics/`
- Comprehensive tests covering limit enforcement, concurrent access, overflow counting, and release semantics

## Test plan
- [ ] Unit tests pass
- [ ] Build succeeds
- [ ] gofmt clean

Resolves #153