### PR TITLE
[Security] Helm NetworkPolicies for agent, controller, and operator (#220)

### DIFF
--- a/charts/novaedge-agent/templates/networkpolicy.yaml
+++ b/charts/novaedge-agent/templates/networkpolicy.yaml
@@ -1,0 +1,61 @@
+{{- if (.Values.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "novaedge-agent.fullname" . }}
+  labels:
+    {{- include "novaedge-agent.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "novaedge-agent.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow external HTTP/HTTPS traffic (load balancer / proxy traffic)
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.ports.http }}
+    - protocol: TCP
+      port: {{ .Values.ports.https }}
+  # Allow metrics scraping from Prometheus
+  {{- if .Values.metrics.enabled }}
+  - from:
+    {{- if .Values.networkPolicy.prometheusSelector }}
+    - podSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.prometheusSelector | nindent 10 }}
+    {{- if .Values.networkPolicy.prometheusNamespaceSelector }}
+      namespaceSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.prometheusNamespaceSelector | nindent 10 }}
+    {{- end }}
+    {{- else }}
+    - podSelector: {}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.ports.metrics }}
+  {{- end }}
+  # Allow health probes from kubelet
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.ports.health }}
+  {{- with .Values.networkPolicy.extraIngress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  egress:
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow gRPC to controller (external endpoint)
+  - ports:
+    - protocol: TCP
+  {{- with .Values.networkPolicy.extraEgress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/novaedge-agent/values.yaml
+++ b/charts/novaedge-agent/values.yaml
@@ -257,6 +257,21 @@ failover:
   # -- Path for persisted configuration
   persistPath: /var/lib/novaedge/config
 
+# -- Network policy configuration
+networkPolicy:
+  # -- Enable NetworkPolicy for the agent
+  enabled: false
+  # -- Pod selector labels for Prometheus (if empty, allows all pods in namespace)
+  # prometheusSelector:
+  #   app.kubernetes.io/name: prometheus
+  # -- Namespace selector for Prometheus
+  # prometheusNamespaceSelector:
+  #   kubernetes.io/metadata.name: monitoring
+  # -- Extra ingress rules
+  # extraIngress: []
+  # -- Extra egress rules
+  # extraEgress: []
+
 # -- RBAC configuration
 rbac:
   create: true

--- a/charts/novaedge-operator/templates/networkpolicy.yaml
+++ b/charts/novaedge-operator/templates/networkpolicy.yaml
@@ -1,0 +1,58 @@
+{{- if (.Values.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "novaedge-operator.fullname" . }}
+  labels:
+    {{- include "novaedge-operator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "novaedge-operator.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow metrics scraping from Prometheus
+  {{- if .Values.metrics.enabled }}
+  - from:
+    {{- if .Values.networkPolicy.prometheusSelector }}
+    - podSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.prometheusSelector | nindent 10 }}
+    {{- if .Values.networkPolicy.prometheusNamespaceSelector }}
+      namespaceSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.prometheusNamespaceSelector | nindent 10 }}
+    {{- end }}
+    {{- else }}
+    - podSelector: {}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.metrics.port }}
+  {{- end }}
+  # Allow health probes from kubelet
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.health.port }}
+  {{- with .Values.networkPolicy.extraIngress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  egress:
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow communication with kube-apiserver
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  {{- with .Values.networkPolicy.extraEgress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/novaedge-operator/values.yaml
+++ b/charts/novaedge-operator/values.yaml
@@ -129,6 +129,21 @@ crds:
   # -- Keep CRDs on chart uninstall (prevents data loss)
   keep: true
 
+# -- Network policy configuration
+networkPolicy:
+  # -- Enable NetworkPolicy for the operator
+  enabled: false
+  # -- Pod selector labels for Prometheus (if empty, allows all pods in namespace)
+  # prometheusSelector:
+  #   app.kubernetes.io/name: prometheus
+  # -- Namespace selector for Prometheus
+  # prometheusNamespaceSelector:
+  #   kubernetes.io/metadata.name: monitoring
+  # -- Extra ingress rules
+  # extraIngress: []
+  # -- Extra egress rules
+  # extraEgress: []
+
 # -- RBAC configuration
 rbac:
   # -- Create RBAC resources

--- a/charts/novaedge/templates/agent-networkpolicy.yaml
+++ b/charts/novaedge/templates/agent-networkpolicy.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.agent.enabled (.Values.agent.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "novaedge.fullname" . }}-agent
+  namespace: {{ include "novaedge.namespace" . }}
+  labels:
+    {{- include "novaedge.agent.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "novaedge.agent.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow external HTTP/HTTPS traffic (load balancer / proxy traffic)
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.agent.ports.http }}
+    - protocol: TCP
+      port: {{ .Values.agent.ports.https }}
+  # Allow metrics scraping from Prometheus
+  {{- if .Values.agent.metrics.enabled }}
+  - from:
+    {{- if (.Values.agent.networkPolicy).prometheusSelector }}
+    - podSelector:
+        matchLabels:
+          {{- toYaml .Values.agent.networkPolicy.prometheusSelector | nindent 10 }}
+    {{- if (.Values.agent.networkPolicy).prometheusNamespaceSelector }}
+      namespaceSelector:
+        matchLabels:
+          {{- toYaml .Values.agent.networkPolicy.prometheusNamespaceSelector | nindent 10 }}
+    {{- end }}
+    {{- else }}
+    - podSelector: {}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.agent.metrics.port }}
+  {{- end }}
+  # Allow health probes from kubelet
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.agent.healthProbe.port }}
+  {{- with (.Values.agent.networkPolicy).extraIngress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  egress:
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow gRPC to controller
+  - to:
+    - podSelector:
+        matchLabels:
+          {{- include "novaedge.controller.selectorLabels" . | nindent 10 }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.controller.grpc.port }}
+  # Allow traffic to upstream backends (all pods in all namespaces)
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+  {{- with (.Values.agent.networkPolicy).extraEgress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/novaedge/templates/controller-networkpolicy.yaml
+++ b/charts/novaedge/templates/controller-networkpolicy.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.controller.enabled (.Values.controller.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "novaedge.fullname" . }}-controller
+  namespace: {{ include "novaedge.namespace" . }}
+  labels:
+    {{- include "novaedge.controller.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "novaedge.controller.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow gRPC from agents
+  - from:
+    - podSelector:
+        matchLabels:
+          {{- include "novaedge.agent.selectorLabels" . | nindent 10 }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.controller.grpc.port }}
+  # Allow metrics scraping from Prometheus
+  {{- if .Values.controller.metrics.enabled }}
+  - from:
+    {{- if (.Values.controller.networkPolicy).prometheusSelector }}
+    - podSelector:
+        matchLabels:
+          {{- toYaml .Values.controller.networkPolicy.prometheusSelector | nindent 10 }}
+    {{- if (.Values.controller.networkPolicy).prometheusNamespaceSelector }}
+      namespaceSelector:
+        matchLabels:
+          {{- toYaml .Values.controller.networkPolicy.prometheusNamespaceSelector | nindent 10 }}
+    {{- end }}
+    {{- else }}
+    - podSelector: {}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.controller.metrics.port }}
+  {{- end }}
+  # Allow health probes from kubelet
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.controller.healthProbe.port }}
+  {{- with (.Values.controller.networkPolicy).extraIngress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  egress:
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow communication with kube-apiserver
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # Allow gRPC responses to agents (established connections)
+  - to:
+    - podSelector:
+        matchLabels:
+          {{- include "novaedge.agent.selectorLabels" . | nindent 10 }}
+  {{- with (.Values.controller.networkPolicy).extraEgress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/novaedge/templates/webui-networkpolicy.yaml
+++ b/charts/novaedge/templates/webui-networkpolicy.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.webui.enabled (.Values.webui.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "novaedge.fullname" . }}-webui
+  namespace: {{ include "novaedge.namespace" . }}
+  labels:
+    {{- include "novaedge.webui.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "novaedge.webui.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow HTTP traffic from ingress controller or direct access
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.webui.service.targetPort }}
+  {{- with (.Values.webui.networkPolicy).extraIngress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  egress:
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow communication with kube-apiserver (for RBAC proxy)
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # Allow Prometheus queries
+  {{- if .Values.webui.prometheus.endpoint }}
+  - ports:
+    - protocol: TCP
+      port: 9090
+  {{- end }}
+  {{- with (.Values.webui.networkPolicy).extraEgress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/novaedge/values.yaml
+++ b/charts/novaedge/values.yaml
@@ -61,6 +61,20 @@ controller:
     enabled: true
     minAvailable: 1
 
+  # Network policy
+  networkPolicy:
+    enabled: false
+    # Pod selector labels for Prometheus (if empty, allows all pods in namespace)
+    # prometheusSelector:
+    #   app.kubernetes.io/name: prometheus
+    # Namespace selector for Prometheus
+    # prometheusNamespaceSelector:
+    #   kubernetes.io/metadata.name: monitoring
+    # Extra ingress rules
+    # extraIngress: []
+    # Extra egress rules
+    # extraEgress: []
+
   # Horizontal pod autoscaler
   autoscaling:
     enabled: false
@@ -127,6 +141,16 @@ agent:
     rollingUpdate:
       maxUnavailable: 1
 
+  # Network policy
+  networkPolicy:
+    enabled: false
+    # prometheusSelector:
+    #   app.kubernetes.io/name: prometheus
+    # prometheusNamespaceSelector:
+    #   kubernetes.io/metadata.name: monitoring
+    # extraIngress: []
+    # extraEgress: []
+
   # Pod disruption budget
   podDisruptionBudget:
     enabled: true
@@ -180,6 +204,12 @@ webui:
     requests:
       cpu: 50m
       memory: 64Mi
+
+  # Network policy
+  networkPolicy:
+    enabled: false
+    # extraIngress: []
+    # extraEgress: []
 
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
## Summary
- Add opt-in Kubernetes NetworkPolicy templates to all three Helm charts (novaedge, novaedge-agent, novaedge-operator)
- Controller policy restricts ingress to agent gRPC, Prometheus metrics, and health probes; egress to kube-apiserver and DNS
- Agent policy allows external HTTP/HTTPS traffic ingress, metrics, health; egress to controller, upstream backends, DNS
- Operator policy allows metrics and health ingress; egress to kube-apiserver and DNS
- All policies disabled by default (`networkPolicy.enabled: false`) — no change to existing deployments
- Configurable Prometheus pod/namespace selectors and extraIngress/extraEgress for custom rules

## Test plan
- [x] `helm lint` passes on all three charts
- [x] `helm template` renders correct NetworkPolicy resources when enabled
- [x] No NetworkPolicies rendered when disabled (default)
- [x] Custom Prometheus selectors render correctly
- [x] Extra ingress/egress rules supported

Resolves #220