### PR TITLE
[Security] Add X-Forwarded-For spoofing protection

### DIFF
--- a/internal/agent/policy/ipfilter.go
+++ b/internal/agent/policy/ipfilter.go
@@ -21,8 +21,22 @@ import (
 	"net/http"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/piwi3910/novaedge/internal/agent/metrics"
 )
+
+// defaultMaxXFFDepth is the default maximum number of X-Forwarded-For entries to process.
+// Headers with more entries than this limit are truncated to the rightmost N entries,
+// preventing header bloat attacks.
+const defaultMaxXFFDepth = 10
+
+// isBogonIP returns true if the IP is a private, loopback, or link-local address
+// (RFC 1918, RFC 4193, loopback, link-local). These IPs should not appear as
+// client IPs in X-Forwarded-For unless from trusted proxies.
+func isBogonIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
 
 // Global list of trusted proxy IP ranges (can be configured at package level)
 var trustedProxyCIDRs []*net.IPNet
@@ -87,25 +101,57 @@ func extractClientIP(r *http.Request) string {
 	// Check X-Forwarded-For header
 	xff := r.Header.Get("X-Forwarded-For")
 	if xff != "" {
-		// X-Forwarded-For format: client, proxy1, proxy2, ...
-		// We need to find the rightmost IP that is NOT a trusted proxy
-		// This is the real client IP
 		ips := strings.Split(xff, ",")
+
+		// Warn on suspiciously large XFF headers
+		if len(ips) > defaultMaxXFFDepth {
+			zap.L().Warn("X-Forwarded-For header exceeds max depth, truncating",
+				zap.Int("entries", len(ips)),
+				zap.Int("maxDepth", defaultMaxXFFDepth),
+				zap.String("remoteAddr", r.RemoteAddr),
+			)
+			// Only process the rightmost N entries (closest to us, most trustworthy)
+			ips = ips[len(ips)-defaultMaxXFFDepth:]
+		}
 
 		// Iterate from right to left, skipping trusted proxies
 		for i := len(ips) - 1; i >= 0; i-- {
-			ip := strings.TrimSpace(ips[i])
-			if !isGlobalTrustedProxy(ip) {
-				// Found the rightmost non-proxy IP
-				return ip
+			ipStr := strings.TrimSpace(ips[i])
+
+			// Validate IP format to prevent spoofed garbage values
+			parsed := net.ParseIP(ipStr)
+			if parsed == nil {
+				zap.L().Warn("unparseable IP in X-Forwarded-For header",
+					zap.String("value", ipStr),
+					zap.String("remoteAddr", r.RemoteAddr),
+				)
+				continue
 			}
+
+			if isGlobalTrustedProxy(ipStr) {
+				continue
+			}
+
+			// Skip bogon/private IPs unless they are from trusted proxies
+			if isBogonIP(parsed) {
+				continue
+			}
+
+			return ipStr
 		}
 	}
 
 	// Check X-Real-IP header as fallback
 	xri := r.Header.Get("X-Real-IP")
 	if xri != "" {
-		return xri
+		// Validate X-Real-IP format
+		if parsed := net.ParseIP(xri); parsed != nil {
+			return xri
+		}
+		zap.L().Warn("unparseable X-Real-IP header",
+			zap.String("value", xri),
+			zap.String("remoteAddr", r.RemoteAddr),
+		)
 	}
 
 	// Fall back to RemoteAddr
@@ -276,25 +322,57 @@ func (f *IPFilter) extractClientIP(r *http.Request) string {
 	// Check X-Forwarded-For header
 	xff := r.Header.Get("X-Forwarded-For")
 	if xff != "" {
-		// X-Forwarded-For format: client, proxy1, proxy2, ...
-		// We need to find the rightmost IP that is NOT a trusted proxy
-		// This is the real client IP
 		ips := strings.Split(xff, ",")
+
+		// Warn on suspiciously large XFF headers
+		if len(ips) > defaultMaxXFFDepth {
+			zap.L().Warn("X-Forwarded-For header exceeds max depth, truncating",
+				zap.Int("entries", len(ips)),
+				zap.Int("maxDepth", defaultMaxXFFDepth),
+				zap.String("remoteAddr", r.RemoteAddr),
+			)
+			// Only process the rightmost N entries (closest to us, most trustworthy)
+			ips = ips[len(ips)-defaultMaxXFFDepth:]
+		}
 
 		// Iterate from right to left, skipping trusted proxies
 		for i := len(ips) - 1; i >= 0; i-- {
-			ip := strings.TrimSpace(ips[i])
-			if !f.isTrustedProxy(ip) {
-				// Found the rightmost non-proxy IP
-				return ip
+			ipStr := strings.TrimSpace(ips[i])
+
+			// Validate IP format to prevent spoofed garbage values
+			parsed := net.ParseIP(ipStr)
+			if parsed == nil {
+				zap.L().Warn("unparseable IP in X-Forwarded-For header",
+					zap.String("value", ipStr),
+					zap.String("remoteAddr", r.RemoteAddr),
+				)
+				continue
 			}
+
+			if f.isTrustedProxy(ipStr) {
+				continue
+			}
+
+			// Skip bogon/private IPs unless they are from trusted proxies
+			if isBogonIP(parsed) {
+				continue
+			}
+
+			return ipStr
 		}
 	}
 
 	// Check X-Real-IP header as fallback
 	xri := r.Header.Get("X-Real-IP")
 	if xri != "" {
-		return xri
+		// Validate X-Real-IP format
+		if parsed := net.ParseIP(xri); parsed != nil {
+			return xri
+		}
+		zap.L().Warn("unparseable X-Real-IP header",
+			zap.String("value", xri),
+			zap.String("remoteAddr", r.RemoteAddr),
+		)
 	}
 
 	// Fall back to RemoteAddr

--- a/internal/agent/policy/ipfilter_test.go
+++ b/internal/agent/policy/ipfilter_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package policy
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -497,6 +499,242 @@ func TestSetTrustedProxies(t *testing.T) {
 		err := filter.SetTrustedProxies([]string{"not-an-ip"})
 		if err == nil {
 			t.Error("Expected error for invalid IP")
+		}
+	})
+}
+
+func TestIsBogonIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{"loopback IPv4", "127.0.0.1", true},
+		{"loopback IPv6", "::1", true},
+		{"private 10.x", "10.0.0.1", true},
+		{"private 172.16.x", "172.16.0.1", true},
+		{"private 192.168.x", "192.168.1.1", true},
+		{"link-local unicast", "169.254.1.1", true},
+		{"link-local multicast", "224.0.0.1", true},
+		{"public IP", "8.8.8.8", false},
+		{"public IP 2", "1.2.3.4", false},
+		{"public IPv6", "2001:db8::1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("Failed to parse test IP: %s", tt.ip)
+			}
+			result := isBogonIP(ip)
+			if result != tt.expected {
+				t.Errorf("isBogonIP(%s) = %v, want %v", tt.ip, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractClientIPBogonFiltering(t *testing.T) {
+	// Setup global trusted proxies
+	if err := SetGlobalTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		trustedProxyCIDRs = nil
+	}()
+
+	t.Run("bogon IP in XFF is skipped", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", "1.2.3.4, 192.168.1.100")
+
+		ip := extractClientIP(req)
+		if ip != "1.2.3.4" {
+			t.Errorf("Expected 1.2.3.4 (skipping bogon 192.168.1.100), got %s", ip)
+		}
+	})
+
+	t.Run("all bogon IPs in XFF falls back to RemoteAddr", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", "192.168.1.1, 172.16.0.1")
+
+		ip := extractClientIP(req)
+		if ip != "10.0.0.1" {
+			t.Errorf("Expected 10.0.0.1 (RemoteAddr fallback), got %s", ip)
+		}
+	})
+
+	t.Run("loopback in XFF is skipped", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", "5.6.7.8, 127.0.0.1")
+
+		ip := extractClientIP(req)
+		if ip != "5.6.7.8" {
+			t.Errorf("Expected 5.6.7.8 (skipping loopback), got %s", ip)
+		}
+	})
+}
+
+func TestExtractClientIPValidation(t *testing.T) {
+	// Setup global trusted proxies
+	if err := SetGlobalTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		trustedProxyCIDRs = nil
+	}()
+
+	t.Run("unparseable IP in XFF is skipped", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", "1.2.3.4, not-an-ip")
+
+		ip := extractClientIP(req)
+		if ip != "1.2.3.4" {
+			t.Errorf("Expected 1.2.3.4 (skipping invalid entry), got %s", ip)
+		}
+	})
+
+	t.Run("all unparseable IPs in XFF falls back to RemoteAddr", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", "garbage, not-an-ip, %%%")
+
+		ip := extractClientIP(req)
+		if ip != "10.0.0.1" {
+			t.Errorf("Expected 10.0.0.1 (RemoteAddr fallback), got %s", ip)
+		}
+	})
+
+	t.Run("unparseable X-Real-IP falls back to RemoteAddr", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Real-IP", "not-an-ip")
+
+		ip := extractClientIP(req)
+		if ip != "10.0.0.1" {
+			t.Errorf("Expected 10.0.0.1 (RemoteAddr fallback for invalid X-Real-IP), got %s", ip)
+		}
+	})
+}
+
+func TestExtractClientIPMaxDepth(t *testing.T) {
+	// Setup global trusted proxies
+	if err := SetGlobalTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		trustedProxyCIDRs = nil
+	}()
+
+	t.Run("XFF within depth limit is fully processed", func(t *testing.T) {
+		// Build an XFF with exactly defaultMaxXFFDepth entries
+		entries := make([]string, defaultMaxXFFDepth)
+		for i := range entries {
+			entries[i] = "10.0.0.2" // trusted proxy IPs
+		}
+		entries[0] = "5.6.7.8" // real client at leftmost position
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", strings.Join(entries, ", "))
+
+		ip := extractClientIP(req)
+		if ip != "5.6.7.8" {
+			t.Errorf("Expected 5.6.7.8 (client IP within depth limit), got %s", ip)
+		}
+	})
+
+	t.Run("XFF exceeding depth limit is truncated to rightmost entries", func(t *testing.T) {
+		// Build an XFF with more entries than the limit
+		entries := make([]string, defaultMaxXFFDepth+5)
+		for i := range entries {
+			entries[i] = "10.0.0.2" // trusted proxy IPs
+		}
+		// Place a public IP at position 0 (leftmost, will be truncated away)
+		entries[0] = "5.6.7.8"
+		// Place a public IP within the rightmost N entries
+		entries[len(entries)-3] = "9.8.7.6"
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", strings.Join(entries, ", "))
+
+		ip := extractClientIP(req)
+		if ip != "9.8.7.6" {
+			t.Errorf("Expected 9.8.7.6 (IP within truncated window), got %s", ip)
+		}
+	})
+
+	t.Run("truncated XFF loses leftmost client IP", func(t *testing.T) {
+		// Build an XFF that exceeds the limit where the only public IP is outside the window
+		entries := make([]string, defaultMaxXFFDepth+5)
+		entries[0] = "5.6.7.8" // real client - will be truncated
+		for i := 1; i < len(entries); i++ {
+			entries[i] = "10.0.0.2" // trusted proxy IPs
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", strings.Join(entries, ", "))
+
+		ip := extractClientIP(req)
+		// The real client IP was truncated, so it falls back to RemoteAddr
+		if ip != "10.0.0.1" {
+			t.Errorf("Expected 10.0.0.1 (RemoteAddr fallback after truncation), got %s", ip)
+		}
+	})
+}
+
+func TestIPFilterExtractClientIPBogonFiltering(t *testing.T) {
+	t.Run("bogon IP in XFF is skipped", func(t *testing.T) {
+		filter, _ := NewIPAllowListFilter([]string{"0.0.0.0/0"})
+		if err := filter.SetTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", "1.2.3.4, 192.168.1.100")
+
+		ip := filter.extractClientIP(req)
+		if ip != "1.2.3.4" {
+			t.Errorf("Expected 1.2.3.4 (skipping bogon), got %s", ip)
+		}
+	})
+
+	t.Run("unparseable IP in XFF is skipped", func(t *testing.T) {
+		filter, _ := NewIPAllowListFilter([]string{"0.0.0.0/0"})
+		if err := filter.SetTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Forwarded-For", "1.2.3.4, garbage-value")
+
+		ip := filter.extractClientIP(req)
+		if ip != "1.2.3.4" {
+			t.Errorf("Expected 1.2.3.4 (skipping invalid), got %s", ip)
+		}
+	})
+
+	t.Run("unparseable X-Real-IP falls back to RemoteAddr", func(t *testing.T) {
+		filter, _ := NewIPAllowListFilter([]string{"0.0.0.0/0"})
+		if err := filter.SetTrustedProxies([]string{"10.0.0.0/8"}); err != nil {
+			t.Fatal(err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = testTrustedProxyAddr
+		req.Header.Set("X-Real-IP", "not-valid")
+
+		ip := filter.extractClientIP(req)
+		if ip != "10.0.0.1" {
+			t.Errorf("Expected 10.0.0.1 (RemoteAddr fallback), got %s", ip)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Add IP format validation via net.ParseIP in both extractClientIP implementations
- Add max XFF header depth limit (default 10) to prevent header bloat attacks
- Add bogon/private IP filtering via isBogonIP helper
- Add warning logs for suspicious XFF patterns
- 6 new tests covering validation, depth limiting, and bogon filtering

## Test plan
- [x] All policy tests pass
- [x] `go build ./...` succeeds
- [x] `gofmt -s -w` applied

Resolves #200