### PR TITLE
[Performance] Pre-compile route expressions at config time

### DIFF
--- a/internal/agent/router/grpcweb_test.go
+++ b/internal/agent/router/grpcweb_test.go
@@ -25,14 +25,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"go.uber.org/zap"
 )
-
-func testLogger() *zap.Logger {
-	logger, _ := zap.NewDevelopment()
-	return logger
-}
 
 // TestIsGRPCWebRequest_DetectsContentTypes verifies that all four gRPC-Web
 // content types are correctly identified as gRPC-Web requests.

--- a/internal/agent/router/router.go
+++ b/internal/agent/router/router.go
@@ -213,6 +213,26 @@ func (r *Router) ApplyConfig(ctx context.Context, snapshot *config.Snapshot) err
 					Filters:        buildFilters(rule.Filters),
 				}
 
+				// Pre-compile boolean routing expression at config time
+				// to avoid per-request parsing overhead (same pattern as
+				// compileHeaderRegexes and createPathMatcher above).
+				if expr := route.GetExpression(); expr != "" {
+					compiled, err := CompileExpression(expr)
+					if err != nil {
+						r.logger.Error("Failed to compile route expression, skipping",
+							zap.String("route", route.Name),
+							zap.String("expression", expr),
+							zap.Error(err),
+						)
+					} else {
+						entry.Expression = compiled
+						r.logger.Debug("Compiled route expression",
+							zap.String("route", route.Name),
+							zap.String("expression", expr),
+						)
+					}
+				}
+
 				// Pre-compute cluster keys for all backend refs to avoid
 				// per-request string concatenation in the forwarding hot path.
 				if len(rule.BackendRefs) > 0 {


### PR DESCRIPTION
## Summary
- Pre-compile boolean routing expressions in ApplyConfig() and cache in RouteEntry
- Eliminates per-request expression parsing overhead
- Follows existing pattern of header regex pre-compilation

## Test plan
- [x] All router tests pass
- [x] `go build ./...` succeeds
- [x] `gofmt -s -w` applied

Resolves #197