### PR TITLE
[Security] Reduce agent container privilege requirements

### DIFF
--- a/charts/novaedge-agent/values.yaml
+++ b/charts/novaedge-agent/values.yaml
@@ -89,14 +89,19 @@ podLabels: {}
 # -- Pod security context
 podSecurityContext: {}
 
-# -- Container security context (agents require elevated privileges)
+# -- Container security context (agents require specific capabilities for VIP management)
 securityContext:
   capabilities:
     add:
       - NET_ADMIN
       - NET_RAW
       - NET_BIND_SERVICE
-  privileged: true
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- Resource limits and requests
 resources:

--- a/charts/novaedge/templates/agent-daemonset.yaml
+++ b/charts/novaedge/templates/agent-daemonset.yaml
@@ -95,12 +95,17 @@ spec:
         resources:
           {{- toYaml .Values.agent.resources | nindent 10 }}
         securityContext:
-          privileged: true
           capabilities:
             add:
             - NET_ADMIN
             - NET_RAW
             - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - name: certs
           mountPath: /etc/novaedge/certs


### PR DESCRIPTION
## Summary
- Remove `privileged: true` from agent containers in both Helm charts
- Add `capabilities.drop: [ALL]` then add back only NET_ADMIN, NET_RAW, NET_BIND_SERVICE
- Add `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`
- Apply RuntimeDefault seccomp profile

## Test plan
- [x] YAML validated
- [x] No remaining `privileged: true` in charts

Resolves #196