### PR TITLE
[Security] Add InsecureSkipVerify audit metrics and logging

### DIFF
--- a/internal/agent/metrics/endpoint_metrics.go
+++ b/internal/agent/metrics/endpoint_metrics.go
@@ -188,6 +188,18 @@ var (
 		},
 		[]string{"cluster"},
 	)
+
+	// InsecureBackendConnectionsTotal tracks backend connections with InsecureSkipVerify enabled.
+	// This is a security audit metric to monitor backends bypassing TLS certificate verification.
+	InsecureBackendConnectionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "novaedge",
+			Subsystem: "upstream",
+			Name:      "insecure_backend_connections_total",
+			Help:      "Total number of backend connections with InsecureSkipVerify enabled.",
+		},
+		[]string{"backend"},
+	)
 )
 
 // RecordBackendRequest records a backend request
@@ -268,6 +280,7 @@ func CleanupClusterMetrics(cluster string) {
 	PoolHitsTotal.DeleteLabelValues(cluster)
 	PoolMissesTotal.DeleteLabelValues(cluster)
 	EndpointsEjected.DeleteLabelValues(cluster)
+	InsecureBackendConnectionsTotal.DeleteLabelValues(cluster)
 }
 
 // CleanupEndpointMetrics removes tracking for a single endpoint in a cluster.

--- a/internal/agent/upstream/pool.go
+++ b/internal/agent/upstream/pool.go
@@ -133,14 +133,13 @@ func NewPool(ctx context.Context, cluster *pb.Cluster, endpoints []*pb.Endpoint,
 	}
 
 	// Configure backend TLS if enabled
+	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
 	if cluster.Tls != nil && cluster.Tls.Enabled {
-		transport.TLSClientConfig = createBackendTLSConfig(cluster.Tls, logger)
+		transport.TLSClientConfig = createBackendTLSConfig(cluster.Tls, clusterKey, logger)
 	}
 
 	// Create context for health checker derived from parent
 	poolCtx, cancel := context.WithCancel(ctx)
-
-	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
 
 	pool := &Pool{
 		logger:     logger,
@@ -164,6 +163,15 @@ func NewPool(ctx context.Context, cluster *pb.Cluster, endpoints []*pb.Endpoint,
 
 	// Start metrics collection goroutine
 	go pool.updateMetrics()
+
+	// Log startup audit message for backends with InsecureSkipVerify
+	if cluster.Tls != nil && cluster.Tls.Enabled && cluster.Tls.InsecureSkipVerify {
+		logger.Error("SECURITY AUDIT: Pool started for backend with InsecureSkipVerify enabled — "+
+			"TLS certificate verification is disabled for all connections to this backend",
+			zap.String("backend", clusterKey),
+			zap.Int("endpoint_count", len(endpoints)),
+		)
+	}
 
 	return pool
 }
@@ -426,16 +434,22 @@ func (p *Pool) GetClusterKey() string {
 }
 
 // createBackendTLSConfig creates a TLS config for backend connections
-func createBackendTLSConfig(backendTLS *pb.BackendTLS, logger *zap.Logger) *tls.Config {
+func createBackendTLSConfig(backendTLS *pb.BackendTLS, clusterKey string, logger *zap.Logger) *tls.Config {
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
 
 	// InsecureSkipVerify is an explicit user configuration for backend connections
-	// where the backend may use self-signed certificates
+	// where the backend may use self-signed certificates.
+	// This is a security risk: certificate verification is completely disabled,
+	// making the connection vulnerable to man-in-the-middle attacks.
 	if backendTLS.InsecureSkipVerify {
 		tlsConfig.InsecureSkipVerify = true
-		logger.Warn("Backend TLS configured with InsecureSkipVerify=true, certificate verification disabled")
+		logger.Error("SECURITY AUDIT: Backend TLS configured with InsecureSkipVerify=true, "+
+			"certificate verification disabled — connection is vulnerable to MITM attacks",
+			zap.String("backend", clusterKey),
+		)
+		metrics.InsecureBackendConnectionsTotal.WithLabelValues(clusterKey).Inc()
 	}
 
 	// Load CA certificate if provided


### PR DESCRIPTION
## Summary
- Add `novaedge_upstream_insecure_backend_connections_total` Prometheus counter
- Upgrade InsecureSkipVerify log from Warn to Error with MITM context
- Add startup audit message for backends with InsecureSkipVerify enabled

## Test plan
- [x] All upstream tests pass
- [x] `go build ./...` succeeds
- [x] `gofmt -s -w` applied

Resolves #199