### PR TITLE
[Feature] Shared gRPC message size limits and interceptors (#217)

### DIFF
--- a/cmd/novaedge-controller/main.go
+++ b/cmd/novaedge-controller/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/piwi3910/novaedge/internal/controller/certmanager"
 	"github.com/piwi3910/novaedge/internal/controller/snapshot"
 	vaultpkg "github.com/piwi3910/novaedge/internal/controller/vault"
+	"github.com/piwi3910/novaedge/internal/pkg/grpclimits"
 	"github.com/piwi3910/novaedge/internal/pkg/tlsutil"
 )
 
@@ -266,7 +267,10 @@ func main() {
 	// Create and start gRPC server for config distribution
 	configServer := snapshot.NewServer(mgr.GetClient())
 
-	// Create gRPC server with optional mTLS
+	// Create gRPC server with message size limits and interceptors
+	grpcLogger, _ := uberzap.NewProduction()
+	serverOpts := grpclimits.ServerOptions(grpcLogger)
+
 	var grpcServer *grpc.Server
 	if grpcTLSCert != "" && grpcTLSKey != "" && grpcTLSCA != "" {
 		// Load TLS credentials for mTLS
@@ -275,13 +279,15 @@ func main() {
 			setupLog.Error(err, "failed to load gRPC TLS credentials")
 			os.Exit(1)
 		}
-		grpcServer = grpc.NewServer(grpc.Creds(creds))
+		grpcServer = grpc.NewServer(append(serverOpts, grpc.Creds(creds))...)
 		setupLog.Info("gRPC server configured with mTLS",
 			"cert", grpcTLSCert,
-			"ca", grpcTLSCA)
+			"ca", grpcTLSCA,
+			"max_recv_msg_size", grpclimits.DefaultMaxRecvMsgSize,
+			"max_send_msg_size", grpclimits.DefaultMaxSendMsgSize)
 	} else {
 		// Create insecure gRPC server (for development only)
-		grpcServer = grpc.NewServer()
+		grpcServer = grpc.NewServer(serverOpts...)
 		setupLog.Info("WARNING: gRPC server running without TLS (insecure)")
 	}
 

--- a/internal/agent/config/failover.go
+++ b/internal/agent/config/failover.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/piwi3910/novaedge/internal/pkg/grpclimits"
 	"github.com/piwi3910/novaedge/internal/pkg/tlsutil"
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
@@ -640,7 +641,8 @@ func (w *FailoverWatcher) connectAndStream(ctrl *ControllerEndpoint) error {
 
 // connect establishes a gRPC connection to a controller
 func (w *FailoverWatcher) connect(ctrl *ControllerEndpoint) (*grpc.ClientConn, error) {
-	var opts []grpc.DialOption
+	// Start with message size limits and keepalive options
+	opts := grpclimits.ClientOptions()
 
 	if w.tlsConfig != nil && w.tlsConfig.CertFile != "" {
 		creds, err := tlsutil.LoadClientTLSCredentials(

--- a/internal/agent/config/watcher.go
+++ b/internal/agent/config/watcher.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/piwi3910/novaedge/internal/pkg/grpclimits"
 	"github.com/piwi3910/novaedge/internal/pkg/tlsutil"
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
@@ -186,7 +187,8 @@ func (w *Watcher) connectWithRetry() (*grpc.ClientConn, error) {
 			zap.String("address", w.controllerAddr),
 			zap.Bool("tls_enabled", w.tlsEnabled))
 
-		var opts []grpc.DialOption
+		// Start with message size limits and keepalive options
+		opts := grpclimits.ClientOptions()
 		var creds credentials.TransportCredentials
 
 		if w.tlsEnabled {

--- a/internal/controller/federation/client.go
+++ b/internal/controller/federation/client.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 
+	"github.com/piwi3910/novaedge/internal/pkg/grpclimits"
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
@@ -82,13 +83,13 @@ func (c *PeerClient) Connect(ctx context.Context) error {
 		return nil // Already connected
 	}
 
-	opts := []grpc.DialOption{
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                10 * time.Second,
-			Timeout:             5 * time.Second,
-			PermitWithoutStream: true,
-		}),
-	}
+	// Start with shared message size limits and keepalive options
+	opts := grpclimits.ClientOptions()
+	opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:                10 * time.Second,
+		Timeout:             5 * time.Second,
+		PermitWithoutStream: true,
+	}))
 
 	// Configure TLS if enabled
 	if c.peer.TLSEnabled {

--- a/internal/pkg/grpclimits/grpclimits.go
+++ b/internal/pkg/grpclimits/grpclimits.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package grpclimits provides shared gRPC configuration for message size
+// limits and interceptors used by the controller-agent communication channel.
+package grpclimits
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// DefaultMaxRecvMsgSize is the maximum inbound message size (16 MiB).
+	// ConfigSnapshots can be large for clusters with many routes/endpoints.
+	DefaultMaxRecvMsgSize = 16 * 1024 * 1024
+
+	// DefaultMaxSendMsgSize is the maximum outbound message size (16 MiB).
+	DefaultMaxSendMsgSize = 16 * 1024 * 1024
+
+	// DefaultMaxConcurrentStreams limits concurrent gRPC streams per connection.
+	DefaultMaxConcurrentStreams = 100
+)
+
+// ServerOptions returns gRPC server options with message size limits,
+// keepalive enforcement, and logging interceptors.
+func ServerOptions(logger *zap.Logger) []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(DefaultMaxRecvMsgSize),
+		grpc.MaxSendMsgSize(DefaultMaxSendMsgSize),
+		grpc.MaxConcurrentStreams(DefaultMaxConcurrentStreams),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: 5 * time.Minute,
+			Time:              1 * time.Minute,
+			Timeout:           20 * time.Second,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             30 * time.Second,
+			PermitWithoutStream: true,
+		}),
+		grpc.ChainUnaryInterceptor(
+			unaryServerLoggingInterceptor(logger),
+		),
+		grpc.ChainStreamInterceptor(
+			streamServerLoggingInterceptor(logger),
+		),
+	}
+}
+
+// ClientOptions returns gRPC dial options with message size limits and
+// keepalive parameters.
+func ClientOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(DefaultMaxRecvMsgSize),
+			grpc.MaxCallSendMsgSize(DefaultMaxSendMsgSize),
+		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                1 * time.Minute,
+			Timeout:             20 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	}
+}
+
+// unaryServerLoggingInterceptor logs unary RPC calls with peer info.
+func unaryServerLoggingInterceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		peerAddr := "unknown"
+		if p, ok := peer.FromContext(ctx); ok {
+			peerAddr = p.Addr.String()
+		}
+
+		if ce := logger.Check(zap.DebugLevel, "gRPC unary call"); ce != nil {
+			ce.Write(
+				zap.String("method", info.FullMethod),
+				zap.String("peer", peerAddr),
+			)
+		}
+
+		resp, err := handler(ctx, req)
+		if err != nil {
+			st, _ := status.FromError(err)
+			if st.Code() != codes.OK {
+				logger.Warn("gRPC unary call failed",
+					zap.String("method", info.FullMethod),
+					zap.String("peer", peerAddr),
+					zap.String("code", st.Code().String()),
+					zap.Error(err),
+				)
+			}
+		}
+		return resp, err
+	}
+}
+
+// streamServerLoggingInterceptor logs streaming RPC calls with peer info.
+func streamServerLoggingInterceptor(logger *zap.Logger) grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		peerAddr := "unknown"
+		if p, ok := peer.FromContext(ss.Context()); ok {
+			peerAddr = p.Addr.String()
+		}
+
+		if ce := logger.Check(zap.DebugLevel, "gRPC stream started"); ce != nil {
+			ce.Write(
+				zap.String("method", info.FullMethod),
+				zap.String("peer", peerAddr),
+			)
+		}
+
+		err := handler(srv, ss)
+		if err != nil {
+			st, _ := status.FromError(err)
+			if st.Code() != codes.OK {
+				logger.Warn("gRPC stream failed",
+					zap.String("method", info.FullMethod),
+					zap.String("peer", peerAddr),
+					zap.String("code", st.Code().String()),
+					zap.Error(err),
+				)
+			}
+		}
+		return err
+	}
+}

--- a/internal/pkg/grpclimits/grpclimits_test.go
+++ b/internal/pkg/grpclimits/grpclimits_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpclimits
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestConstants(t *testing.T) {
+	if DefaultMaxRecvMsgSize != 16*1024*1024 {
+		t.Errorf("DefaultMaxRecvMsgSize = %d, want 16 MiB", DefaultMaxRecvMsgSize)
+	}
+	if DefaultMaxSendMsgSize != 16*1024*1024 {
+		t.Errorf("DefaultMaxSendMsgSize = %d, want 16 MiB", DefaultMaxSendMsgSize)
+	}
+	if DefaultMaxConcurrentStreams != 100 {
+		t.Errorf("DefaultMaxConcurrentStreams = %d, want 100", DefaultMaxConcurrentStreams)
+	}
+}
+
+func TestServerOptions(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	opts := ServerOptions(logger)
+	if len(opts) == 0 {
+		t.Error("ServerOptions returned no options")
+	}
+	// Verify we get a reasonable number of options:
+	// MaxRecvMsgSize, MaxSendMsgSize, MaxConcurrentStreams,
+	// KeepaliveParams, KeepaliveEnforcementPolicy,
+	// ChainUnaryInterceptor, ChainStreamInterceptor
+	if len(opts) < 7 {
+		t.Errorf("ServerOptions returned %d options, expected at least 7", len(opts))
+	}
+}
+
+func TestClientOptions(t *testing.T) {
+	opts := ClientOptions()
+	if len(opts) == 0 {
+		t.Error("ClientOptions returned no options")
+	}
+	// Verify we get at least DefaultCallOptions + KeepaliveParams
+	if len(opts) < 2 {
+		t.Errorf("ClientOptions returned %d options, expected at least 2", len(opts))
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/pkg/grpclimits` package with shared gRPC configuration constants (16 MiB msg limits, 100 max concurrent streams)
- Provide `ServerOptions()` and `ClientOptions()` helpers with keepalive params, enforcement policy, and logging interceptors
- Wire into controller gRPC server, agent config watcher, agent failover client, and federation peer client

## Test plan
- [x] Unit tests for constants and option counts
- [x] `go build ./...` passes
- [x] `go test ./internal/pkg/grpclimits/...` passes
- [x] `golangci-lint run` clean on modified packages

Resolves #217