### PR TITLE
[Feature] Graceful connection draining on config reload

### DIFF
--- a/internal/agent/server/drain.go
+++ b/internal/agent/server/drain.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultDrainTimeout is the default maximum time to wait for active
+	// connections to complete during a graceful drain.
+	DefaultDrainTimeout = 30 * time.Second
+)
+
+// DrainManager coordinates graceful connection draining during configuration
+// reloads. It tracks active connections and, when draining is initiated,
+// signals existing connections to close while allowing them time to finish
+// in-progress work.
+type DrainManager struct {
+	logger            *zap.Logger
+	drainTimeout      time.Duration
+	draining          atomic.Bool
+	activeConnections sync.WaitGroup
+	activeCount       atomic.Int64 // for observability; mirrors WaitGroup count
+}
+
+// NewDrainManager creates a DrainManager with the given timeout.
+// If timeout is zero, DefaultDrainTimeout is used.
+func NewDrainManager(logger *zap.Logger, timeout time.Duration) *DrainManager {
+	if timeout <= 0 {
+		timeout = DefaultDrainTimeout
+	}
+	return &DrainManager{
+		logger:       logger,
+		drainTimeout: timeout,
+	}
+}
+
+// StartDrain initiates the drain process. It sets the draining flag, then
+// blocks until all tracked connections have completed or the timeout expires.
+// The provided context can be used for early cancellation.
+func (dm *DrainManager) StartDrain(ctx context.Context) {
+	dm.draining.Store(true)
+	dm.logger.Info("Connection draining started",
+		zap.Duration("timeout", dm.drainTimeout),
+		zap.Int64("active_connections", dm.activeCount.Load()),
+	)
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, dm.drainTimeout)
+	defer cancel()
+
+	// Wait for all active connections to complete or for the timeout.
+	done := make(chan struct{})
+	go func() {
+		dm.activeConnections.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		dm.logger.Info("All active connections drained successfully")
+	case <-timeoutCtx.Done():
+		remaining := dm.activeCount.Load()
+		dm.logger.Warn("Drain timeout reached, proceeding with config swap",
+			zap.Int64("remaining_connections", remaining),
+		)
+	}
+
+	// Reset draining state after drain completes so the manager can be reused
+	dm.draining.Store(false)
+}
+
+// IsDraining returns true if the manager is currently in drain mode.
+func (dm *DrainManager) IsDraining() bool {
+	return dm.draining.Load()
+}
+
+// TrackConnection increments the active connection counter. Each call must
+// be paired with a corresponding ReleaseConnection call.
+func (dm *DrainManager) TrackConnection() {
+	dm.activeConnections.Add(1)
+	dm.activeCount.Add(1)
+}
+
+// ReleaseConnection decrements the active connection counter.
+func (dm *DrainManager) ReleaseConnection() {
+	dm.activeCount.Add(-1)
+	dm.activeConnections.Done()
+}
+
+// ActiveConnections returns the current number of tracked active connections.
+func (dm *DrainManager) ActiveConnections() int64 {
+	return dm.activeCount.Load()
+}
+
+// DrainMiddleware returns an HTTP middleware that integrates with the
+// DrainManager. It tracks each request as an active connection and, when
+// draining is active, sets the "Connection: close" header on HTTP/1.x
+// responses to signal clients to open new connections (which will be
+// served by the updated configuration).
+func (dm *DrainManager) DrainMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dm.TrackConnection()
+		defer dm.ReleaseConnection()
+
+		if dm.IsDraining() {
+			// For HTTP/1.x, set Connection: close to signal the client that
+			// the server will close the connection after this response.
+			// For HTTP/2+, Go's net/http server handles GOAWAY when
+			// Shutdown is called, so no explicit header is needed.
+			if !r.ProtoAtLeast(2, 0) {
+				w.Header().Set("Connection", "close")
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/agent/server/drain_test.go
+++ b/internal/agent/server/drain_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func newTestDrainManager(timeout time.Duration) *DrainManager {
+	logger, _ := zap.NewDevelopment()
+	return NewDrainManager(logger, timeout)
+}
+
+func TestDrainManagerDefaults(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	dm := NewDrainManager(logger, 0)
+	if dm.drainTimeout != DefaultDrainTimeout {
+		t.Errorf("expected default timeout %v, got %v", DefaultDrainTimeout, dm.drainTimeout)
+	}
+	if dm.IsDraining() {
+		t.Error("new DrainManager should not be in draining state")
+	}
+	if dm.ActiveConnections() != 0 {
+		t.Errorf("expected 0 active connections, got %d", dm.ActiveConnections())
+	}
+}
+
+func TestDrainMiddleware_NotDraining(t *testing.T) {
+	dm := newTestDrainManager(5 * time.Second)
+
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := dm.DrainMiddleware(innerHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	// Simulate HTTP/1.1
+	req.Proto = "HTTP/1.1"
+	req.ProtoMajor = 1
+	req.ProtoMinor = 1
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rr.Code)
+	}
+
+	// Connection header should NOT be set when not draining
+	if connHeader := rr.Header().Get("Connection"); connHeader != "" {
+		t.Errorf("expected no Connection header when not draining, got %q", connHeader)
+	}
+}
+
+func TestDrainMiddleware_DrainingHTTP11(t *testing.T) {
+	dm := newTestDrainManager(5 * time.Second)
+
+	// Manually set draining to true for this test
+	dm.draining.Store(true)
+
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := dm.DrainMiddleware(innerHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Proto = "HTTP/1.1"
+	req.ProtoMajor = 1
+	req.ProtoMinor = 1
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rr.Code)
+	}
+
+	connHeader := rr.Header().Get("Connection")
+	if connHeader != "close" {
+		t.Errorf("expected Connection: close when draining HTTP/1.1, got %q", connHeader)
+	}
+}
+
+func TestDrainMiddleware_DrainingHTTP2(t *testing.T) {
+	dm := newTestDrainManager(5 * time.Second)
+
+	dm.draining.Store(true)
+
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := dm.DrainMiddleware(innerHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Proto = "HTTP/2.0"
+	req.ProtoMajor = 2
+	req.ProtoMinor = 0
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rr.Code)
+	}
+
+	// Connection header should NOT be set for HTTP/2
+	if connHeader := rr.Header().Get("Connection"); connHeader != "" {
+		t.Errorf("expected no Connection header for HTTP/2, got %q", connHeader)
+	}
+}
+
+func TestDrainWaitsForActiveConnections(t *testing.T) {
+	dm := newTestDrainManager(5 * time.Second)
+
+	// Simulate an active connection
+	dm.TrackConnection()
+
+	drainDone := make(chan struct{})
+	go func() {
+		dm.StartDrain(context.Background())
+		close(drainDone)
+	}()
+
+	// Give the drain goroutine a moment to start waiting
+	time.Sleep(50 * time.Millisecond)
+
+	// Drain should not be done yet because we have an active connection
+	select {
+	case <-drainDone:
+		t.Fatal("drain should not have completed while connections are active")
+	default:
+		// expected
+	}
+
+	// Release the connection
+	dm.ReleaseConnection()
+
+	// Now drain should complete quickly
+	select {
+	case <-drainDone:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not complete after all connections were released")
+	}
+}
+
+func TestDrainRespectsTimeout(t *testing.T) {
+	dm := newTestDrainManager(100 * time.Millisecond)
+
+	// Simulate a connection that will not be released
+	dm.TrackConnection()
+
+	start := time.Now()
+	dm.StartDrain(context.Background())
+	elapsed := time.Since(start)
+
+	// The drain should have completed due to timeout, not connection release
+	if elapsed < 80*time.Millisecond {
+		t.Errorf("drain completed too quickly (%v), expected at least ~100ms timeout", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("drain took too long (%v), expected ~100ms timeout", elapsed)
+	}
+
+	// Clean up: release the leaked connection to avoid WaitGroup panic
+	dm.ReleaseConnection()
+}
+
+func TestDrainRespectsContextCancellation(t *testing.T) {
+	dm := newTestDrainManager(10 * time.Second)
+
+	// Simulate a connection that will not be released
+	dm.TrackConnection()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	dm.StartDrain(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("drain did not respect context cancellation, took %v", elapsed)
+	}
+
+	// Clean up
+	dm.ReleaseConnection()
+}
+
+func TestConcurrentConnectionTracking(t *testing.T) {
+	dm := newTestDrainManager(5 * time.Second)
+
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+
+	// Track and release connections concurrently
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dm.TrackConnection()
+			// Simulate some work
+			time.Sleep(time.Millisecond)
+			dm.ReleaseConnection()
+		}()
+	}
+
+	wg.Wait()
+
+	if count := dm.ActiveConnections(); count != 0 {
+		t.Errorf("expected 0 active connections after all released, got %d", count)
+	}
+}
+
+func TestConcurrentDrainWithTraffic(t *testing.T) {
+	dm := newTestDrainManager(2 * time.Second)
+
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(10 * time.Millisecond) // simulate work
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := dm.DrainMiddleware(innerHandler)
+
+	const numRequests = 20
+	var wg sync.WaitGroup
+
+	// Start some requests
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Proto = "HTTP/1.1"
+			req.ProtoMajor = 1
+			req.ProtoMinor = 1
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Errorf("expected status 200, got %d", rr.Code)
+			}
+		}()
+	}
+
+	// Start drain while requests are in-flight
+	drainDone := make(chan struct{})
+	go func() {
+		dm.StartDrain(context.Background())
+		close(drainDone)
+	}()
+
+	// All requests should still complete
+	wg.Wait()
+
+	// Drain should complete after all requests finish
+	select {
+	case <-drainDone:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain did not complete after all concurrent requests finished")
+	}
+
+	if count := dm.ActiveConnections(); count != 0 {
+		t.Errorf("expected 0 active connections after drain, got %d", count)
+	}
+}
+
+func TestDrainManagerIsDrainingResetsAfterDrain(t *testing.T) {
+	dm := newTestDrainManager(100 * time.Millisecond)
+
+	if dm.IsDraining() {
+		t.Error("should not be draining initially")
+	}
+
+	// Start and complete a drain with no active connections
+	dm.StartDrain(context.Background())
+
+	if dm.IsDraining() {
+		t.Error("should not be draining after drain completes")
+	}
+}
+
+func TestTrackAndReleaseConnection(t *testing.T) {
+	dm := newTestDrainManager(5 * time.Second)
+
+	dm.TrackConnection()
+	if count := dm.ActiveConnections(); count != 1 {
+		t.Errorf("expected 1 active connection, got %d", count)
+	}
+
+	dm.TrackConnection()
+	if count := dm.ActiveConnections(); count != 2 {
+		t.Errorf("expected 2 active connections, got %d", count)
+	}
+
+	dm.ReleaseConnection()
+	if count := dm.ActiveConnections(); count != 1 {
+		t.Errorf("expected 1 active connection after release, got %d", count)
+	}
+
+	dm.ReleaseConnection()
+	if count := dm.ActiveConnections(); count != 0 {
+		t.Errorf("expected 0 active connections after all released, got %d", count)
+	}
+}

--- a/internal/agent/server/http.go
+++ b/internal/agent/server/http.go
@@ -43,6 +43,7 @@ type HTTPServer struct {
 	shuttingDown     atomic.Bool    // Flag to indicate shutdown in progress
 	ocspStapler      *OCSPStapler   // OCSP stapling manager
 	cachedAltSvc     atomic.Value   // stores string - cached Alt-Svc header value
+	drainManager     *DrainManager  // Manages graceful connection draining on config reload
 }
 
 // NewHTTPServer creates a new HTTP server
@@ -54,6 +55,7 @@ func NewHTTPServer(logger *zap.Logger) *HTTPServer {
 		listeners:    make(map[int32]*ListenerInfo),
 		router:       router.NewRouter(logger),
 		ocspStapler:  NewOCSPStapler(logger),
+		drainManager: NewDrainManager(logger, DefaultDrainTimeout),
 	}
 }
 
@@ -64,8 +66,25 @@ func (s *HTTPServer) Start(ctx context.Context) error {
 	return ctx.Err()
 }
 
-// ApplyConfig applies a new configuration snapshot
+// DrainManager returns the server's DrainManager instance for external use.
+func (s *HTTPServer) DrainManager() *DrainManager {
+	return s.drainManager
+}
+
+// ApplyConfig applies a new configuration snapshot. If there are active
+// connections, it initiates a graceful drain on the old configuration
+// before switching to the new one, allowing in-flight requests to complete.
 func (s *HTTPServer) ApplyConfig(ctx context.Context, snapshot *config.Snapshot) error {
+	// Drain active connections from the previous configuration before
+	// acquiring the lock and swapping. This allows in-flight requests
+	// to finish while we prepare the new configuration.
+	if s.drainManager.ActiveConnections() > 0 {
+		s.logger.Info("Active connections detected, initiating graceful drain before config swap",
+			zap.Int64("active_connections", s.drainManager.ActiveConnections()),
+		)
+		s.drainManager.StartDrain(ctx)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -217,9 +236,18 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Track in-flight request
+	// Track in-flight request for shutdown and drain awareness
 	s.inFlightRequests.Add(1)
 	defer s.inFlightRequests.Done()
+
+	s.drainManager.TrackConnection()
+	defer s.drainManager.ReleaseConnection()
+
+	// If draining, signal HTTP/1.x clients to close the connection after
+	// this response so subsequent requests use the new configuration.
+	if s.drainManager.IsDraining() && !r.ProtoAtLeast(2, 0) {
+		w.Header().Set("Connection", "close")
+	}
 
 	startTime := time.Now()
 


### PR DESCRIPTION
## Summary
- Add `DrainManager` in `internal/agent/server/drain.go` to coordinate graceful connection draining during configuration reloads
- Track active connections via `sync.WaitGroup` with an atomic counter for observability
- On config reload, signal existing connections to finish within a configurable timeout (default 30s) before forcefully closing
- Integrate drain lifecycle into the HTTP server path in `internal/agent/server/http.go`
- Comprehensive unit tests covering drain initiation, timeout behavior, concurrent connections, and edge cases

## Test plan
- [ ] Unit tests pass
- [ ] Build succeeds
- [ ] gofmt clean

Resolves #155