### PR TITLE
[Performance] Reduce metrics cardinality with status class bucketing

### DIFF
--- a/internal/agent/metrics/cluster_metrics.go
+++ b/internal/agent/metrics/cluster_metrics.go
@@ -120,7 +120,7 @@ var (
 			Name: "novaedge_http3_requests_total",
 			Help: "Total number of HTTP/3 requests",
 		},
-		[]string{"method", "status"},
+		[]string{"method", "status_class"},
 	)
 
 	// QUICStreamsActive tracks active QUIC streams

--- a/internal/agent/metrics/metrics.go
+++ b/internal/agent/metrics/metrics.go
@@ -175,7 +175,7 @@ var (
 			Name: "novaedge_http_requests_total",
 			Help: "Total number of HTTP requests",
 		},
-		[]string{"method", "status", "cluster"},
+		[]string{"method", "status_class", "cluster"},
 	)
 
 	// HTTPRequestDuration tracks HTTP request duration
@@ -197,9 +197,29 @@ var (
 	)
 )
 
+// StatusClass converts an HTTP status code to a bounded class label.
+// The returned values are "1xx", "2xx", "3xx", "4xx", or "5xx".
+// Unknown or out-of-range codes return "unknown".
+func StatusClass(code int) string {
+	switch {
+	case code >= 100 && code < 200:
+		return "1xx"
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 300 && code < 400:
+		return "3xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500 && code < 600:
+		return "5xx"
+	default:
+		return "unknown"
+	}
+}
+
 // RecordHTTPRequest records an HTTP request
-func RecordHTTPRequest(method, status, cluster string, duration float64) {
-	HTTPRequestsTotal.WithLabelValues(method, status, cluster).Inc()
+func RecordHTTPRequest(method, statusClass, cluster string, duration float64) {
+	HTTPRequestsTotal.WithLabelValues(method, statusClass, cluster).Inc()
 	HTTPRequestDuration.WithLabelValues(method, cluster).Observe(duration)
 }
 

--- a/internal/agent/metrics/otel_exporter.go
+++ b/internal/agent/metrics/otel_exporter.go
@@ -130,14 +130,14 @@ func (e *OTelExporter) MeterProvider() *metric.MeterProvider {
 // RecordHTTPRequest records an HTTP request in the OTel metric instruments.
 // This should be called alongside the Prometheus RecordHTTPRequest function
 // so that both exporters receive the same data.
-func (e *OTelExporter) RecordHTTPRequest(ctx context.Context, method, status, cluster string, duration float64) {
+func (e *OTelExporter) RecordHTTPRequest(ctx context.Context, method, statusClass, cluster string, duration float64) {
 	if !e.started || e.shutdown {
 		return
 	}
 
 	attrs := otelmetric.WithAttributes(
 		attribute.String("method", method),
-		attribute.String("status", status),
+		attribute.String("status_class", statusClass),
 		attribute.String("cluster", cluster),
 	)
 	e.httpRequestsTotal.Add(ctx, 1, attrs)

--- a/internal/agent/metrics/otel_exporter_test.go
+++ b/internal/agent/metrics/otel_exporter_test.go
@@ -226,7 +226,7 @@ func TestOTelExporterStartAndShutdownGRPC(t *testing.T) {
 	}
 
 	// Record some metrics to ensure instruments work without panic.
-	exporter.RecordHTTPRequest(ctx, "GET", "200", "test-cluster", 0.05)
+	exporter.RecordHTTPRequest(ctx, "GET", "2xx", "test-cluster", 0.05)
 	exporter.RecordInFlightChange(ctx, 1)
 	exporter.RecordInFlightChange(ctx, -1)
 	exporter.RecordUpstreamDuration(ctx, "test-cluster", "10.0.0.1:8080", 0.03)
@@ -261,7 +261,7 @@ func TestOTelExporterStartAndShutdownHTTP(t *testing.T) {
 	}
 
 	// Record some metrics.
-	exporter.RecordHTTPRequest(ctx, "POST", "201", "api-cluster", 0.12)
+	exporter.RecordHTTPRequest(ctx, "POST", "2xx", "api-cluster", 0.12)
 	exporter.RecordUpstreamDuration(ctx, "api-cluster", "10.0.0.2:9090", 0.08)
 
 	// Shutdown may return a connection error when no collector is running;
@@ -362,7 +362,7 @@ func TestOTelExporterRecordWithoutStart(t *testing.T) {
 
 	// These should not panic even though the exporter has not been started.
 	ctx := context.Background()
-	exporter.RecordHTTPRequest(ctx, "GET", "200", "test", 0.01)
+	exporter.RecordHTTPRequest(ctx, "GET", "2xx", "test", 0.01)
 	exporter.RecordInFlightChange(ctx, 1)
 	exporter.RecordUpstreamDuration(ctx, "test", "10.0.0.1:80", 0.05)
 }

--- a/internal/agent/router/router.go
+++ b/internal/agent/router/router.go
@@ -480,7 +480,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Defer metrics and span status recording
 	defer func() {
 		duration := time.Since(startTime).Seconds()
-		statusCode := statusString(wrappedWriter.statusCode)
+		statusClass := metrics.StatusClass(wrappedWriter.statusCode)
 
 		// Record span status based on HTTP status code (only if sampled)
 		if span.IsRecording() {
@@ -497,7 +497,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 
 		// We'll set cluster in handleRoute, for now use "unknown"
-		metrics.RecordHTTPRequest(req.Method, statusCode, "unknown", duration)
+		metrics.RecordHTTPRequest(req.Method, statusClass, "unknown", duration)
 
 		// Record access log entry if access logging is enabled
 		if r.accessLog != nil && r.accessLog.IsEnabled() {

--- a/internal/agent/server/http3.go
+++ b/internal/agent/server/http3.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/piwi3910/novaedge/internal/agent/metrics"
@@ -54,7 +53,7 @@ func NewHTTP3Server(logger *zap.Logger, port int32, tlsConfig *tls.Config, quicC
 		rw := &http3ResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 		handler.ServeHTTP(rw, r)
 
-		metrics.HTTP3RequestsTotal.WithLabelValues(r.Method, strconv.Itoa(rw.statusCode)).Inc()
+		metrics.HTTP3RequestsTotal.WithLabelValues(r.Method, metrics.StatusClass(rw.statusCode)).Inc()
 	})
 
 	return &HTTP3Server{


### PR DESCRIPTION
## Summary
- Replace high-cardinality `status` label (100+ values) with bounded `status_class` label (5 values: 1xx/2xx/3xx/4xx/5xx)
- Add `StatusClass(code int) string` helper function in metrics package
- Update all callers in router, server/http3, and OTel exporter

## Test plan
- [x] All existing tests updated and passing
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -s -w` applied

Resolves #204