### PR TITLE
[Feature] Request hedging for tail latency reduction

### DIFF
--- a/internal/agent/metrics/hedging_metrics.go
+++ b/internal/agent/metrics/hedging_metrics.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// Hedging Metrics
+
+	// HedgingRequestsTotal tracks total hedged requests sent
+	HedgingRequestsTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "novaedge_hedging_requests_total",
+			Help: "Total number of hedged requests sent",
+		},
+	)
+
+	// HedgingWins tracks how many times the hedged request won the race
+	HedgingWins = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "novaedge_hedging_wins_total",
+			Help: "Total number of times the hedged request completed before the original",
+		},
+	)
+
+	// HedgingCancelled tracks how many hedged requests were cancelled
+	HedgingCancelled = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "novaedge_hedging_cancelled_total",
+			Help: "Total number of hedged requests cancelled because the original completed first",
+		},
+	)
+)

--- a/internal/agent/router/hedging.go
+++ b/internal/agent/router/hedging.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/novaedge/internal/agent/metrics"
+)
+
+// defaultHedgingInitialRequests is the default number of initial (non-hedged) requests.
+const defaultHedgingInitialRequests = 1
+
+// defaultHedgingMaxConcurrent is the default maximum number of concurrent
+// requests (initial + hedged).
+const defaultHedgingMaxConcurrent = 2
+
+// defaultHedgingPerTryTimeout is the default per-try timeout before a hedge is triggered.
+const defaultHedgingPerTryTimeout = 100 * time.Millisecond
+
+// HedgingConfig holds configuration for request hedging.
+type HedgingConfig struct {
+	// Enabled controls whether request hedging is active.
+	Enabled bool
+
+	// InitialRequests is the number of initial requests to send before
+	// considering hedging. Defaults to 1.
+	InitialRequests int
+
+	// MaxConcurrent is the maximum number of in-flight requests allowed
+	// (initial + hedged). Defaults to 2.
+	MaxConcurrent int
+
+	// HedgeOnPerTryTimeout controls whether a hedged request is sent when
+	// the per-try timeout elapses. Defaults to true.
+	HedgeOnPerTryTimeout bool
+
+	// PerTryTimeout is how long to wait for the initial request before
+	// sending a hedged request to a different endpoint.
+	PerTryTimeout time.Duration
+}
+
+// applyDefaults fills in zero-value fields with sensible defaults.
+func (c *HedgingConfig) applyDefaults() {
+	if c.InitialRequests <= 0 {
+		c.InitialRequests = defaultHedgingInitialRequests
+	}
+	if c.MaxConcurrent <= 0 {
+		c.MaxConcurrent = defaultHedgingMaxConcurrent
+	}
+	if c.PerTryTimeout <= 0 {
+		c.PerTryTimeout = defaultHedgingPerTryTimeout
+	}
+}
+
+// hedgingResult holds the outcome of one leg (original or hedged) of the race.
+type hedgingResult struct {
+	resp    *http.Response
+	err     error
+	isHedge bool
+}
+
+// HedgingHandler races an original request against hedged copies that are sent
+// to different endpoints when the per-try timeout elapses. The first successful
+// response wins; all other in-flight requests are cancelled.
+type HedgingHandler struct {
+	config HedgingConfig
+	logger *zap.Logger
+}
+
+// NewHedgingHandler creates a HedgingHandler with the given configuration.
+// Zero-value fields in cfg are replaced with defaults.
+func NewHedgingHandler(cfg HedgingConfig, logger *zap.Logger) *HedgingHandler {
+	cfg.applyDefaults()
+	return &HedgingHandler{
+		config: cfg,
+		logger: logger,
+	}
+}
+
+// Execute sends the initial request and, if it does not complete within
+// PerTryTimeout, sends hedged requests to different endpoints (up to
+// MaxConcurrent total). The first successful response is returned; all other
+// in-flight requests are cancelled.
+//
+// selectEndpoint returns the URL of a backend to try. It must return a
+// different endpoint on each call when possible.
+//
+// doRequest performs the actual HTTP round-trip to the given endpoint.
+func (h *HedgingHandler) Execute(
+	ctx context.Context,
+	req *http.Request,
+	selectEndpoint func() (*url.URL, error),
+	doRequest func(ctx context.Context, endpoint *url.URL, req *http.Request) (*http.Response, error),
+) (*http.Response, error) {
+	// When hedging is disabled, just forward directly.
+	if !h.config.Enabled {
+		ep, err := selectEndpoint()
+		if err != nil {
+			return nil, err
+		}
+		return doRequest(ctx, ep, req)
+	}
+
+	resultCh := make(chan hedgingResult, h.config.MaxConcurrent)
+
+	// masterCtx governs all legs; cancelling it tears down every in-flight request.
+	masterCtx, masterCancel := context.WithCancel(ctx)
+	defer masterCancel()
+
+	var wg sync.WaitGroup
+	inflight := 0
+
+	// launch starts a single request leg in its own goroutine.
+	launch := func(isHedge bool) error {
+		ep, err := selectEndpoint()
+		if err != nil {
+			return err
+		}
+
+		legCtx, legCancel := context.WithCancel(masterCtx)
+		inflight++
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			defer legCancel()
+
+			resp, doErr := doRequest(legCtx, ep, req)
+			resultCh <- hedgingResult{resp: resp, err: doErr, isHedge: isHedge}
+		}()
+
+		if isHedge {
+			metrics.HedgingRequestsTotal.Inc()
+			if ce := h.logger.Check(zap.DebugLevel, "Sent hedged request"); ce != nil {
+				ce.Write(zap.String("endpoint", ep.String()))
+			}
+		}
+
+		return nil
+	}
+
+	// Send the initial request(s).
+	for i := 0; i < h.config.InitialRequests && inflight < h.config.MaxConcurrent; i++ {
+		if err := launch(false); err != nil {
+			// If we haven't launched anything yet, propagate the error.
+			if inflight == 0 {
+				return nil, err
+			}
+			break
+		}
+	}
+
+	// hedgeTimer fires when we should send a hedged request.
+	var hedgeTimer *time.Timer
+	var hedgeC <-chan time.Time
+	if h.config.HedgeOnPerTryTimeout && inflight < h.config.MaxConcurrent {
+		hedgeTimer = time.NewTimer(h.config.PerTryTimeout)
+		hedgeC = hedgeTimer.C
+		defer hedgeTimer.Stop()
+	}
+
+	// Collect results until we get a success or exhaust all legs.
+	var lastErr error
+	received := 0
+
+	for received < inflight {
+		select {
+		case <-ctx.Done():
+			masterCancel()
+			return nil, ctx.Err()
+
+		case <-hedgeC:
+			// Per-try timeout elapsed; send a hedged request if allowed.
+			hedgeC = nil // disarm so we only hedge once
+			if inflight < h.config.MaxConcurrent {
+				if err := launch(true); err != nil {
+					if ce := h.logger.Check(zap.DebugLevel, "Failed to launch hedged request"); ce != nil {
+						ce.Write(zap.Error(err))
+					}
+				}
+			}
+
+		case res := <-resultCh:
+			received++
+
+			if res.err != nil {
+				lastErr = res.err
+				// If there are more legs still in flight, keep waiting.
+				continue
+			}
+
+			// We have a winner. Cancel everything else.
+			masterCancel()
+
+			if res.isHedge {
+				metrics.HedgingWins.Inc()
+			} else {
+				// The original won; the hedged copy (if any) will be cancelled.
+				metrics.HedgingCancelled.Inc()
+			}
+
+			// Drain remaining results in the background so goroutines can exit.
+			go func() {
+				for range resultCh {
+					// discard
+				}
+			}()
+			go func() {
+				wg.Wait()
+				close(resultCh)
+			}()
+
+			return res.resp, nil
+		}
+	}
+
+	// All legs failed.
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, errors.New("hedging: all requests failed with no error")
+}

--- a/internal/agent/router/hedging_test.go
+++ b/internal/agent/router/hedging_test.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// testLogger returns a no-op logger suitable for unit tests.
+func testLogger() *zap.Logger {
+	return zap.NewNop()
+}
+
+// endpointPool returns a selectEndpoint function that cycles through the
+// provided URLs, returning a different one each call.
+func endpointPool(urls ...*url.URL) func() (*url.URL, error) {
+	var idx int64
+	return func() (*url.URL, error) {
+		i := atomic.AddInt64(&idx, 1) - 1
+		if int(i) >= len(urls) {
+			return nil, errors.New("no more endpoints")
+		}
+		return urls[i], nil
+	}
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestHedgingConfig_ApplyDefaults(t *testing.T) {
+	cfg := &HedgingConfig{}
+	cfg.applyDefaults()
+
+	if cfg.InitialRequests != defaultHedgingInitialRequests {
+		t.Errorf("InitialRequests = %d, want %d", cfg.InitialRequests, defaultHedgingInitialRequests)
+	}
+	if cfg.MaxConcurrent != defaultHedgingMaxConcurrent {
+		t.Errorf("MaxConcurrent = %d, want %d", cfg.MaxConcurrent, defaultHedgingMaxConcurrent)
+	}
+	if cfg.PerTryTimeout != defaultHedgingPerTryTimeout {
+		t.Errorf("PerTryTimeout = %v, want %v", cfg.PerTryTimeout, defaultHedgingPerTryTimeout)
+	}
+}
+
+func TestHedgingConfig_CustomValues(t *testing.T) {
+	cfg := &HedgingConfig{
+		InitialRequests: 2,
+		MaxConcurrent:   4,
+		PerTryTimeout:   500 * time.Millisecond,
+	}
+	cfg.applyDefaults()
+
+	if cfg.InitialRequests != 2 {
+		t.Errorf("InitialRequests = %d, want 2", cfg.InitialRequests)
+	}
+	if cfg.MaxConcurrent != 4 {
+		t.Errorf("MaxConcurrent = %d, want 4", cfg.MaxConcurrent)
+	}
+	if cfg.PerTryTimeout != 500*time.Millisecond {
+		t.Errorf("PerTryTimeout = %v, want 500ms", cfg.PerTryTimeout)
+	}
+}
+
+func TestHedging_DisabledForwardsDirect(t *testing.T) {
+	handler := NewHedgingHandler(HedgingConfig{
+		Enabled: false,
+	}, testLogger())
+
+	ep := mustParseURL("http://backend1:8080")
+	selectEP := func() (*url.URL, error) {
+		return ep, nil
+	}
+
+	var called int64
+	doReq := func(_ context.Context, endpoint *url.URL, _ *http.Request) (*http.Response, error) {
+		atomic.AddInt64(&called, 1)
+		if endpoint.String() != ep.String() {
+			t.Errorf("unexpected endpoint %s", endpoint)
+		}
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	resp, err := handler.Execute(context.Background(), req, selectEP, doReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if atomic.LoadInt64(&called) != 1 {
+		t.Errorf("doRequest called %d times, want 1", atomic.LoadInt64(&called))
+	}
+}
+
+func TestHedging_NoHedgeWhenInitialSucceedsQuickly(t *testing.T) {
+	handler := NewHedgingHandler(HedgingConfig{
+		Enabled:              true,
+		InitialRequests:      1,
+		MaxConcurrent:        2,
+		HedgeOnPerTryTimeout: true,
+		PerTryTimeout:        500 * time.Millisecond,
+	}, testLogger())
+
+	eps := endpointPool(
+		mustParseURL("http://backend1:8080"),
+		mustParseURL("http://backend2:8080"),
+	)
+
+	var called int64
+	doReq := func(_ context.Context, _ *url.URL, _ *http.Request) (*http.Response, error) {
+		atomic.AddInt64(&called, 1)
+		// Respond immediately -- well before the 500ms hedge timeout.
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/fast", nil)
+	resp, err := handler.Execute(context.Background(), req, eps, doReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Only the initial request should have been sent.
+	if atomic.LoadInt64(&called) != 1 {
+		t.Errorf("doRequest called %d times, want 1", atomic.LoadInt64(&called))
+	}
+}
+
+func TestHedging_HedgedRequestSentAfterTimeout(t *testing.T) {
+	handler := NewHedgingHandler(HedgingConfig{
+		Enabled:              true,
+		InitialRequests:      1,
+		MaxConcurrent:        2,
+		HedgeOnPerTryTimeout: true,
+		PerTryTimeout:        50 * time.Millisecond,
+	}, testLogger())
+
+	eps := endpointPool(
+		mustParseURL("http://backend1:8080"),
+		mustParseURL("http://backend2:8080"),
+	)
+
+	var callCount int64
+	doReq := func(ctx context.Context, ep *url.URL, _ *http.Request) (*http.Response, error) {
+		n := atomic.AddInt64(&callCount, 1)
+		if n == 1 {
+			// First request: slow -- exceeds the hedge timeout.
+			select {
+			case <-time.After(2 * time.Second):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return nil, ctx.Err()
+		}
+		// Hedged request: respond immediately.
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/slow", nil)
+	resp, err := handler.Execute(context.Background(), req, eps, doReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Both the initial and the hedged request should have been launched.
+	if atomic.LoadInt64(&callCount) < 2 {
+		t.Errorf("doRequest called %d times, want >= 2", atomic.LoadInt64(&callCount))
+	}
+}
+
+func TestHedging_FirstResponseWinsOtherCancelled(t *testing.T) {
+	handler := NewHedgingHandler(HedgingConfig{
+		Enabled:              true,
+		InitialRequests:      1,
+		MaxConcurrent:        2,
+		HedgeOnPerTryTimeout: true,
+		PerTryTimeout:        10 * time.Millisecond,
+	}, testLogger())
+
+	eps := endpointPool(
+		mustParseURL("http://backend1:8080"),
+		mustParseURL("http://backend2:8080"),
+	)
+
+	cancelledCtxs := make(chan context.Context, 2)
+	doReq := func(ctx context.Context, ep *url.URL, _ *http.Request) (*http.Response, error) {
+		cancelledCtxs <- ctx
+		if ep.Host == "backend1:8080" {
+			// Original: slow
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return nil, ctx.Err()
+		}
+		// Hedged: fast winner
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/race", nil)
+	resp, err := handler.Execute(context.Background(), req, eps, doReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// The losing context should be cancelled shortly.
+	select {
+	case ctx := <-cancelledCtxs:
+		// Give a moment for cancellation to propagate.
+		select {
+		case <-ctx.Done():
+			// good -- cancelled
+		case <-time.After(2 * time.Second):
+			t.Error("expected losing request context to be cancelled")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for context from losing request")
+	}
+}
+
+func TestHedging_MaxConcurrentRespected(t *testing.T) {
+	handler := NewHedgingHandler(HedgingConfig{
+		Enabled:              true,
+		InitialRequests:      1,
+		MaxConcurrent:        2,
+		HedgeOnPerTryTimeout: true,
+		PerTryTimeout:        10 * time.Millisecond,
+	}, testLogger())
+
+	// Provide 3 endpoints but MaxConcurrent is 2.
+	eps := endpointPool(
+		mustParseURL("http://backend1:8080"),
+		mustParseURL("http://backend2:8080"),
+		mustParseURL("http://backend3:8080"),
+	)
+
+	var callCount int64
+	doReq := func(ctx context.Context, _ *url.URL, _ *http.Request) (*http.Response, error) {
+		n := atomic.AddInt64(&callCount, 1)
+		if n == 1 {
+			// Slow initial request.
+			select {
+			case <-time.After(2 * time.Second):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return nil, ctx.Err()
+		}
+		// Hedged responds.
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/maxconc", nil)
+	resp, err := handler.Execute(context.Background(), req, eps, doReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// At most MaxConcurrent (2) requests should have been launched.
+	total := atomic.LoadInt64(&callCount)
+	if total > 2 {
+		t.Errorf("doRequest called %d times, want <= 2 (MaxConcurrent)", total)
+	}
+}
+
+func TestHedging_AllRequestsFail(t *testing.T) {
+	handler := NewHedgingHandler(HedgingConfig{
+		Enabled:              true,
+		InitialRequests:      1,
+		MaxConcurrent:        2,
+		HedgeOnPerTryTimeout: true,
+		PerTryTimeout:        10 * time.Millisecond,
+	}, testLogger())
+
+	eps := endpointPool(
+		mustParseURL("http://backend1:8080"),
+		mustParseURL("http://backend2:8080"),
+	)
+
+	errBackend := errors.New("backend unavailable")
+	doReq := func(_ context.Context, _ *url.URL, _ *http.Request) (*http.Response, error) {
+		return nil, errBackend
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/fail", nil)
+	_, err := handler.Execute(context.Background(), req, eps, doReq)
+	if err == nil {
+		t.Fatal("expected error when all requests fail")
+	}
+	if !errors.Is(err, errBackend) {
+		t.Errorf("error = %v, want %v", err, errBackend)
+	}
+}
+
+func TestHedging_ContextCancellation(t *testing.T) {
+	handler := NewHedgingHandler(HedgingConfig{
+		Enabled:              true,
+		InitialRequests:      1,
+		MaxConcurrent:        2,
+		HedgeOnPerTryTimeout: true,
+		PerTryTimeout:        50 * time.Millisecond,
+	}, testLogger())
+
+	eps := endpointPool(
+		mustParseURL("http://backend1:8080"),
+		mustParseURL("http://backend2:8080"),
+	)
+
+	doReq := func(ctx context.Context, _ *url.URL, _ *http.Request) (*http.Response, error) {
+		// Block until context is cancelled.
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/cancel", nil)
+	_, err := handler.Execute(ctx, req, eps, doReq)
+	if err == nil {
+		t.Fatal("expected error on context cancellation")
+	}
+}
+
+func TestHedging_SelectEndpointError(t *testing.T) {
+	handler := NewHedgingHandler(HedgingConfig{
+		Enabled:         true,
+		InitialRequests: 1,
+		MaxConcurrent:   2,
+		PerTryTimeout:   50 * time.Millisecond,
+	}, testLogger())
+
+	epErr := errors.New("no healthy endpoints")
+	selectEP := func() (*url.URL, error) {
+		return nil, epErr
+	}
+
+	doReq := func(_ context.Context, _ *url.URL, _ *http.Request) (*http.Response, error) {
+		t.Fatal("doRequest should not be called when selectEndpoint fails")
+		return nil, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/noep", nil)
+	_, err := handler.Execute(context.Background(), req, selectEP, doReq)
+	if !errors.Is(err, epErr) {
+		t.Errorf("error = %v, want %v", err, epErr)
+	}
+}


### PR DESCRIPTION
## Summary
- Add request hedging middleware to reduce tail latency by sending redundant requests to alternate backends after a configurable delay
- New `hedging.go` in `internal/agent/router/` implements the hedging middleware with configurable delay, max extra requests, and cancellation of in-flight hedged requests once the first response arrives
- Dedicated hedging metrics in `internal/agent/metrics/hedging_metrics.go` for observability into hedging behavior
- Comprehensive test coverage in `hedging_test.go` (389 lines of tests)

## Test plan
- [ ] Unit tests pass
- [ ] Build succeeds
- [ ] gofmt clean

Resolves #161