### PR TITLE
[Feature] gRPC-Web to gRPC bridge middleware

### DIFF
--- a/internal/agent/router/grpcweb.go
+++ b/internal/agent/router/grpcweb.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// gRPC-Web content types.
+const (
+	// ContentTypeGRPCWeb is the binary gRPC-Web content type.
+	ContentTypeGRPCWeb = "application/grpc-web"
+
+	// ContentTypeGRPCWebProto is the binary gRPC-Web+proto content type.
+	ContentTypeGRPCWebProto = "application/grpc-web+proto"
+
+	// ContentTypeGRPCWebText is the base64-encoded gRPC-Web content type.
+	ContentTypeGRPCWebText = "application/grpc-web-text"
+
+	// ContentTypeGRPCWebTextProto is the base64-encoded gRPC-Web+proto content type.
+	ContentTypeGRPCWebTextProto = "application/grpc-web-text+proto"
+
+	// ContentTypeGRPC is the standard gRPC content type sent to the backend.
+	ContentTypeGRPC = "application/grpc"
+
+	// grpcWebTrailerFlag is the gRPC frame flag byte indicating a trailer frame (0x80).
+	grpcWebTrailerFlag = 0x80
+)
+
+// GRPCWebConfig holds configuration for the gRPC-Web middleware.
+type GRPCWebConfig struct {
+	// AllowedOrigins specifies origins permitted for CORS preflight.
+	// If empty, no CORS headers are set (the caller should handle CORS separately).
+	AllowedOrigins []string
+
+	// AllowCredentials controls the Access-Control-Allow-Credentials header.
+	AllowCredentials bool
+}
+
+// DefaultGRPCWebConfig returns a sensible default gRPC-Web configuration.
+func DefaultGRPCWebConfig() *GRPCWebConfig {
+	return &GRPCWebConfig{}
+}
+
+// GRPCWebMiddleware translates gRPC-Web requests into standard gRPC requests so
+// that browser clients can communicate with gRPC backends through the proxy.
+// Non-gRPC-Web requests are passed through to the next handler unmodified.
+type GRPCWebMiddleware struct {
+	config *GRPCWebConfig
+	logger *zap.Logger
+}
+
+// NewGRPCWebMiddleware creates a new GRPCWebMiddleware with the given configuration.
+func NewGRPCWebMiddleware(config *GRPCWebConfig, logger *zap.Logger) *GRPCWebMiddleware {
+	if config == nil {
+		config = DefaultGRPCWebConfig()
+	}
+	return &GRPCWebMiddleware{
+		config: config,
+		logger: logger.With(zap.String("component", "grpc-web")),
+	}
+}
+
+// IsGRPCWebRequest reports whether the request carries a gRPC-Web content type.
+func IsGRPCWebRequest(r *http.Request) bool {
+	ct := r.Header.Get("Content-Type")
+	return isGRPCWebContentType(ct)
+}
+
+// isGRPCWebContentType checks if a Content-Type value is a recognised gRPC-Web type.
+func isGRPCWebContentType(ct string) bool {
+	// Strip optional parameters (e.g. charset).
+	if idx := strings.IndexByte(ct, ';'); idx != -1 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+	switch ct {
+	case ContentTypeGRPCWeb, ContentTypeGRPCWebProto,
+		ContentTypeGRPCWebText, ContentTypeGRPCWebTextProto:
+		return true
+	default:
+		return false
+	}
+}
+
+// isTextEncoding returns true when the content type is the base64-encoded text variant.
+func isTextEncoding(ct string) bool {
+	if idx := strings.IndexByte(ct, ';'); idx != -1 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+	return ct == ContentTypeGRPCWebText || ct == ContentTypeGRPCWebTextProto
+}
+
+// Wrap returns an http.Handler that intercepts gRPC-Web requests, translates them
+// into native gRPC, and converts the response back to gRPC-Web format.
+func (m *GRPCWebMiddleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle CORS preflight for gRPC-Web (browsers send OPTIONS).
+		if r.Method == http.MethodOptions && isGRPCWebPreflight(r) {
+			m.handleCORSPreflight(w, r)
+			return
+		}
+
+		if !IsGRPCWebRequest(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		origContentType := r.Header.Get("Content-Type")
+		textMode := isTextEncoding(origContentType)
+
+		m.logger.Debug("translating gRPC-Web request",
+			zap.String("path", r.URL.Path),
+			zap.String("content_type", origContentType),
+			zap.Bool("text_mode", textMode),
+		)
+
+		// Rewrite request Content-Type to standard gRPC.
+		r.Header.Set("Content-Type", ContentTypeGRPC)
+
+		// For the text variant, decode the base64-encoded request body.
+		if textMode {
+			r.Body = io.NopCloser(base64.NewDecoder(base64.StdEncoding, r.Body))
+		}
+
+		// Determine the response content type to send back to the client.
+		respContentType := ContentTypeGRPCWeb
+		if textMode {
+			respContentType = ContentTypeGRPCWebText
+		}
+
+		// Wrap the response writer to capture gRPC trailers and convert them.
+		gw := &grpcWebResponseWriter{
+			ResponseWriter:  w,
+			textMode:        textMode,
+			respContentType: respContentType,
+			bodyBuf:         &bytes.Buffer{},
+		}
+
+		next.ServeHTTP(gw, r)
+
+		// Flush any buffered trailer frame and write final output.
+		gw.finish()
+	})
+}
+
+// isGRPCWebPreflight checks whether an OPTIONS request is a CORS preflight for gRPC-Web.
+func isGRPCWebPreflight(r *http.Request) bool {
+	reqMethod := r.Header.Get("Access-Control-Request-Method")
+	if reqMethod == "" {
+		return false
+	}
+	reqHeaders := r.Header.Get("Access-Control-Request-Headers")
+	// Browsers typically include content-type and x-grpc-web in the preflight.
+	lower := strings.ToLower(reqHeaders)
+	return strings.Contains(lower, "content-type") ||
+		strings.Contains(lower, "x-grpc-web") ||
+		strings.Contains(lower, "x-user-agent")
+}
+
+// handleCORSPreflight writes CORS preflight response headers.
+func (m *GRPCWebMiddleware) handleCORSPreflight(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	allowedOrigin := m.matchOrigin(origin)
+	if allowedOrigin == "" {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers",
+		"Content-Type, X-Grpc-Web, X-User-Agent, Grpc-Timeout, Authorization")
+	w.Header().Set("Access-Control-Max-Age", "86400")
+
+	if m.config.AllowCredentials {
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// matchOrigin returns the allowed origin string if the provided origin is permitted,
+// or an empty string otherwise.
+func (m *GRPCWebMiddleware) matchOrigin(origin string) string {
+	if len(m.config.AllowedOrigins) == 0 {
+		return ""
+	}
+	for _, allowed := range m.config.AllowedOrigins {
+		if allowed == "*" {
+			return "*"
+		}
+		if allowed == origin {
+			return origin
+		}
+	}
+	return ""
+}
+
+// grpcWebResponseWriter intercepts the gRPC response and converts it back to
+// gRPC-Web format. For the text variant, it buffers all binary gRPC frames and
+// base64-encodes the entire body (data frames + trailer frame) as a single
+// contiguous base64 stream, as required by the gRPC-Web specification.
+type grpcWebResponseWriter struct {
+	http.ResponseWriter
+	textMode        bool
+	respContentType string
+	wroteHeader     bool
+	statusCode      int
+	bodyBuf         *bytes.Buffer // accumulates binary gRPC frames
+}
+
+// WriteHeader sets the response content type to the gRPC-Web variant and
+// captures the status code. The actual status code is forwarded during finish().
+func (gw *grpcWebResponseWriter) WriteHeader(code int) {
+	if gw.wroteHeader {
+		return
+	}
+	gw.wroteHeader = true
+	gw.statusCode = code
+}
+
+// Write buffers the binary gRPC frame data. The data is written to the client
+// during finish(), after trailers have been appended.
+func (gw *grpcWebResponseWriter) Write(b []byte) (int, error) {
+	if !gw.wroteHeader {
+		gw.WriteHeader(http.StatusOK)
+	}
+	return gw.bodyBuf.Write(b)
+}
+
+// Flush implements http.Flusher. Since we buffer everything, this is a no-op
+// until finish() is called.
+func (gw *grpcWebResponseWriter) Flush() {
+	// Intentionally a no-op during buffering; flushing happens in finish().
+}
+
+// Hijack implements http.Hijacker.
+func (gw *grpcWebResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := gw.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
+}
+
+// Unwrap returns the underlying ResponseWriter.
+func (gw *grpcWebResponseWriter) Unwrap() http.ResponseWriter {
+	return gw.ResponseWriter
+}
+
+// finish appends the gRPC-Web trailer frame to the buffered body, then writes
+// the complete response to the client. For the text variant, the entire body
+// (data frames + trailer frame) is base64-encoded as a single string.
+func (gw *grpcWebResponseWriter) finish() {
+	// Collect and append trailer frame.
+	trailers := gw.collectTrailers()
+	if len(trailers) > 0 {
+		trailerFrame := buildTrailerFrame(trailers)
+		gw.bodyBuf.Write(trailerFrame)
+	}
+
+	// Set response headers.
+	gw.ResponseWriter.Header().Set("Content-Type", gw.respContentType)
+	gw.ResponseWriter.Header().Set("Access-Control-Expose-Headers",
+		"Grpc-Status, Grpc-Message, Grpc-Status-Details-Bin")
+
+	statusCode := gw.statusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	gw.ResponseWriter.WriteHeader(statusCode)
+
+	// Write the body, base64-encoding if text mode.
+	binaryBody := gw.bodyBuf.Bytes()
+	if gw.textMode && len(binaryBody) > 0 {
+		encoded := base64.StdEncoding.EncodeToString(binaryBody)
+		_, _ = gw.ResponseWriter.Write([]byte(encoded))
+	} else {
+		_, _ = gw.ResponseWriter.Write(binaryBody)
+	}
+
+	if f, ok := gw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// buildTrailerFrame serialises HTTP trailers into a gRPC-Web trailer frame:
+// 1-byte flag (0x80) + 4-byte big-endian length + "key: value\r\n" pairs.
+func buildTrailerFrame(trailers http.Header) []byte {
+	var trailerBuf bytes.Buffer
+	for key, values := range trailers {
+		for _, v := range values {
+			trailerBuf.WriteString(key)
+			trailerBuf.WriteString(": ")
+			trailerBuf.WriteString(v)
+			trailerBuf.WriteString("\r\n")
+		}
+	}
+
+	payload := trailerBuf.Bytes()
+	frame := make([]byte, 5+len(payload))
+	frame[0] = grpcWebTrailerFlag
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(payload)))
+	copy(frame[5:], payload)
+	return frame
+}
+
+// collectTrailers gathers gRPC trailing metadata from the response.
+// It looks for grpc-status, grpc-message, grpc-status-details-bin headers
+// and headers with the "Trailer:" prefix convention.
+func (gw *grpcWebResponseWriter) collectTrailers() http.Header {
+	trailers := make(http.Header)
+
+	for key, values := range gw.ResponseWriter.Header() {
+		lower := strings.ToLower(key)
+		if strings.HasPrefix(lower, "trailer:") {
+			trailerKey := strings.TrimPrefix(lower, "trailer:")
+			trailerKey = strings.TrimSpace(trailerKey)
+			trailers[trailerKey] = values
+			continue
+		}
+		// Capture grpc-status and grpc-message if set as regular headers
+		// (common when the backend is an HTTP/1.1 gRPC server or the response
+		// writer doesn't support true HTTP/2 trailers).
+		if lower == "grpc-status" || lower == "grpc-message" || lower == "grpc-status-details-bin" {
+			trailers[lower] = values
+		}
+	}
+
+	return trailers
+}

--- a/internal/agent/router/grpcweb_test.go
+++ b/internal/agent/router/grpcweb_test.go
@@ -1,0 +1,584 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func testLogger() *zap.Logger {
+	logger, _ := zap.NewDevelopment()
+	return logger
+}
+
+// TestIsGRPCWebRequest_DetectsContentTypes verifies that all four gRPC-Web
+// content types are correctly identified as gRPC-Web requests.
+func TestIsGRPCWebRequest_DetectsContentTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{
+			name:        "application/grpc-web",
+			contentType: ContentTypeGRPCWeb,
+			want:        true,
+		},
+		{
+			name:        "application/grpc-web+proto",
+			contentType: ContentTypeGRPCWebProto,
+			want:        true,
+		},
+		{
+			name:        "application/grpc-web-text",
+			contentType: ContentTypeGRPCWebText,
+			want:        true,
+		},
+		{
+			name:        "application/grpc-web-text+proto",
+			contentType: ContentTypeGRPCWebTextProto,
+			want:        true,
+		},
+		{
+			name:        "with charset parameter",
+			contentType: "application/grpc-web; charset=utf-8",
+			want:        true,
+		},
+		{
+			name:        "standard grpc is not grpc-web",
+			contentType: ContentTypeGRPC,
+			want:        false,
+		},
+		{
+			name:        "regular json",
+			contentType: "application/json",
+			want:        false,
+		},
+		{
+			name:        "empty content type",
+			contentType: "",
+			want:        false,
+		},
+		{
+			name:        "text/html",
+			contentType: "text/html",
+			want:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/test.Service/Method", nil)
+			if tc.contentType != "" {
+				req.Header.Set("Content-Type", tc.contentType)
+			}
+			got := IsGRPCWebRequest(req)
+			if got != tc.want {
+				t.Errorf("IsGRPCWebRequest(%q) = %v, want %v", tc.contentType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGRPCWebMiddleware_PassthroughNonGRPCWeb verifies that requests without
+// gRPC-Web content types are forwarded to the next handler unmodified.
+func TestGRPCWebMiddleware_PassthroughNonGRPCWeb(t *testing.T) {
+	logger := testLogger()
+	mw := NewGRPCWebMiddleware(nil, logger)
+
+	var capturedContentType string
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	handler := mw.Wrap(backend)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/data", strings.NewReader(`{"key":"value"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", result.StatusCode)
+	}
+
+	if capturedContentType != "application/json" {
+		t.Errorf("expected backend to receive application/json, got %q", capturedContentType)
+	}
+
+	body, _ := io.ReadAll(result.Body)
+	if string(body) != "hello" {
+		t.Errorf("expected body 'hello', got %q", string(body))
+	}
+
+	// Content-Type should NOT be rewritten for non-gRPC-Web responses.
+	if ct := result.Header.Get("Content-Type"); ct == ContentTypeGRPCWeb {
+		t.Errorf("non-gRPC-Web response should not have grpc-web content type, got %q", ct)
+	}
+}
+
+// TestGRPCWebMiddleware_ConvertsContentType verifies that the middleware rewrites
+// the request Content-Type from gRPC-Web to standard gRPC, and converts the
+// response Content-Type back to gRPC-Web.
+func TestGRPCWebMiddleware_ConvertsContentType(t *testing.T) {
+	logger := testLogger()
+	mw := NewGRPCWebMiddleware(nil, logger)
+
+	var capturedContentType string
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		w.Header().Set("Grpc-Status", "0")
+		w.Header().Set("Grpc-Message", "OK")
+		w.WriteHeader(http.StatusOK)
+		// Write a minimal gRPC frame: flag(1) + length(4) + payload.
+		frame := buildGRPCFrame(0x00, []byte("response-payload"))
+		_, _ = w.Write(frame)
+	})
+
+	handler := mw.Wrap(backend)
+
+	// Build a minimal gRPC-Web request body (flag + length + payload).
+	reqBody := buildGRPCFrame(0x00, []byte("request-payload"))
+
+	req := httptest.NewRequest(http.MethodPost, "/test.Service/Method", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", ContentTypeGRPCWeb)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	// Backend should receive standard gRPC content type.
+	if capturedContentType != ContentTypeGRPC {
+		t.Errorf("expected backend Content-Type %q, got %q", ContentTypeGRPC, capturedContentType)
+	}
+
+	// Response content type should be gRPC-Web.
+	respCT := result.Header.Get("Content-Type")
+	if respCT != ContentTypeGRPCWeb {
+		t.Errorf("expected response Content-Type %q, got %q", ContentTypeGRPCWeb, respCT)
+	}
+
+	// Verify the CORS exposure headers are set.
+	expose := result.Header.Get("Access-Control-Expose-Headers")
+	if !strings.Contains(expose, "Grpc-Status") {
+		t.Errorf("expected Access-Control-Expose-Headers to contain Grpc-Status, got %q", expose)
+	}
+}
+
+// TestGRPCWebMiddleware_TextVariantBase64 verifies that the grpc-web-text variant
+// decodes base64 request bodies and encodes response bodies in base64.
+func TestGRPCWebMiddleware_TextVariantBase64(t *testing.T) {
+	logger := testLogger()
+	mw := NewGRPCWebMiddleware(nil, logger)
+
+	requestPayload := []byte("text-request-data")
+	responsePayload := []byte("text-response-data")
+
+	var capturedBody []byte
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		w.Header().Set("Grpc-Status", "0")
+		w.WriteHeader(http.StatusOK)
+		frame := buildGRPCFrame(0x00, responsePayload)
+		_, _ = w.Write(frame)
+	})
+
+	handler := mw.Wrap(backend)
+
+	// Build the request: gRPC frame then base64-encode it.
+	reqFrame := buildGRPCFrame(0x00, requestPayload)
+	b64Body := base64.StdEncoding.EncodeToString(reqFrame)
+
+	req := httptest.NewRequest(http.MethodPost, "/test.Service/TextMethod",
+		strings.NewReader(b64Body))
+	req.Header.Set("Content-Type", ContentTypeGRPCWebText)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	// Verify the backend received decoded binary gRPC frame.
+	expectedFrame := buildGRPCFrame(0x00, requestPayload)
+	if !bytes.Equal(capturedBody, expectedFrame) {
+		t.Errorf("backend received unexpected body:\n  got:  %x\n  want: %x", capturedBody, expectedFrame)
+	}
+
+	// Response Content-Type should be grpc-web-text.
+	respCT := result.Header.Get("Content-Type")
+	if respCT != ContentTypeGRPCWebText {
+		t.Errorf("expected response Content-Type %q, got %q", ContentTypeGRPCWebText, respCT)
+	}
+
+	// Response body should be base64-encoded.
+	respBody, _ := io.ReadAll(result.Body)
+	decoded, err := base64.StdEncoding.DecodeString(string(respBody))
+	if err != nil {
+		t.Fatalf("response body is not valid base64: %v", err)
+	}
+
+	// The decoded body should start with the response frame.
+	expectedRespFrame := buildGRPCFrame(0x00, responsePayload)
+	if !bytes.HasPrefix(decoded, expectedRespFrame) {
+		t.Errorf("decoded response does not start with expected frame:\n  got:  %x\n  want prefix: %x",
+			decoded, expectedRespFrame)
+	}
+}
+
+// TestGRPCWebMiddleware_CORSPreflight verifies that OPTIONS preflight requests
+// for gRPC-Web are handled correctly with appropriate CORS headers.
+func TestGRPCWebMiddleware_CORSPreflight(t *testing.T) {
+	logger := testLogger()
+	config := &GRPCWebConfig{
+		AllowedOrigins:   []string{"https://app.example.com", "*"},
+		AllowCredentials: true,
+	}
+	mw := NewGRPCWebMiddleware(config, logger)
+
+	backendCalled := false
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		backendCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := mw.Wrap(backend)
+
+	req := httptest.NewRequest(http.MethodOptions, "/test.Service/Method", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "content-type, x-grpc-web")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if backendCalled {
+		t.Error("backend should not be called for CORS preflight")
+	}
+
+	if result.StatusCode != http.StatusNoContent {
+		t.Errorf("expected status 204, got %d", result.StatusCode)
+	}
+
+	allowOrigin := result.Header.Get("Access-Control-Allow-Origin")
+	if allowOrigin != "https://app.example.com" {
+		t.Errorf("expected Access-Control-Allow-Origin %q, got %q",
+			"https://app.example.com", allowOrigin)
+	}
+
+	allowMethods := result.Header.Get("Access-Control-Allow-Methods")
+	if !strings.Contains(allowMethods, "POST") {
+		t.Errorf("expected Access-Control-Allow-Methods to contain POST, got %q", allowMethods)
+	}
+
+	allowHeaders := result.Header.Get("Access-Control-Allow-Headers")
+	if !strings.Contains(allowHeaders, "Content-Type") {
+		t.Errorf("expected Access-Control-Allow-Headers to contain Content-Type, got %q", allowHeaders)
+	}
+
+	allowCreds := result.Header.Get("Access-Control-Allow-Credentials")
+	if allowCreds != "true" {
+		t.Errorf("expected Access-Control-Allow-Credentials 'true', got %q", allowCreds)
+	}
+}
+
+// TestGRPCWebMiddleware_CORSPreflightForbidden verifies that preflight with
+// an unknown origin is rejected when AllowedOrigins does not match.
+func TestGRPCWebMiddleware_CORSPreflightForbidden(t *testing.T) {
+	logger := testLogger()
+	config := &GRPCWebConfig{
+		AllowedOrigins: []string{"https://trusted.example.com"},
+	}
+	mw := NewGRPCWebMiddleware(config, logger)
+
+	handler := mw.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/test.Service/Method", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusForbidden {
+		t.Errorf("expected status 403 for disallowed origin, got %d", result.StatusCode)
+	}
+}
+
+// TestGRPCWebMiddleware_CORSPreflightNoOrigin verifies that preflight without
+// an Origin header returns 204 without CORS headers.
+func TestGRPCWebMiddleware_CORSPreflightNoOrigin(t *testing.T) {
+	logger := testLogger()
+	config := &GRPCWebConfig{
+		AllowedOrigins: []string{"*"},
+	}
+	mw := NewGRPCWebMiddleware(config, logger)
+
+	handler := mw.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/test.Service/Method", nil)
+	// No Origin header.
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	if result.StatusCode != http.StatusNoContent {
+		t.Errorf("expected status 204, got %d", result.StatusCode)
+	}
+
+	if result.Header.Get("Access-Control-Allow-Origin") != "" {
+		t.Error("expected no CORS headers without Origin")
+	}
+}
+
+// TestGRPCWebMiddleware_CORSWildcardOrigin verifies that wildcard origin returns
+// "*" as the allowed origin.
+func TestGRPCWebMiddleware_CORSWildcardOrigin(t *testing.T) {
+	logger := testLogger()
+	config := &GRPCWebConfig{
+		AllowedOrigins: []string{"*"},
+	}
+	mw := NewGRPCWebMiddleware(config, logger)
+
+	handler := mw.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/test.Service/Method", nil)
+	req.Header.Set("Origin", "https://any-origin.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	allowOrigin := result.Header.Get("Access-Control-Allow-Origin")
+	if allowOrigin != "*" {
+		t.Errorf("expected Access-Control-Allow-Origin '*', got %q", allowOrigin)
+	}
+}
+
+// TestGRPCWebMiddleware_TrailerFrame verifies that gRPC trailers (grpc-status,
+// grpc-message) are serialised as a gRPC-Web trailer frame in the response body.
+func TestGRPCWebMiddleware_TrailerFrame(t *testing.T) {
+	logger := testLogger()
+	mw := NewGRPCWebMiddleware(nil, logger)
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Grpc-Status", "0")
+		w.Header().Set("Grpc-Message", "OK")
+		w.WriteHeader(http.StatusOK)
+		frame := buildGRPCFrame(0x00, []byte("data"))
+		_, _ = w.Write(frame)
+	})
+
+	handler := mw.Wrap(backend)
+
+	req := httptest.NewRequest(http.MethodPost, "/test.Service/Method",
+		bytes.NewReader(buildGRPCFrame(0x00, []byte("req"))))
+	req.Header.Set("Content-Type", ContentTypeGRPCWeb)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	body, _ := io.ReadAll(result.Body)
+
+	// The body should contain the data frame followed by a trailer frame.
+	// Data frame: flag=0x00 + 4-byte length + "data"
+	dataFrame := buildGRPCFrame(0x00, []byte("data"))
+	if !bytes.HasPrefix(body, dataFrame) {
+		t.Errorf("response body should start with data frame, got %x", body[:min(len(body), 20)])
+	}
+
+	// Find the trailer frame after the data frame.
+	trailerPart := body[len(dataFrame):]
+	if len(trailerPart) < 5 {
+		t.Fatalf("expected trailer frame after data frame, remaining bytes: %d", len(trailerPart))
+	}
+
+	// Trailer frame flag should be 0x80.
+	if trailerPart[0] != grpcWebTrailerFlag {
+		t.Errorf("expected trailer flag 0x80, got 0x%02x", trailerPart[0])
+	}
+
+	// Parse trailer length.
+	trailerLen := binary.BigEndian.Uint32(trailerPart[1:5])
+	if int(trailerLen) != len(trailerPart)-5 {
+		t.Errorf("trailer length mismatch: header says %d, actual payload %d",
+			trailerLen, len(trailerPart)-5)
+	}
+
+	// Verify trailer content contains grpc-status.
+	trailerContent := string(trailerPart[5:])
+	if !strings.Contains(trailerContent, "grpc-status: 0") {
+		t.Errorf("trailer should contain 'grpc-status: 0', got %q", trailerContent)
+	}
+	if !strings.Contains(trailerContent, "grpc-message: OK") {
+		t.Errorf("trailer should contain 'grpc-message: OK', got %q", trailerContent)
+	}
+}
+
+// TestGRPCWebMiddleware_NonPreflightOptionsPassthrough verifies that an OPTIONS
+// request that is not a gRPC-Web preflight is passed through to the backend.
+func TestGRPCWebMiddleware_NonPreflightOptionsPassthrough(t *testing.T) {
+	logger := testLogger()
+	mw := NewGRPCWebMiddleware(nil, logger)
+
+	backendCalled := false
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		backendCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := mw.Wrap(backend)
+
+	// OPTIONS without Access-Control-Request-Method is not a preflight.
+	req := httptest.NewRequest(http.MethodOptions, "/api/info", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if !backendCalled {
+		t.Error("non-preflight OPTIONS should be passed to backend")
+	}
+}
+
+// TestGRPCWebMiddleware_GRPCWebProtoContentType verifies that the +proto
+// variant is also correctly handled.
+func TestGRPCWebMiddleware_GRPCWebProtoContentType(t *testing.T) {
+	logger := testLogger()
+	mw := NewGRPCWebMiddleware(nil, logger)
+
+	var capturedContentType string
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := mw.Wrap(backend)
+
+	req := httptest.NewRequest(http.MethodPost, "/test.Service/Method",
+		bytes.NewReader(buildGRPCFrame(0x00, []byte("proto-data"))))
+	req.Header.Set("Content-Type", ContentTypeGRPCWebProto)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if capturedContentType != ContentTypeGRPC {
+		t.Errorf("expected backend Content-Type %q, got %q", ContentTypeGRPC, capturedContentType)
+	}
+
+	result := rec.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	// Response should use the binary grpc-web variant (not text).
+	respCT := result.Header.Get("Content-Type")
+	if respCT != ContentTypeGRPCWeb {
+		t.Errorf("expected response Content-Type %q, got %q", ContentTypeGRPCWeb, respCT)
+	}
+}
+
+// TestIsTextEncoding verifies the text encoding detection helper.
+func TestIsTextEncoding(t *testing.T) {
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{ContentTypeGRPCWebText, true},
+		{ContentTypeGRPCWebTextProto, true},
+		{"application/grpc-web-text; charset=utf-8", true},
+		{ContentTypeGRPCWeb, false},
+		{ContentTypeGRPCWebProto, false},
+		{ContentTypeGRPC, false},
+		{"application/json", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.ct, func(t *testing.T) {
+			got := isTextEncoding(tc.ct)
+			if got != tc.want {
+				t.Errorf("isTextEncoding(%q) = %v, want %v", tc.ct, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGRPCWebMiddleware_DefaultConfig verifies that NewGRPCWebMiddleware
+// handles a nil config gracefully.
+func TestGRPCWebMiddleware_DefaultConfig(t *testing.T) {
+	logger := testLogger()
+	mw := NewGRPCWebMiddleware(nil, logger)
+	if mw == nil {
+		t.Fatal("NewGRPCWebMiddleware(nil, logger) returned nil")
+	}
+	if mw.config == nil {
+		t.Fatal("expected default config, got nil")
+	}
+}
+
+// buildGRPCFrame constructs a gRPC length-prefixed frame:
+// 1-byte flag + 4-byte big-endian length + payload.
+func buildGRPCFrame(flag byte, payload []byte) []byte {
+	frame := make([]byte, 5+len(payload))
+	frame[0] = flag
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(payload)))
+	copy(frame[5:], payload)
+	return frame
+}


### PR DESCRIPTION
## Summary
- Add gRPC-Web bridge middleware that translates gRPC-Web requests (from browser clients) into standard gRPC requests for upstream backends
- Handles both `application/grpc-web` and `application/grpc-web-text` (base64-encoded) content types
- Supports gRPC-Web trailers-in-body framing and re-encodes responses for gRPC-Web clients
- New `grpcweb.go` in `internal/agent/router/` with full protocol translation
- Comprehensive test coverage in `grpcweb_test.go` (584 lines of tests)

## Test plan
- [ ] Unit tests pass
- [ ] Build succeeds
- [ ] gofmt clean

Resolves #163