### PR TITLE
[Chore] Fix 32 lint issues in test files (#232)

### DIFF
--- a/internal/acme/dns/provider_test.go
+++ b/internal/acme/dns/provider_test.go
@@ -160,12 +160,12 @@ func TestMockProvider_WaitForPropagation(t *testing.T) {
 func TestDNS01ChallengeProvider_Wrap(t *testing.T) {
 	mock := &mockProvider{}
 	logger := zap.NewNop()
-	
+
 	provider := &DNS01ChallengeProvider{
 		provider: mock,
 		logger:   logger,
 	}
-	
+
 	if provider.provider != mock {
 		t.Error("provider not set correctly")
 	}

--- a/internal/acme/types_test.go
+++ b/internal/acme/types_test.go
@@ -235,10 +235,10 @@ func TestCertificate_ShouldRenew(t *testing.T) {
 func TestCertificate_ExpiresIn(t *testing.T) {
 	now := time.Now()
 	tests := []struct {
-		name      string
-		notAfter  time.Time
-		minDur    time.Duration
-		maxDur    time.Duration
+		name     string
+		notAfter time.Time
+		minDur   time.Duration
+		maxDur   time.Duration
 	}{
 		{
 			name:     "1 hour from now",

--- a/internal/agent/l4/types_test.go
+++ b/internal/agent/l4/types_test.go
@@ -39,9 +39,9 @@ func TestListenerType_Constants(t *testing.T) {
 
 func TestListenerConfig_Fields(t *testing.T) {
 	cfg := ListenerConfig{
-		Name:       "test-listener",
-		Port:       8080,
-		Type:       ListenerTypeTCP,
+		Name:        "test-listener",
+		Port:        8080,
+		Type:        ListenerTypeTCP,
 		BackendName: "test-backend",
 		Backends: []*pb.Endpoint{
 			{Address: "10.0.0.1", Port: 8080},

--- a/internal/agent/lb/maglev_test.go
+++ b/internal/agent/lb/maglev_test.go
@@ -279,7 +279,7 @@ func TestMaglev_SingleEndpoint(t *testing.T) {
 		ep := m.Select(string(rune(i)))
 		if ep == nil {
 			t.Error("Select() returned nil")
-		} else if ep.Address != "10.0.0.1" {
+		} else if ep.Address != testAddrEWMA {
 			t.Errorf("Select() returned wrong endpoint: %s", ep.Address)
 		}
 	}
@@ -311,7 +311,7 @@ func TestMaglev_Failover(t *testing.T) {
 	// Should still get a valid endpoint
 	newSelection := m.Select(key)
 	if newSelection == nil {
-		t.Error("Select() returned nil after endpoint removal")
+		t.Fatal("Select() returned nil after endpoint removal")
 	}
 	if newSelection.Address == initial.Address {
 		t.Error("Select() returned removed endpoint")

--- a/internal/agent/lb/ringhash_test.go
+++ b/internal/agent/lb/ringhash_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestNewRingHash(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 		{Address: "10.0.0.3", Port: 8080, Ready: true},
 	}
@@ -59,7 +59,7 @@ func TestNewRingHash_EmptyEndpoints(t *testing.T) {
 
 func TestRingHash_Select(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 		{Address: "10.0.0.3", Port: 8080, Ready: true},
 	}
@@ -98,7 +98,7 @@ func TestRingHash_Select_EmptyEndpoints(t *testing.T) {
 
 func TestRingHash_Select_Consistency(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 		{Address: "10.0.0.3", Port: 8080, Ready: true},
 	}
@@ -119,7 +119,7 @@ func TestRingHash_Select_Consistency(t *testing.T) {
 
 func TestRingHash_SelectDefault(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 	}
 
@@ -133,7 +133,7 @@ func TestRingHash_SelectDefault(t *testing.T) {
 
 func TestRingHash_SelectDefault_NoReadyEndpoints(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: false},
+		{Address: testAddrEWMA, Port: 8080, Ready: false},
 		{Address: "10.0.0.2", Port: 8080, Ready: false},
 	}
 
@@ -156,7 +156,7 @@ func TestRingHash_SelectDefault_EmptyEndpoints(t *testing.T) {
 
 func TestRingHash_UpdateEndpoints(t *testing.T) {
 	initialEndpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 	}
 
@@ -187,7 +187,7 @@ func TestRingHash_UpdateEndpoints(t *testing.T) {
 
 func TestRingHash_GetRingSize(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 	}
 
@@ -202,7 +202,7 @@ func TestRingHash_GetRingSize(t *testing.T) {
 
 func TestRingHash_Distribution(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 		{Address: "10.0.0.3", Port: 8080, Ready: true},
 	}
@@ -240,7 +240,7 @@ func TestRingHash_Distribution(t *testing.T) {
 func TestRingHash_MinimalChange(t *testing.T) {
 	// When an endpoint is added/removed, minimal keys should remap
 	initialEndpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 	}
 
@@ -258,7 +258,7 @@ func TestRingHash_MinimalChange(t *testing.T) {
 
 	// Add a new endpoint
 	newEndpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 		{Address: "10.0.0.3", Port: 8080, Ready: true},
 	}
@@ -282,7 +282,7 @@ func TestRingHash_MinimalChange(t *testing.T) {
 
 func TestRingHash_ConcurrentAccess(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: true},
 	}
 
@@ -305,7 +305,7 @@ func TestRingHash_ConcurrentAccess(t *testing.T) {
 	go func() {
 		for i := 0; i < 10; i++ {
 			newEndpoints := []*pb.Endpoint{
-				{Address: "10.0.0.1", Port: 8080, Ready: true},
+				{Address: testAddrEWMA, Port: 8080, Ready: true},
 			}
 			rh.UpdateEndpoints(newEndpoints)
 		}
@@ -320,7 +320,7 @@ func TestRingHash_ConcurrentAccess(t *testing.T) {
 
 func TestRingHash_SingleEndpoint(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 	}
 
 	rh := NewRingHash(endpoints)
@@ -330,7 +330,7 @@ func TestRingHash_SingleEndpoint(t *testing.T) {
 		ep := rh.Select(string(rune(i)))
 		if ep == nil {
 			t.Error("Select() returned nil")
-		} else if ep.Address != "10.0.0.1" {
+		} else if ep.Address != testAddrEWMA {
 			t.Errorf("Select() returned wrong endpoint: %s", ep.Address)
 		}
 	}
@@ -338,7 +338,7 @@ func TestRingHash_SingleEndpoint(t *testing.T) {
 
 func TestRingHash_UnreadyEndpoints(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: false},
+		{Address: testAddrEWMA, Port: 8080, Ready: false},
 		{Address: "10.0.0.2", Port: 8080, Ready: false},
 	}
 
@@ -358,7 +358,7 @@ func TestRingHash_UnreadyEndpoints(t *testing.T) {
 
 func TestRingHash_MixedReadyEndpoints(t *testing.T) {
 	endpoints := []*pb.Endpoint{
-		{Address: "10.0.0.1", Port: 8080, Ready: true},
+		{Address: testAddrEWMA, Port: 8080, Ready: true},
 		{Address: "10.0.0.2", Port: 8080, Ready: false},
 		{Address: "10.0.0.3", Port: 8080, Ready: true},
 	}

--- a/internal/agent/lb/sticky_additional_test.go
+++ b/internal/agent/lb/sticky_additional_test.go
@@ -45,7 +45,6 @@ func TestDefaultStickyConfig(t *testing.T) {
 	}
 }
 
-
 func TestNewStickyWrapper(t *testing.T) {
 	endpoints := []*pb.Endpoint{
 		{Address: "10.0.0.1", Port: 8080, Ready: true},
@@ -357,14 +356,14 @@ func TestStickyWrapper_ConcurrentAccess(t *testing.T) {
 
 	// Concurrent SelectWithAffinity
 	for i := 0; i < 10; i++ {
-		go func(id int) {
+		go func() {
 			for j := 0; j < 100; j++ {
 				req := httptest.NewRequest("GET", "/test", nil)
 				rec := httptest.NewRecorder()
 				_ = sw.SelectWithAffinity(req, rec)
 			}
 			done <- true
-		}(i)
+		}()
 	}
 
 	// Concurrent UpdateEndpoints

--- a/internal/agent/router/format_test.go
+++ b/internal/agent/router/format_test.go
@@ -49,11 +49,11 @@ func TestFormatEndpointKey(t *testing.T) {
 func TestFormatEndpointKey_Concurrent(t *testing.T) {
 	done := make(chan bool)
 
-	for i := 0; i < 100; i++ {
-		go func(id int) {
-			for j := 0; j < 100; j++ {
+	for i := int32(0); i < 100; i++ {
+		go func(id int32) {
+			for j := int32(0); j < 100; j++ {
 				address := "10.0.0.1"
-				port := int32(id*100 + j)
+				port := id*100 + j
 				result := formatEndpointKey(address, port)
 				if result == "" {
 					t.Error("formatEndpointKey returned empty string")

--- a/internal/agent/vip/manager_test.go
+++ b/internal/agent/vip/manager_test.go
@@ -293,7 +293,7 @@ func TestGetActiveVIPs_NilAssignments(t *testing.T) {
 			t.Logf("GetActiveVIPs panicked with nil map (expected behavior): %v", r)
 		}
 	}()
-	
+
 	active := manager.GetActiveVIPs()
 	// If we get here without panic, check the result
 	_ = active
@@ -302,7 +302,7 @@ func TestGetActiveVIPs_NilAssignments(t *testing.T) {
 func TestNewManager(t *testing.T) {
 	logger := zap.NewNop()
 	manager, err := NewManager(logger)
-	
+
 	// NewManager may fail in environments without network access
 	// This is expected behavior - the handlers need network interfaces
 	if err != nil {

--- a/internal/controller/certmanager/detector_extended_test.go
+++ b/internal/controller/certmanager/detector_extended_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestDetector_IsCertManagerInstalled_EmptyResources(t *testing.T) {

--- a/internal/controller/errors_test.go
+++ b/internal/controller/errors_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 )
 
+const testMessage = "message"
+
 func TestReconcileError_Error(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -101,7 +103,7 @@ func TestReconcileError_Unwrap(t *testing.T) {
 
 func TestNewReconcileError(t *testing.T) {
 	underlying := errors.New("underlying")
-	err := NewReconcileError("ProxyGateway", "default", "test", "init", "message", underlying)
+	err := NewReconcileError("ProxyGateway", "default", "test", "init", testMessage, underlying)
 
 	if err.Resource != "ProxyGateway" {
 		t.Errorf("Resource = %q, want %q", err.Resource, "ProxyGateway")
@@ -115,8 +117,8 @@ func TestNewReconcileError(t *testing.T) {
 	if err.Phase != "init" {
 		t.Errorf("Phase = %q, want %q", err.Phase, "init")
 	}
-	if err.Message != "message" {
-		t.Errorf("Message = %q, want %q", err.Message, "message")
+	if err.Message != testMessage {
+		t.Errorf("Message = %q, want %q", err.Message, testMessage)
 	}
 	if err.Err != underlying {
 		t.Error("Err should be underlying error")
@@ -192,7 +194,7 @@ func TestTranslationError_Unwrap(t *testing.T) {
 
 func TestNewTranslationError(t *testing.T) {
 	underlying := errors.New("underlying")
-	err := NewTranslationError("Ingress", "ProxyRoute", "default", "test", "message", underlying)
+	err := NewTranslationError("Ingress", "ProxyRoute", "default", "test", testMessage, underlying)
 
 	if err.SourceKind != "Ingress" {
 		t.Errorf("SourceKind = %q, want %q", err.SourceKind, "Ingress")
@@ -206,8 +208,8 @@ func TestNewTranslationError(t *testing.T) {
 	if err.Name != "test" {
 		t.Errorf("Name = %q, want %q", err.Name, "test")
 	}
-	if err.Message != "message" {
-		t.Errorf("Message = %q, want %q", err.Message, "message")
+	if err.Message != testMessage {
+		t.Errorf("Message = %q, want %q", err.Message, testMessage)
 	}
 	if err.Err != underlying {
 		t.Error("Err should be underlying error")
@@ -277,7 +279,7 @@ func TestSnapshotError_Unwrap(t *testing.T) {
 
 func TestNewSnapshotError(t *testing.T) {
 	underlying := errors.New("underlying")
-	err := NewSnapshotError("node-1", "v1.0.0", "message", underlying)
+	err := NewSnapshotError("node-1", "v1.0.0", testMessage, underlying)
 
 	if err.Node != "node-1" {
 		t.Errorf("Node = %q, want %q", err.Node, "node-1")
@@ -285,8 +287,8 @@ func TestNewSnapshotError(t *testing.T) {
 	if err.Version != "v1.0.0" {
 		t.Errorf("Version = %q, want %q", err.Version, "v1.0.0")
 	}
-	if err.Message != "message" {
-		t.Errorf("Message = %q, want %q", err.Message, "message")
+	if err.Message != testMessage {
+		t.Errorf("Message = %q, want %q", err.Message, testMessage)
 	}
 	if err.Err != underlying {
 		t.Error("Err should be underlying error")

--- a/internal/controller/federation/manager_test.go
+++ b/internal/controller/federation/manager_test.go
@@ -27,17 +27,22 @@ import (
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 )
 
+const (
+	testFederationID = "test-federation"
+	testLocalMember  = "local"
+)
+
 func TestNewManager(t *testing.T) {
 	logger := zap.NewNop()
 	config := DefaultConfig()
-	config.FederationID = "test-federation"
+	config.FederationID = testFederationID
 
 	manager := NewManager(config, logger)
 	if manager == nil {
 		t.Fatal("expected manager, got nil")
 	}
 
-	if manager.config.FederationID != "test-federation" {
+	if manager.config.FederationID != testFederationID {
 		t.Errorf("FederationID = %v, want test-federation", manager.config.FederationID)
 	}
 
@@ -51,13 +56,13 @@ func TestNewManagerFromCRD(t *testing.T) {
 
 	federation := &novaedgev1alpha1.NovaEdgeFederation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-federation",
+			Name:      testFederationID,
 			Namespace: "default",
 		},
 		Spec: novaedgev1alpha1.NovaEdgeFederationSpec{
 			FederationID: "fed-123",
 			LocalMember: novaedgev1alpha1.FederationMember{
-				Name:     "local",
+				Name:     testLocalMember,
 				Endpoint: "localhost:50051",
 				Region:   "us-east-1",
 				Zone:     "us-east-1a",
@@ -114,7 +119,7 @@ func TestNewManagerFromCRD(t *testing.T) {
 		t.Errorf("FederationID = %v, want fed-123", manager.config.FederationID)
 	}
 
-	if manager.config.LocalMember.Name != "local" {
+	if manager.config.LocalMember.Name != testLocalMember {
 		t.Errorf("LocalMember.Name = %v, want local", manager.config.LocalMember.Name)
 	}
 
@@ -163,13 +168,13 @@ func TestNewManagerFromCRDWithCreds(t *testing.T) {
 
 	federation := &novaedgev1alpha1.NovaEdgeFederation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-federation",
+			Name:      testFederationID,
 			Namespace: "default",
 		},
 		Spec: novaedgev1alpha1.NovaEdgeFederationSpec{
 			FederationID: "fed-123",
 			LocalMember: novaedgev1alpha1.FederationMember{
-				Name:     "local",
+				Name:     testLocalMember,
 				Endpoint: "localhost:50051",
 			},
 			Members: []novaedgev1alpha1.FederationPeer{
@@ -220,13 +225,13 @@ func TestNewManagerFromCRDWithCreds_NilCreds(t *testing.T) {
 
 	federation := &novaedgev1alpha1.NovaEdgeFederation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-federation",
+			Name:      testFederationID,
 			Namespace: "default",
 		},
 		Spec: novaedgev1alpha1.NovaEdgeFederationSpec{
 			FederationID: "fed-123",
 			LocalMember: novaedgev1alpha1.FederationMember{
-				Name:     "local",
+				Name:     testLocalMember,
 				Endpoint: "localhost:50051",
 			},
 			Members: []novaedgev1alpha1.FederationPeer{
@@ -348,13 +353,13 @@ func TestManagerOnResourceChange(t *testing.T) {
 func TestCrdToConfig_EmptyMembers(t *testing.T) {
 	federation := &novaedgev1alpha1.NovaEdgeFederation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-federation",
+			Name:      testFederationID,
 			Namespace: "default",
 		},
 		Spec: novaedgev1alpha1.NovaEdgeFederationSpec{
 			FederationID: "fed-123",
 			LocalMember: novaedgev1alpha1.FederationMember{
-				Name:     "local",
+				Name:     testLocalMember,
 				Endpoint: "localhost:50051",
 			},
 			Members: []novaedgev1alpha1.FederationPeer{},
@@ -375,13 +380,13 @@ func TestCrdToConfig_EmptyMembers(t *testing.T) {
 func TestCrdToConfig_NilSync(t *testing.T) {
 	federation := &novaedgev1alpha1.NovaEdgeFederation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-federation",
+			Name:      testFederationID,
 			Namespace: "default",
 		},
 		Spec: novaedgev1alpha1.NovaEdgeFederationSpec{
 			FederationID: "fed-123",
 			LocalMember: novaedgev1alpha1.FederationMember{
-				Name:     "local",
+				Name:     testLocalMember,
 				Endpoint: "localhost:50051",
 			},
 			Sync: nil, // No sync config
@@ -399,13 +404,13 @@ func TestCrdToConfig_NilSync(t *testing.T) {
 func TestCrdToConfig_TLSDisabled(t *testing.T) {
 	federation := &novaedgev1alpha1.NovaEdgeFederation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-federation",
+			Name:      testFederationID,
 			Namespace: "default",
 		},
 		Spec: novaedgev1alpha1.NovaEdgeFederationSpec{
 			FederationID: "fed-123",
 			LocalMember: novaedgev1alpha1.FederationMember{
-				Name:     "local",
+				Name:     testLocalMember,
 				Endpoint: "localhost:50051",
 			},
 			Members: []novaedgev1alpha1.FederationPeer{
@@ -434,13 +439,13 @@ func TestCrdToConfig_TLSDisabled(t *testing.T) {
 func TestCrdToConfig_TLSNil(t *testing.T) {
 	federation := &novaedgev1alpha1.NovaEdgeFederation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-federation",
+			Name:      testFederationID,
 			Namespace: "default",
 		},
 		Spec: novaedgev1alpha1.NovaEdgeFederationSpec{
 			FederationID: "fed-123",
 			LocalMember: novaedgev1alpha1.FederationMember{
-				Name:     "local",
+				Name:     testLocalMember,
 				Endpoint: "localhost:50051",
 			},
 			Members: []novaedgev1alpha1.FederationPeer{
@@ -468,13 +473,13 @@ func TestCrdToConfig_TLSNil(t *testing.T) {
 func TestCrdToConfig_Labels(t *testing.T) {
 	federation := &novaedgev1alpha1.NovaEdgeFederation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-federation",
+			Name:      testFederationID,
 			Namespace: "default",
 		},
 		Spec: novaedgev1alpha1.NovaEdgeFederationSpec{
 			FederationID: "fed-123",
 			LocalMember: novaedgev1alpha1.FederationMember{
-				Name:     "local",
+				Name:     testLocalMember,
 				Endpoint: "localhost:50051",
 				Labels:   map[string]string{"env": "prod", "team": "platform"},
 			},

--- a/internal/controller/federation/types_test.go
+++ b/internal/controller/federation/types_test.go
@@ -70,7 +70,7 @@ func TestConfig_WithCustomValues(t *testing.T) {
 	// Modify config
 	cfg.FederationID = "test-federation"
 	cfg.LocalMember = &PeerInfo{
-		Name:     "local",
+		Name:     testLocalMember,
 		Endpoint: "localhost:8080",
 	}
 	cfg.Peers = []*PeerInfo{
@@ -118,8 +118,8 @@ func TestTrackedResource_Creation(t *testing.T) {
 		ResourceVersion: "12345",
 		Hash:            "abc123",
 		Data:            []byte(`{"kind":"ProxyGateway"}`),
-		VectorClock:     map[string]int64{"local": 1, "peer1": 2},
-		OriginMember:    "local",
+		VectorClock:     map[string]int64{testLocalMember: 1, "peer1": 2},
+		OriginMember:    testLocalMember,
 		LastModified:    now,
 		Labels:          map[string]string{"env": "test"},
 	}
@@ -137,11 +137,11 @@ func TestTrackedResource_Creation(t *testing.T) {
 	if string(tr.Data) != `{"kind":"ProxyGateway"}` {
 		t.Errorf("Data = %s, want %s", string(tr.Data), `{"kind":"ProxyGateway"}`)
 	}
-	if tr.VectorClock["local"] != 1 {
-		t.Errorf("VectorClock[local] = %d, want 1", tr.VectorClock["local"])
+	if tr.VectorClock[testLocalMember] != 1 {
+		t.Errorf("VectorClock[local] = %d, want 1", tr.VectorClock[testLocalMember])
 	}
-	if tr.OriginMember != "local" {
-		t.Errorf("OriginMember = %q, want %q", tr.OriginMember, "local")
+	if tr.OriginMember != testLocalMember {
+		t.Errorf("OriginMember = %q, want %q", tr.OriginMember, testLocalMember)
 	}
 	if tr.LastModified != now {
 		t.Errorf("LastModified = %v, want %v", tr.LastModified, now)
@@ -161,8 +161,8 @@ func TestTombstone_Creation(t *testing.T) {
 			Name:      "deleted-route",
 		},
 		DeletionTime: now,
-		VectorClock:  map[string]int64{"local": 5},
-		OriginMember: "local",
+		VectorClock:  map[string]int64{testLocalMember: 5},
+		OriginMember: testLocalMember,
 	}
 
 	// Verify fields
@@ -172,11 +172,11 @@ func TestTombstone_Creation(t *testing.T) {
 	if ts.DeletionTime != now {
 		t.Errorf("DeletionTime = %v, want %v", ts.DeletionTime, now)
 	}
-	if ts.VectorClock["local"] != 5 {
-		t.Errorf("VectorClock[local] = %d, want 5", ts.VectorClock["local"])
+	if ts.VectorClock[testLocalMember] != 5 {
+		t.Errorf("VectorClock[local] = %d, want 5", ts.VectorClock[testLocalMember])
 	}
-	if ts.OriginMember != "local" {
-		t.Errorf("OriginMember = %q, want %q", ts.OriginMember, "local")
+	if ts.OriginMember != testLocalMember {
+		t.Errorf("OriginMember = %q, want %q", ts.OriginMember, testLocalMember)
 	}
 }
 
@@ -184,14 +184,14 @@ func TestConflictInfo_Creation(t *testing.T) {
 	now := time.Now()
 
 	local := &TrackedResource{
-		Key:           ResourceKey{Kind: "ProxyGateway", Namespace: "default", Name: "gw"},
-		OriginMember:  "local",
-		LastModified:  now.Add(-time.Minute),
+		Key:          ResourceKey{Kind: "ProxyGateway", Namespace: "default", Name: "gw"},
+		OriginMember: testLocalMember,
+		LastModified: now.Add(-time.Minute),
 	}
 	remote := &TrackedResource{
-		Key:           ResourceKey{Kind: "ProxyGateway", Namespace: "default", Name: "gw"},
-		OriginMember:  "peer1",
-		LastModified:  now,
+		Key:          ResourceKey{Kind: "ProxyGateway", Namespace: "default", Name: "gw"},
+		OriginMember: "peer1",
+		LastModified: now,
 	}
 
 	ci := &ConflictInfo{
@@ -207,8 +207,8 @@ func TestConflictInfo_Creation(t *testing.T) {
 	if ci.Key.Name != "gw" {
 		t.Errorf("Key.Name = %q, want %q", ci.Key.Name, "gw")
 	}
-	if ci.LocalVersion.OriginMember != "local" {
-		t.Errorf("LocalVersion.OriginMember = %q, want %q", ci.LocalVersion.OriginMember, "local")
+	if ci.LocalVersion.OriginMember != testLocalMember {
+		t.Errorf("LocalVersion.OriginMember = %q, want %q", ci.LocalVersion.OriginMember, testLocalMember)
 	}
 	if ci.RemoteVersion.OriginMember != "peer1" {
 		t.Errorf("RemoteVersion.OriginMember = %q, want %q", ci.RemoteVersion.OriginMember, "peer1")
@@ -315,14 +315,14 @@ func TestChangeEntry_Creation(t *testing.T) {
 		Type: ChangeTypeCreated,
 		Resource: &TrackedResource{
 			Key:          ResourceKey{Kind: "ProxyGateway", Namespace: "default", Name: "test-gateway"},
-			OriginMember: "local",
+			OriginMember: testLocalMember,
 		},
 		Tombstone:   nil,
-		VectorClock: map[string]int64{"local": 1},
+		VectorClock: map[string]int64{testLocalMember: 1},
 		Timestamp:   now,
 		Acknowledged: map[string]bool{
-			"local": true,
-			"peer1": false,
+			testLocalMember: true,
+			"peer1":         false,
 		},
 	}
 
@@ -342,7 +342,7 @@ func TestChangeEntry_Creation(t *testing.T) {
 	if ce.Timestamp != now {
 		t.Errorf("Timestamp = %v, want %v", ce.Timestamp, now)
 	}
-	if !ce.Acknowledged["local"] {
+	if !ce.Acknowledged[testLocalMember] {
 		t.Error("local should have acknowledged")
 	}
 	if ce.Acknowledged["peer1"] {
@@ -363,11 +363,11 @@ func TestChangeEntry_DeleteChange(t *testing.T) {
 		Type:     ChangeTypeDeleted,
 		Resource: nil,
 		Tombstone: &Tombstone{
-			Key:           ResourceKey{Kind: "ProxyRoute", Namespace: "default", Name: "deleted-route"},
-			DeletionTime:  now,
-			OriginMember:  "local",
+			Key:          ResourceKey{Kind: "ProxyRoute", Namespace: "default", Name: "deleted-route"},
+			DeletionTime: now,
+			OriginMember: testLocalMember,
 		},
-		VectorClock:  map[string]int64{"local": 5},
+		VectorClock:  map[string]int64{testLocalMember: 5},
 		Timestamp:    now,
 		Acknowledged: map[string]bool{},
 	}
@@ -406,9 +406,9 @@ func TestChangeType_Constants(t *testing.T) {
 
 func TestPeerInfo_TLSEnabled(t *testing.T) {
 	tests := []struct {
-		name     string
-		peer     *PeerInfo
-		wantTLS  bool
+		name    string
+		peer    *PeerInfo
+		wantTLS bool
 	}{
 		{
 			name: "TLS enabled",
@@ -423,8 +423,8 @@ func TestPeerInfo_TLSEnabled(t *testing.T) {
 		{
 			name: "TLS disabled",
 			peer: &PeerInfo{
-				Name:      "peer2",
-				Endpoint:  "peer2:8080",
+				Name:       "peer2",
+				Endpoint:   "peer2:8080",
 				TLSEnabled: false,
 			},
 			wantTLS: false,
@@ -468,9 +468,9 @@ func TestPeerState_Updates(t *testing.T) {
 			Name:     "peer1",
 			Endpoint: "peer1:8080",
 		},
-		VectorClock:  NewVectorClock(),
-		Healthy:      true,
-		Connected:    true,
+		VectorClock: NewVectorClock(),
+		Healthy:     true,
+		Connected:   true,
 	}
 
 	// Simulate connection loss
@@ -529,9 +529,9 @@ func TestResourceKey_Equality(t *testing.T) {
 
 func TestConfig_Validation(t *testing.T) {
 	tests := []struct {
-		name    string
-		modify  func(*Config)
-		valid   bool
+		name   string
+		modify func(*Config)
+		valid  bool
 	}{
 		{
 			name:   "default config is valid",
@@ -576,7 +576,7 @@ func TestConfig_Validation(t *testing.T) {
 		{
 			name: "with local member",
 			modify: func(c *Config) {
-				c.LocalMember = &PeerInfo{Name: "local", Endpoint: "localhost:8080"}
+				c.LocalMember = &PeerInfo{Name: testLocalMember, Endpoint: "localhost:8080"}
 			},
 			valid: true,
 		},
@@ -649,7 +649,7 @@ func TestChangeEntry_AcknowledgmentTracking(t *testing.T) {
 	}
 
 	// Add acknowledgments
-	ce.Acknowledged["local"] = true
+	ce.Acknowledged[testLocalMember] = true
 	ce.Acknowledged["peer1"] = true
 	ce.Acknowledged["peer2"] = false
 

--- a/internal/controller/federation/vectorclock_test.go
+++ b/internal/controller/federation/vectorclock_test.go
@@ -362,16 +362,16 @@ func TestVectorClock_Concurrent(t *testing.T) {
 
 func TestVectorClock_Copy(t *testing.T) {
 	original := NewVectorClockFromMap(map[string]int64{"node1": 5, "node2": 10})
-	copy := original.Copy()
+	cloned := original.Copy()
 
 	// Verify copy is equal
-	if !original.Equal(copy) {
+	if !original.Equal(cloned) {
 		t.Error("copy is not equal to original")
 	}
 
 	// Modify original and verify copy is independent
 	original.Set("node1", 100)
-	if copy.Get("node1") == 100 {
+	if cloned.Get("node1") == 100 {
 		t.Error("copy was affected by modification to original")
 	}
 }
@@ -686,10 +686,10 @@ func TestPeerState_TimeTracking(t *testing.T) {
 	now := time.Now()
 
 	state := &PeerState{
-		Info:          &PeerInfo{Name: "peer1", Endpoint: "localhost:8080"},
-		VectorClock:   NewVectorClock(),
-		LastSeen:      now,
-		LastSyncTime:  now.Add(-time.Minute),
+		Info:         &PeerInfo{Name: "peer1", Endpoint: "localhost:8080"},
+		VectorClock:  NewVectorClock(),
+		LastSeen:     now,
+		LastSyncTime: now.Add(-time.Minute),
 	}
 
 	// Verify time is properly set

--- a/internal/controller/ingress_translator_extended_test.go
+++ b/internal/controller/ingress_translator_extended_test.go
@@ -729,10 +729,10 @@ func TestGetCanaryWeight(t *testing.T) {
 
 func TestGetCanaryHeader(t *testing.T) {
 	tests := []struct {
-		name            string
-		ingress         *networkingv1.Ingress
-		expectedHeader  string
-		expectedValue   string
+		name           string
+		ingress        *networkingv1.Ingress
+		expectedHeader string
+		expectedValue  string
 	}{
 		{
 			name: "header with custom value",
@@ -745,8 +745,8 @@ func TestGetCanaryHeader(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader:  "X-Canary",
-			expectedValue:   "v1",
+			expectedHeader: "X-Canary",
+			expectedValue:  "v1",
 		},
 		{
 			name: "header with default value",
@@ -756,16 +756,16 @@ func TestGetCanaryHeader(t *testing.T) {
 					Annotations: map[string]string{AnnotationCanaryHeader: "X-Canary"},
 				},
 			},
-			expectedHeader:  "X-Canary",
-			expectedValue:   "true",
+			expectedHeader: "X-Canary",
+			expectedValue:  "true",
 		},
 		{
 			name: "no canary header",
 			ingress: &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
-			expectedHeader:  "",
-			expectedValue:   "",
+			expectedHeader: "",
+			expectedValue:  "",
 		},
 		{
 			name: "empty canary header",
@@ -775,8 +775,8 @@ func TestGetCanaryHeader(t *testing.T) {
 					Annotations: map[string]string{AnnotationCanaryHeader: ""},
 				},
 			},
-			expectedHeader:  "",
-			expectedValue:   "",
+			expectedHeader: "",
+			expectedValue:  "",
 		},
 	}
 
@@ -852,12 +852,12 @@ func TestUseRegexPathMatching(t *testing.T) {
 
 func TestGetMirrorConfig(t *testing.T) {
 	tests := []struct {
-		name            string
-		ingress         *networkingv1.Ingress
-		expectBackend   bool
-		backendName     string
-		expectPercent   bool
-		percentValue    int32
+		name          string
+		ingress       *networkingv1.Ingress
+		expectBackend bool
+		backendName   string
+		expectPercent bool
+		percentValue  int32
 	}{
 		{
 			name: "with backend and percent",
@@ -865,8 +865,8 @@ func TestGetMirrorConfig(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
-						AnnotationMirrorBackend:  "mirror-backend",
-						AnnotationMirrorPercent:  "50",
+						AnnotationMirrorBackend: "mirror-backend",
+						AnnotationMirrorPercent: "50",
 					},
 				},
 			},
@@ -902,7 +902,7 @@ func TestGetMirrorConfig(t *testing.T) {
 					Name: "test",
 					Annotations: map[string]string{
 						AnnotationMirrorBackend: "mirror-backend",
-						AnnotationMirrorPercent:  "150",
+						AnnotationMirrorPercent: "150",
 					},
 				},
 			},

--- a/internal/controller/ipam/allocator_test.go
+++ b/internal/controller/ipam/allocator_test.go
@@ -384,7 +384,7 @@ func TestAllocator_IsAddressConflict(t *testing.T) {
 	}
 
 	// Check non-conflict
-	poolName, isConflict = a.IsAddressConflict("192.168.1.250")
+	_, isConflict = a.IsAddressConflict("192.168.1.250")
 	if isConflict {
 		t.Error("IsAddressConflict() should return false for unallocated address")
 	}

--- a/internal/controller/snapshot/metrics_test.go
+++ b/internal/controller/snapshot/metrics_test.go
@@ -23,10 +23,10 @@ import (
 func TestRecordSnapshotBuild(t *testing.T) {
 	// This test verifies the function doesn't panic
 	resourceCounts := map[string]int{
-		"routes":    10,
-		"backends":  5,
-		"policies":  3,
-		"gateways":  2,
+		"routes":   10,
+		"backends": 5,
+		"policies": 3,
+		"gateways": 2,
 	}
 
 	RecordSnapshotBuild("test-node", 0.001, 1024, resourceCounts)

--- a/internal/controller/vault/health_test.go
+++ b/internal/controller/vault/health_test.go
@@ -25,10 +25,12 @@ import (
 	"go.uber.org/zap"
 )
 
+const testHealthPath = "/v1/sys/health"
+
 func TestHealthStatus_IsHealthy(t *testing.T) {
 	tests := []struct {
-		name       string
-		status     HealthStatus
+		name        string
+		status      HealthStatus
 		wantHealthy bool
 	}{
 		{
@@ -118,7 +120,7 @@ func TestNewHealthChecker(t *testing.T) {
 func TestHealthChecker_Check_Healthy(t *testing.T) {
 	// Create a test server that returns healthy status
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/sys/health" {
+		if r.URL.Path == testHealthPath {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{
@@ -154,7 +156,7 @@ func TestHealthChecker_Check_Healthy(t *testing.T) {
 func TestHealthChecker_Check_Sealed(t *testing.T) {
 	// Create a test server that returns sealed status
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/sys/health" {
+		if r.URL.Path == testHealthPath {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte(`{
@@ -189,7 +191,7 @@ func TestHealthChecker_Check_NotInitialized(t *testing.T) {
 	// Create a test server that returns not initialized status
 	// Note: sealed must be false so we hit the !Initialized check first
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/sys/health" {
+		if r.URL.Path == testHealthPath {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte(`{
@@ -223,7 +225,7 @@ func TestHealthChecker_Check_NotInitialized(t *testing.T) {
 func TestHealthChecker_Check_Standby(t *testing.T) {
 	// Create a test server that returns standby status
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/sys/health" {
+		if r.URL.Path == testHealthPath {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte(`{
@@ -256,7 +258,7 @@ func TestHealthChecker_Check_Standby(t *testing.T) {
 
 func TestHealthChecker_Handler_Healthy(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/sys/health" {
+		if r.URL.Path == testHealthPath {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"initialized": true, "sealed": false, "standby": false}`))
@@ -291,7 +293,7 @@ func TestHealthChecker_Handler_Healthy(t *testing.T) {
 
 func TestHealthChecker_Handler_Unhealthy(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/sys/health" {
+		if r.URL.Path == testHealthPath {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte(`{"initialized": true, "sealed": true, "standby": false}`))
@@ -323,7 +325,7 @@ func TestHealthChecker_Handler_Unhealthy(t *testing.T) {
 
 func TestHealthChecker_CheckerFunc(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/sys/health" {
+		if r.URL.Path == testHealthPath {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"initialized": true, "sealed": false, "standby": false}`))

--- a/internal/pkg/grpclimits/grpclimits_additional_test.go
+++ b/internal/pkg/grpclimits/grpclimits_additional_test.go
@@ -45,7 +45,7 @@ func TestDefaultMaxConcurrentStreams(t *testing.T) {
 func TestServerOptions_ReturnsOptions(t *testing.T) {
 	logger := zap.NewNop()
 	opts := ServerOptions(logger)
-	
+
 	if len(opts) == 0 {
 		t.Error("ServerOptions() returned empty slice")
 	}
@@ -53,7 +53,7 @@ func TestServerOptions_ReturnsOptions(t *testing.T) {
 
 func TestClientOptions_ReturnsOptions(t *testing.T) {
 	opts := ClientOptions()
-	
+
 	if len(opts) == 0 {
 		t.Error("ClientOptions() returned empty slice")
 	}

--- a/internal/pkg/tlsutil/tls_test.go
+++ b/internal/pkg/tlsutil/tls_test.go
@@ -75,10 +75,11 @@ func generateTestCertificate(t *testing.T, commonName string, isCA bool) ([]byte
 }
 
 // generateTestCertificates creates CA, server, and client certificates for testing
-func generateTestCertificates(t *testing.T) (caCert, caKey, serverCert, serverKey, clientCert, clientKey []byte) {
+func generateTestCertificates(t *testing.T) (caCert, serverCert, serverKey, clientCert, clientKey []byte) {
 	t.Helper()
 
 	// Generate CA certificate
+	var caKey []byte
 	caCert, caKey = generateTestCertificate(t, "Test CA", true)
 
 	// Parse CA for signing
@@ -256,8 +257,7 @@ func TestCreateServerTLSConfig_InvalidCert(t *testing.T) {
 }
 
 func TestCreateServerTLSConfigWithMTLS(t *testing.T) {
-	caCert, caKey, serverCert, serverKey, _, _ := generateTestCertificates(t)
-	_ = caKey // Not used in this test
+	caCert, serverCert, serverKey, _, _ := generateTestCertificates(t)
 
 	config, err := CreateServerTLSConfigWithMTLS(serverCert, serverKey, caCert)
 	if err != nil {
@@ -315,7 +315,7 @@ func TestCreateClientTLSConfig(t *testing.T) {
 }
 
 func TestCreateClientTLSConfigWithMTLS(t *testing.T) {
-	caCert, _, _, _, clientCert, clientKey := generateTestCertificates(t)
+	caCert, _, _, clientCert, clientKey := generateTestCertificates(t)
 
 	config, err := CreateClientTLSConfigWithMTLS(clientCert, clientKey, caCert, "server.example.com")
 	if err != nil {
@@ -343,7 +343,7 @@ func TestCreateClientTLSConfigWithMTLS(t *testing.T) {
 }
 
 func TestCreateClientTLSConfigWithMTLS_InvalidCert(t *testing.T) {
-	caCert, _, _, _, _, _ := generateTestCertificates(t)
+	caCert, _, _, _, _ := generateTestCertificates(t)
 
 	_, err := CreateClientTLSConfigWithMTLS([]byte("invalid"), []byte("invalid"), caCert, "server.example.com")
 	if err == nil {
@@ -352,7 +352,7 @@ func TestCreateClientTLSConfigWithMTLS_InvalidCert(t *testing.T) {
 }
 
 func TestCreateClientTLSConfigWithMTLS_InvalidCA(t *testing.T) {
-	_, _, _, _, clientCert, clientKey := generateTestCertificates(t)
+	_, _, _, clientCert, clientKey := generateTestCertificates(t)
 
 	_, err := CreateClientTLSConfigWithMTLS(clientCert, clientKey, []byte("invalid-ca"), "server.example.com")
 	if err == nil {
@@ -361,47 +361,47 @@ func TestCreateClientTLSConfigWithMTLS_InvalidCA(t *testing.T) {
 }
 
 func TestCreateBackendTLSConfig(t *testing.T) {
-	caCert, _, _, _, _, _ := generateTestCertificates(t)
+	caCert, _, _, _, _ := generateTestCertificates(t)
 
 	tests := []struct {
-		name              string
-		caCertPEM         []byte
-		serverName        string
+		name               string
+		caCertPEM          []byte
+		serverName         string
 		insecureSkipVerify bool
-		wantInsecure      bool
-		wantRootCAs       bool
+		wantInsecure       bool
+		wantRootCAs        bool
 	}{
 		{
-			name:              "with CA cert",
-			caCertPEM:         caCert,
-			serverName:        "backend.example.com",
+			name:               "with CA cert",
+			caCertPEM:          caCert,
+			serverName:         "backend.example.com",
 			insecureSkipVerify: false,
-			wantInsecure:      false,
-			wantRootCAs:       true,
+			wantInsecure:       false,
+			wantRootCAs:        true,
 		},
 		{
-			name:              "without CA cert",
-			caCertPEM:         nil,
-			serverName:        "backend.example.com",
+			name:               "without CA cert",
+			caCertPEM:          nil,
+			serverName:         "backend.example.com",
 			insecureSkipVerify: false,
-			wantInsecure:      false,
-			wantRootCAs:       false,
+			wantInsecure:       false,
+			wantRootCAs:        false,
 		},
 		{
-			name:              "insecure skip verify",
-			caCertPEM:         nil,
-			serverName:        "backend.example.com",
+			name:               "insecure skip verify",
+			caCertPEM:          nil,
+			serverName:         "backend.example.com",
 			insecureSkipVerify: true,
-			wantInsecure:      true,
-			wantRootCAs:       false,
+			wantInsecure:       true,
+			wantRootCAs:        false,
 		},
 		{
-			name:              "insecure with CA cert",
-			caCertPEM:         caCert,
-			serverName:        "backend.example.com",
+			name:               "insecure with CA cert",
+			caCertPEM:          caCert,
+			serverName:         "backend.example.com",
 			insecureSkipVerify: true,
-			wantInsecure:      true,
-			wantRootCAs:       true,
+			wantInsecure:       true,
+			wantRootCAs:        true,
 		},
 	}
 
@@ -514,7 +514,7 @@ func TestCreateServerTLSConfigWithSNI_Wildcard(t *testing.T) {
 
 	// Test wildcard matching
 	tests := []struct {
-		serverName string
+		serverName  string
 		wantDefault bool
 	}{
 		{"www.example.com", false}, // Should match wildcard
@@ -568,17 +568,17 @@ func TestLoadServerTLSCredentials(t *testing.T) {
 	// Create temp directory for test files
 	tmpDir := t.TempDir()
 
-	caCert, _, serverCert, serverKey, _, _ := generateTestCertificates(t)
+	caCert, serverCert, serverKey, _, _ := generateTestCertificates(t)
 
 	// Write test files
 	caFile := filepath.Join(tmpDir, "ca.crt")
 	certFile := filepath.Join(tmpDir, "server.crt")
 	keyFile := filepath.Join(tmpDir, "server.key")
 
-	if err := os.WriteFile(caFile, caCert, 0644); err != nil {
+	if err := os.WriteFile(caFile, caCert, 0600); err != nil {
 		t.Fatalf("Failed to write CA file: %v", err)
 	}
-	if err := os.WriteFile(certFile, serverCert, 0644); err != nil {
+	if err := os.WriteFile(certFile, serverCert, 0600); err != nil {
 		t.Fatalf("Failed to write cert file: %v", err)
 	}
 	if err := os.WriteFile(keyFile, serverKey, 0600); err != nil {
@@ -598,10 +598,10 @@ func TestLoadServerTLSCredentials(t *testing.T) {
 func TestLoadServerTLSCredentials_MissingCert(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	caCert, _, _, _, _, _ := generateTestCertificates(t)
+	caCert, _, _, _, _ := generateTestCertificates(t)
 
 	caFile := filepath.Join(tmpDir, "ca.crt")
-	if err := os.WriteFile(caFile, caCert, 0644); err != nil {
+	if err := os.WriteFile(caFile, caCert, 0600); err != nil {
 		t.Fatalf("Failed to write CA file: %v", err)
 	}
 
@@ -614,12 +614,12 @@ func TestLoadServerTLSCredentials_MissingCert(t *testing.T) {
 func TestLoadServerTLSCredentials_MissingCA(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	_, _, serverCert, serverKey, _, _ := generateTestCertificates(t)
+	_, serverCert, serverKey, _, _ := generateTestCertificates(t)
 
 	certFile := filepath.Join(tmpDir, "server.crt")
 	keyFile := filepath.Join(tmpDir, "server.key")
 
-	if err := os.WriteFile(certFile, serverCert, 0644); err != nil {
+	if err := os.WriteFile(certFile, serverCert, 0600); err != nil {
 		t.Fatalf("Failed to write cert file: %v", err)
 	}
 	if err := os.WriteFile(keyFile, serverKey, 0600); err != nil {
@@ -635,16 +635,16 @@ func TestLoadServerTLSCredentials_MissingCA(t *testing.T) {
 func TestLoadClientTLSCredentials(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	caCert, _, _, _, clientCert, clientKey := generateTestCertificates(t)
+	caCert, _, _, clientCert, clientKey := generateTestCertificates(t)
 
 	caFile := filepath.Join(tmpDir, "ca.crt")
 	certFile := filepath.Join(tmpDir, "client.crt")
 	keyFile := filepath.Join(tmpDir, "client.key")
 
-	if err := os.WriteFile(caFile, caCert, 0644); err != nil {
+	if err := os.WriteFile(caFile, caCert, 0600); err != nil {
 		t.Fatalf("Failed to write CA file: %v", err)
 	}
-	if err := os.WriteFile(certFile, clientCert, 0644); err != nil {
+	if err := os.WriteFile(certFile, clientCert, 0600); err != nil {
 		t.Fatalf("Failed to write cert file: %v", err)
 	}
 	if err := os.WriteFile(keyFile, clientKey, 0600); err != nil {
@@ -664,10 +664,10 @@ func TestLoadClientTLSCredentials(t *testing.T) {
 func TestLoadClientTLSCredentials_MissingCert(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	caCert, _, _, _, _, _ := generateTestCertificates(t)
+	caCert, _, _, _, _ := generateTestCertificates(t)
 
 	caFile := filepath.Join(tmpDir, "ca.crt")
-	if err := os.WriteFile(caFile, caCert, 0644); err != nil {
+	if err := os.WriteFile(caFile, caCert, 0600); err != nil {
 		t.Fatalf("Failed to write CA file: %v", err)
 	}
 
@@ -678,7 +678,7 @@ func TestLoadClientTLSCredentials_MissingCert(t *testing.T) {
 }
 
 func TestLoadServerTLSCredentialsFromMemory(t *testing.T) {
-	caCert, _, serverCert, serverKey, _, _ := generateTestCertificates(t)
+	caCert, serverCert, serverKey, _, _ := generateTestCertificates(t)
 
 	creds, err := LoadServerTLSCredentialsFromMemory(serverCert, serverKey, caCert)
 	if err != nil {
@@ -691,7 +691,7 @@ func TestLoadServerTLSCredentialsFromMemory(t *testing.T) {
 }
 
 func TestLoadServerTLSCredentialsFromMemory_InvalidCert(t *testing.T) {
-	caCert, _, _, _, _, _ := generateTestCertificates(t)
+	caCert, _, _, _, _ := generateTestCertificates(t)
 
 	_, err := LoadServerTLSCredentialsFromMemory([]byte("invalid"), []byte("invalid"), caCert)
 	if err == nil {
@@ -700,7 +700,7 @@ func TestLoadServerTLSCredentialsFromMemory_InvalidCert(t *testing.T) {
 }
 
 func TestLoadServerTLSCredentialsFromMemory_InvalidCA(t *testing.T) {
-	_, _, serverCert, serverKey, _, _ := generateTestCertificates(t)
+	_, serverCert, serverKey, _, _ := generateTestCertificates(t)
 
 	_, err := LoadServerTLSCredentialsFromMemory(serverCert, serverKey, []byte("invalid-ca"))
 	if err == nil {
@@ -709,7 +709,7 @@ func TestLoadServerTLSCredentialsFromMemory_InvalidCA(t *testing.T) {
 }
 
 func TestLoadClientTLSCredentialsFromMemory(t *testing.T) {
-	caCert, _, _, _, clientCert, clientKey := generateTestCertificates(t)
+	caCert, _, _, clientCert, clientKey := generateTestCertificates(t)
 
 	creds, err := LoadClientTLSCredentialsFromMemory(clientCert, clientKey, caCert, "server.example.com")
 	if err != nil {
@@ -722,7 +722,7 @@ func TestLoadClientTLSCredentialsFromMemory(t *testing.T) {
 }
 
 func TestLoadClientTLSCredentialsFromMemory_InvalidCert(t *testing.T) {
-	caCert, _, _, _, _, _ := generateTestCertificates(t)
+	caCert, _, _, _, _ := generateTestCertificates(t)
 
 	_, err := LoadClientTLSCredentialsFromMemory([]byte("invalid"), []byte("invalid"), caCert, "server.example.com")
 	if err == nil {
@@ -731,7 +731,7 @@ func TestLoadClientTLSCredentialsFromMemory_InvalidCert(t *testing.T) {
 }
 
 func TestLoadClientTLSCredentialsFromMemory_InvalidCA(t *testing.T) {
-	_, _, _, _, clientCert, clientKey := generateTestCertificates(t)
+	_, _, _, clientCert, clientKey := generateTestCertificates(t)
 
 	_, err := LoadClientTLSCredentialsFromMemory(clientCert, clientKey, []byte("invalid-ca"), "server.example.com")
 	if err == nil {
@@ -776,8 +776,8 @@ func TestSNIConfig_DefaultFallback(t *testing.T) {
 	// When Certificates map is empty, GetCertificate is not set
 	// The default cert is in config.Certificates[0] instead
 	sniConfig := &SNIConfig{
-		DefaultCert:   defaultCert,
-		Certificates:  map[string]tls.Certificate{},
+		DefaultCert:  defaultCert,
+		Certificates: map[string]tls.Certificate{},
 	}
 
 	config, err := CreateServerTLSConfigWithSNI(sniConfig)
@@ -818,9 +818,9 @@ func TestParseTLSVersion(t *testing.T) {
 
 func TestParseCipherSuites(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    []string
-		wantLen  int // > 0 means we expect specific suites
+		name    string
+		input   []string
+		wantLen int // > 0 means we expect specific suites
 	}{
 		{
 			name:    "empty returns defaults",


### PR DESCRIPTION
## Summary
- Fix all 32 lint findings across 19 test files (gofmt, goconst, gosec, staticcheck, unparam, ineffassign, revive)
- Extract repeated string literals to test constants
- Fix file permissions, integer overflow, nil pointer dereference, unused params, and shadowed built-in

## Test plan
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go test ./...` all pass
- [x] `go build ./...` clean

Resolves #232