### PR TITLE
[Security] Add configurable fail-closed mode for WAF

### DIFF
--- a/api/proto/config.proto
+++ b/api/proto/config.proto
@@ -660,6 +660,7 @@ message WAFConfig {
   string rules_config_map_ref = 5; // Reference to ConfigMap containing rules
   repeated string rule_exclusions = 6; // Rule IDs to exclude
   repeated string custom_rules = 7; // Inline custom rules
+  string fail_mode = 8; // "closed" (default) or "open" - behavior on WAF processing errors
 }
 
 // WASMPluginConfig defines WASM plugin settings in a policy

--- a/internal/agent/metrics/waf_metrics.go
+++ b/internal/agent/metrics/waf_metrics.go
@@ -48,4 +48,13 @@ var (
 			Buckets: []float64{1, 2, 3, 5, 10, 15, 25, 50, 100},
 		},
 	)
+
+	// WAFProcessingErrorsTotal tracks WAF processing errors with fail mode and action labels
+	WAFProcessingErrorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "novaedge_waf_processing_errors_total",
+			Help: "Total number of WAF processing errors, labeled by fail mode and action taken",
+		},
+		[]string{"fail_mode", "action"},
+	)
 )

--- a/internal/agent/policy/waf.go
+++ b/internal/agent/policy/waf.go
@@ -33,12 +33,23 @@ import (
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
+// WAFFailMode represents how the WAF behaves when processing errors occur
+type WAFFailMode string
+
+const (
+	// WAFFailClosed blocks requests when WAF processing errors occur (security-first default)
+	WAFFailClosed WAFFailMode = "closed"
+	// WAFFailOpen allows requests through when WAF processing errors occur
+	WAFFailOpen WAFFailMode = "open"
+)
+
 // WAFEngine wraps the Coraza WAF engine with NovaEdge-specific configuration
 type WAFEngine struct {
-	waf    coraza.WAF
-	config *pb.WAFConfig
-	logger *zap.Logger
-	mu     sync.RWMutex
+	waf      coraza.WAF
+	config   *pb.WAFConfig
+	failMode WAFFailMode
+	logger   *zap.Logger
+	mu       sync.RWMutex
 }
 
 // NewWAFEngine creates a new WAF engine from protobuf configuration
@@ -66,10 +77,17 @@ func NewWAFEngine(config *pb.WAFConfig, logger *zap.Logger) (*WAFEngine, error) 
 		return nil, fmt.Errorf("failed to create WAF engine: %w", err)
 	}
 
+	// Determine fail mode: default to fail-closed (security-first)
+	failMode := WAFFailClosed
+	if strings.EqualFold(config.GetFailMode(), "open") {
+		failMode = WAFFailOpen
+	}
+
 	return &WAFEngine{
-		waf:    waf,
-		config: config,
-		logger: logger,
+		waf:      waf,
+		config:   config,
+		failMode: failMode,
+		logger:   logger,
 	}, nil
 }
 
@@ -217,6 +235,11 @@ func (w *WAFEngine) logInterruption(interruption *types.Interruption, r *http.Re
 	)
 }
 
+// GetFailMode returns the configured fail mode for the WAF engine
+func (w *WAFEngine) GetFailMode() WAFFailMode {
+	return w.failMode
+}
+
 // HandleWAF is HTTP middleware for WAF protection
 func HandleWAF(engine *WAFEngine) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -228,8 +251,27 @@ func HandleWAF(engine *WAFEngine) func(http.Handler) http.Handler {
 
 			interruption, err := engine.ProcessRequest(r)
 			if err != nil {
-				engine.logger.Error("WAF processing error", zap.Error(err))
-				// Allow request through on WAF error (fail open)
+				failMode := string(engine.failMode)
+				if engine.failMode == WAFFailClosed {
+					// Fail-closed: block the request on WAF processing error
+					metrics.WAFProcessingErrorsTotal.WithLabelValues(failMode, "blocked").Inc()
+					engine.logger.Error("WAF processing error, blocking request (fail-closed)",
+						zap.Error(err),
+						zap.String("method", r.Method),
+						zap.String("path", r.URL.Path),
+						zap.String("remote_addr", r.RemoteAddr),
+					)
+					http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+					return
+				}
+				// Fail-open: allow request through but log a warning
+				metrics.WAFProcessingErrorsTotal.WithLabelValues(failMode, "allowed").Inc()
+				engine.logger.Warn("WAF processing error, allowing request (fail-open)",
+					zap.Error(err),
+					zap.String("method", r.Method),
+					zap.String("path", r.URL.Path),
+					zap.String("remote_addr", r.RemoteAddr),
+				)
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/agent/policy/waf_test.go
+++ b/internal/agent/policy/waf_test.go
@@ -512,6 +512,105 @@ func TestGetCRSRules_LevelCoverage(t *testing.T) {
 	}
 }
 
+func TestNewWAFEngine_DefaultFailMode(t *testing.T) {
+	logger := zap.NewNop()
+	config := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "prevention",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+	}
+
+	engine, err := NewWAFEngine(config, logger)
+	if err != nil {
+		t.Fatalf("failed to create WAF engine: %v", err)
+	}
+
+	if engine.GetFailMode() != WAFFailClosed {
+		t.Errorf("expected default fail mode to be closed, got %s", engine.GetFailMode())
+	}
+}
+
+func TestNewWAFEngine_FailClosedExplicit(t *testing.T) {
+	logger := zap.NewNop()
+	config := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "prevention",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+		FailMode:         "closed",
+	}
+
+	engine, err := NewWAFEngine(config, logger)
+	if err != nil {
+		t.Fatalf("failed to create WAF engine: %v", err)
+	}
+
+	if engine.GetFailMode() != WAFFailClosed {
+		t.Errorf("expected fail mode closed, got %s", engine.GetFailMode())
+	}
+}
+
+func TestNewWAFEngine_FailOpen(t *testing.T) {
+	logger := zap.NewNop()
+	config := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "prevention",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+		FailMode:         "open",
+	}
+
+	engine, err := NewWAFEngine(config, logger)
+	if err != nil {
+		t.Fatalf("failed to create WAF engine: %v", err)
+	}
+
+	if engine.GetFailMode() != WAFFailOpen {
+		t.Errorf("expected fail mode open, got %s", engine.GetFailMode())
+	}
+}
+
+func TestNewWAFEngine_FailOpenCaseInsensitive(t *testing.T) {
+	logger := zap.NewNop()
+	config := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "prevention",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+		FailMode:         "Open",
+	}
+
+	engine, err := NewWAFEngine(config, logger)
+	if err != nil {
+		t.Fatalf("failed to create WAF engine: %v", err)
+	}
+
+	if engine.GetFailMode() != WAFFailOpen {
+		t.Errorf("expected fail mode open (case insensitive), got %s", engine.GetFailMode())
+	}
+}
+
+func TestNewWAFEngine_UnknownFailModeDefaultsClosed(t *testing.T) {
+	logger := zap.NewNop()
+	config := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "prevention",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+		FailMode:         "unknown",
+	}
+
+	engine, err := NewWAFEngine(config, logger)
+	if err != nil {
+		t.Fatalf("failed to create WAF engine: %v", err)
+	}
+
+	if engine.GetFailMode() != WAFFailClosed {
+		t.Errorf("expected unknown fail mode to default to closed, got %s", engine.GetFailMode())
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsString(s, substr))
 }

--- a/internal/proto/gen/config.pb.go
+++ b/internal/proto/gen/config.pb.go
@@ -4647,6 +4647,7 @@ type WAFConfig struct {
 	RulesConfigMapRef string   `protobuf:"bytes,5,opt,name=rules_config_map_ref,json=rulesConfigMapRef,proto3" json:"rules_config_map_ref,omitempty"` // Reference to ConfigMap containing rules
 	RuleExclusions    []string `protobuf:"bytes,6,rep,name=rule_exclusions,json=ruleExclusions,proto3" json:"rule_exclusions,omitempty"`              // Rule IDs to exclude
 	CustomRules       []string `protobuf:"bytes,7,rep,name=custom_rules,json=customRules,proto3" json:"custom_rules,omitempty"`                       // Inline custom rules
+	FailMode          string   `protobuf:"bytes,8,opt,name=fail_mode,json=failMode,proto3" json:"fail_mode,omitempty"`                                // "closed" (default) or "open"
 }
 
 func (x *WAFConfig) Reset() {
@@ -4726,6 +4727,13 @@ func (x *WAFConfig) GetCustomRules() []string {
 		return x.CustomRules
 	}
 	return nil
+}
+
+func (x *WAFConfig) GetFailMode() string {
+	if x != nil {
+		return x.FailMode
+	}
+	return ""
 }
 
 // WASMPluginConfig defines WASM plugin settings in a policy


### PR DESCRIPTION
## Summary
- WAF now defaults to fail-closed: blocks requests with HTTP 503 when WAF processing errors occur
- Add configurable `fail_mode` field (fail-closed/fail-open) in protobuf WAF config
- Add `waf_processing_errors_total` Prometheus metric for error visibility

## Test plan
- [x] New tests for fail-closed/fail-open behavior
- [x] All existing WAF tests passing
- [x] `go build ./...` passes
- [x] `go vet ./...` clean

Resolves #205