### PR TITLE
[Feature] Implement BFD UDP packet transmission and reception (RFC 5880)

### DIFF
--- a/internal/agent/vip/bfd.go
+++ b/internal/agent/vip/bfd.go
@@ -19,6 +19,7 @@ package vip
 import (
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -135,8 +136,17 @@ type BFDManager struct {
 	// Callback when BFD detects a neighbor is down
 	onNeighborDown func(peerIP net.IP)
 
-	// One-time warning for unimplemented packet transmission
-	txWarningOnce sync.Once
+	// UDP transport for BFD control packets
+	transport *bfdTransport
+
+	// ListenPort is the UDP port to listen on for BFD control packets.
+	// Defaults to bfdControlPort (3784). Set to 0 for OS-assigned port in tests.
+	ListenPort int
+
+	// PeerPort is the destination UDP port for sending BFD control packets.
+	// Defaults to bfdControlPort (3784). Override for testing with multiple
+	// managers on localhost.
+	PeerPort int
 }
 
 // BFD Prometheus metrics
@@ -184,6 +194,8 @@ func NewBFDManager(logger *zap.Logger, onNeighborDown func(peerIP net.IP)) *BFDM
 		ctx:               ctx,
 		cancel:            cancel,
 		onNeighborDown:    onNeighborDown,
+		ListenPort:        bfdControlPort,
+		PeerPort:          bfdControlPort,
 	}
 }
 
@@ -194,6 +206,18 @@ func (m *BFDManager) Start(ctx context.Context) error {
 	m.mu.Unlock()
 
 	m.logger.Info("Starting BFD manager")
+
+	// Start the UDP transport for BFD control packets
+	transport := newBFDTransport(m.logger, m, m.ListenPort)
+	if err := transport.Start(m.ctx); err != nil {
+		m.logger.Warn("Failed to start BFD transport, running without UDP",
+			zap.Error(err),
+		)
+	} else {
+		m.mu.Lock()
+		m.transport = transport
+		m.mu.Unlock()
+	}
 
 	// Start the detection timer loop
 	go m.detectionLoop()
@@ -208,6 +232,11 @@ func (m *BFDManager) Start(ctx context.Context) error {
 func (m *BFDManager) Stop() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.transport != nil {
+		m.transport.Stop()
+		m.transport = nil
+	}
 
 	if m.cancel != nil {
 		m.cancel()
@@ -476,12 +505,14 @@ func (m *BFDManager) transmitLoop() {
 	}
 }
 
-// sendControlPackets sends BFD control packets for all active sessions.
-// TODO: Implement actual UDP packet transmission per RFC 5880 Section 4.1.
+// sendControlPackets sends BFD control packets for all active sessions via
+// the UDP transport. If the transport is nil (e.g., in unit tests that don't
+// require UDP), the method updates metrics and timestamps without sending.
 func (m *BFDManager) sendControlPackets() {
-	m.txWarningOnce.Do(func() {
-		m.logger.Warn("BFD control packet transmission not yet implemented - using BGP hold timer for failover detection")
-	})
+	m.mu.RLock()
+	transport := m.transport
+	peerPort := m.PeerPort
+	m.mu.RUnlock()
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -497,20 +528,42 @@ func (m *BFDManager) sendControlPackets() {
 		}
 
 		// Check if it's time to send a packet
-		if session.lastPacketSent.IsZero() || now.Sub(session.lastPacketSent) >= session.desiredMinTxInterval {
-			// In a production implementation, this would send actual BFD
-			// control packets over UDP port 3784. The packet format is defined
-			// in RFC 5880 Section 4.1. For now, we log and update metrics.
-			session.lastPacketSent = now
-			session.packetsTx++
-
-			bfdPacketTx.WithLabelValues(peerKey).Inc()
-
-			session.logger.Debug("BFD control packet sent",
-				zap.String("state", session.state.String()),
-				zap.Uint32("local_discr", session.localDiscriminator),
-			)
+		if !session.lastPacketSent.IsZero() && now.Sub(session.lastPacketSent) < session.desiredMinTxInterval {
+			session.mu.Unlock()
+			continue
 		}
+
+		// Build BFD control packet from session state
+		pkt := &bfdControlPacket{
+			Version:               bfdVersion,
+			Diagnostic:            bfdDiagNone,
+			State:                 session.state,
+			DetectMult:            clampInt32ToUint8(session.detectMultiplier),
+			MyDiscriminator:       session.localDiscriminator,
+			YourDiscriminator:     session.remoteDiscriminator,
+			DesiredMinTxInterval:  clampDurationToMicroseconds(session.desiredMinTxInterval),
+			RequiredMinRxInterval: clampDurationToMicroseconds(session.requiredMinRxInterval),
+		}
+
+		// Send via transport if available
+		if transport != nil {
+			if err := transport.Send(session.peerAddress, peerPort, pkt); err != nil {
+				session.logger.Debug("Failed to send BFD control packet",
+					zap.Error(err),
+				)
+				session.mu.Unlock()
+				continue
+			}
+		}
+
+		session.lastPacketSent = now
+		session.packetsTx++
+		bfdPacketTx.WithLabelValues(peerKey).Inc()
+
+		session.logger.Debug("BFD control packet sent",
+			zap.String("state", session.state.String()),
+			zap.Uint32("local_discr", session.localDiscriminator),
+		)
 
 		session.mu.Unlock()
 	}
@@ -542,4 +595,17 @@ func (m *BFDManager) GetSessionStats(peerIP net.IP) (packetsRx, packetsTx, flaps
 		return session.packetsRx, session.packetsTx, session.sessionFlaps, true
 	}
 	return 0, 0, 0, false
+}
+
+// clampDurationToMicroseconds safely converts a time.Duration to microseconds
+// as uint32, clamping to [0, math.MaxUint32] to avoid overflow (gosec G115).
+func clampDurationToMicroseconds(d time.Duration) uint32 {
+	us := int64(d / time.Microsecond)
+	if us < 0 {
+		return 0
+	}
+	if us > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(us)
 }

--- a/internal/agent/vip/bfd_packet.go
+++ b/internal/agent/vip/bfd_packet.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vip
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// BFD control packet constants per RFC 5880 Section 4.1
+const (
+	bfdPacketLength = 24 // Fixed header length without authentication
+	bfdVersion      = 1  // BFD protocol version
+)
+
+// BFD diagnostic values per RFC 5880 Section 4.1
+const (
+	bfdDiagNone                 uint8 = 0
+	bfdDiagControlDetectExpired uint8 = 1
+	bfdDiagEchoFailed           uint8 = 2
+	bfdDiagNeighborDown         uint8 = 3
+	bfdDiagForwardingReset      uint8 = 4
+	bfdDiagPathDown             uint8 = 5
+	bfdDiagConcatPathDown       uint8 = 6
+	bfdDiagAdminDown            uint8 = 7
+)
+
+// bfdControlPacket represents a BFD control packet per RFC 5880 Section 4.1.
+//
+// Packet layout (24 bytes):
+//
+//	Byte 0:  Version (3 bits) | Diagnostic (5 bits)
+//	Byte 1:  State (2 bits) | P | F | C | A | D | M flags
+//	Byte 2:  Detect Multiplier
+//	Byte 3:  Length
+//	Bytes 4-7:   My Discriminator (uint32 big-endian)
+//	Bytes 8-11:  Your Discriminator (uint32 big-endian)
+//	Bytes 12-15: Desired Min TX Interval (uint32 big-endian, microseconds)
+//	Bytes 16-19: Required Min RX Interval (uint32 big-endian, microseconds)
+//	Bytes 20-23: Required Min Echo RX Interval (uint32 big-endian, microseconds)
+type bfdControlPacket struct {
+	Version                   uint8
+	Diagnostic                uint8
+	State                     BFDSessionState
+	Poll                      bool
+	Final                     bool
+	ControlPlaneIndependent   bool
+	AuthPresent               bool
+	Demand                    bool
+	Multipoint                bool
+	DetectMult                uint8
+	MyDiscriminator           uint32
+	YourDiscriminator         uint32
+	DesiredMinTxInterval      uint32 // microseconds
+	RequiredMinRxInterval     uint32 // microseconds
+	RequiredMinEchoRxInterval uint32 // microseconds
+}
+
+var (
+	errBFDPacketTooShort = errors.New("BFD packet too short: minimum 24 bytes required")
+	errBFDInvalidVersion = errors.New("BFD packet has invalid version: expected 1")
+	errBFDInvalidLength  = errors.New("BFD packet length field does not match actual length")
+)
+
+// encodeBFDPacket encodes a BFD control packet into its wire format per RFC 5880.
+func encodeBFDPacket(pkt *bfdControlPacket) ([]byte, error) {
+	if pkt == nil {
+		return nil, errors.New("cannot encode nil BFD packet")
+	}
+
+	buf := make([]byte, bfdPacketLength)
+
+	// Byte 0: Version (3 bits) | Diagnostic (5 bits)
+	buf[0] = (pkt.Version & 0x07 << 5) | (pkt.Diagnostic & 0x1F)
+
+	// Byte 1: State (2 bits) | P | F | C | A | D | M flags
+	buf[1] = clampInt32ToUint8(int32(pkt.State)&0x03) << 6
+	if pkt.Poll {
+		buf[1] |= 0x20
+	}
+	if pkt.Final {
+		buf[1] |= 0x10
+	}
+	if pkt.ControlPlaneIndependent {
+		buf[1] |= 0x08
+	}
+	if pkt.AuthPresent {
+		buf[1] |= 0x04
+	}
+	if pkt.Demand {
+		buf[1] |= 0x02
+	}
+	if pkt.Multipoint {
+		buf[1] |= 0x01
+	}
+
+	// Byte 2: Detect Multiplier
+	buf[2] = pkt.DetectMult
+
+	// Byte 3: Length
+	buf[3] = bfdPacketLength
+
+	// Bytes 4-7: My Discriminator
+	binary.BigEndian.PutUint32(buf[4:8], pkt.MyDiscriminator)
+
+	// Bytes 8-11: Your Discriminator
+	binary.BigEndian.PutUint32(buf[8:12], pkt.YourDiscriminator)
+
+	// Bytes 12-15: Desired Min TX Interval
+	binary.BigEndian.PutUint32(buf[12:16], pkt.DesiredMinTxInterval)
+
+	// Bytes 16-19: Required Min RX Interval
+	binary.BigEndian.PutUint32(buf[16:20], pkt.RequiredMinRxInterval)
+
+	// Bytes 20-23: Required Min Echo RX Interval
+	binary.BigEndian.PutUint32(buf[20:24], pkt.RequiredMinEchoRxInterval)
+
+	return buf, nil
+}
+
+// decodeBFDPacket decodes a BFD control packet from its wire format per RFC 5880.
+func decodeBFDPacket(data []byte) (*bfdControlPacket, error) {
+	if len(data) < bfdPacketLength {
+		return nil, fmt.Errorf("%w: got %d bytes", errBFDPacketTooShort, len(data))
+	}
+
+	pkt := &bfdControlPacket{}
+
+	// Byte 0: Version (3 bits) | Diagnostic (5 bits)
+	pkt.Version = (data[0] >> 5) & 0x07
+	pkt.Diagnostic = data[0] & 0x1F
+
+	if pkt.Version != bfdVersion {
+		return nil, fmt.Errorf("%w: got %d", errBFDInvalidVersion, pkt.Version)
+	}
+
+	// Byte 1: State (2 bits) | P | F | C | A | D | M flags
+	pkt.State = BFDSessionState((data[1] >> 6) & 0x03)
+	pkt.Poll = data[1]&0x20 != 0
+	pkt.Final = data[1]&0x10 != 0
+	pkt.ControlPlaneIndependent = data[1]&0x08 != 0
+	pkt.AuthPresent = data[1]&0x04 != 0
+	pkt.Demand = data[1]&0x02 != 0
+	pkt.Multipoint = data[1]&0x01 != 0
+
+	// Byte 2: Detect Multiplier
+	pkt.DetectMult = data[2]
+
+	// Byte 3: Length validation
+	pktLen := data[3]
+	if int(pktLen) > len(data) {
+		return nil, fmt.Errorf("%w: header says %d but got %d bytes", errBFDInvalidLength, pktLen, len(data))
+	}
+
+	// Bytes 4-7: My Discriminator
+	pkt.MyDiscriminator = binary.BigEndian.Uint32(data[4:8])
+
+	// Bytes 8-11: Your Discriminator
+	pkt.YourDiscriminator = binary.BigEndian.Uint32(data[8:12])
+
+	// Bytes 12-15: Desired Min TX Interval
+	pkt.DesiredMinTxInterval = binary.BigEndian.Uint32(data[12:16])
+
+	// Bytes 16-19: Required Min RX Interval
+	pkt.RequiredMinRxInterval = binary.BigEndian.Uint32(data[16:20])
+
+	// Bytes 20-23: Required Min Echo RX Interval
+	pkt.RequiredMinEchoRxInterval = binary.BigEndian.Uint32(data[20:24])
+
+	return pkt, nil
+}
+
+// clampInt32ToUint8 safely converts an int32 to uint8, clamping to
+// [0, 255] to avoid integer overflow (gosec G115).
+func clampInt32ToUint8(v int32) uint8 {
+	if v < 0 {
+		return 0
+	}
+	if v > 255 {
+		return 255
+	}
+	return uint8(v)
+}

--- a/internal/agent/vip/bfd_packet_test.go
+++ b/internal/agent/vip/bfd_packet_test.go
@@ -1,0 +1,467 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vip
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+func TestEncodeBFDPacket_Basic(t *testing.T) {
+	pkt := &bfdControlPacket{
+		Version:               bfdVersion,
+		Diagnostic:            bfdDiagNone,
+		State:                 BFDStateUp,
+		DetectMult:            3,
+		MyDiscriminator:       42,
+		YourDiscriminator:     99,
+		DesiredMinTxInterval:  300000,
+		RequiredMinRxInterval: 300000,
+	}
+
+	data, err := encodeBFDPacket(pkt)
+	if err != nil {
+		t.Fatalf("encodeBFDPacket failed: %v", err)
+	}
+
+	if len(data) != bfdPacketLength {
+		t.Fatalf("expected %d bytes, got %d", bfdPacketLength, len(data))
+	}
+
+	// Verify version (bits 7-5 of byte 0) = 1
+	version := (data[0] >> 5) & 0x07
+	if version != 1 {
+		t.Errorf("expected version 1, got %d", version)
+	}
+
+	// Verify diagnostic (bits 4-0 of byte 0) = 0
+	diag := data[0] & 0x1F
+	if diag != 0 {
+		t.Errorf("expected diagnostic 0, got %d", diag)
+	}
+
+	// Verify state (bits 7-6 of byte 1) = 3 (Up)
+	state := (data[1] >> 6) & 0x03
+	if state != 3 {
+		t.Errorf("expected state 3 (Up), got %d", state)
+	}
+
+	// Verify detect multiplier
+	if data[2] != 3 {
+		t.Errorf("expected detect mult 3, got %d", data[2])
+	}
+
+	// Verify length
+	if data[3] != bfdPacketLength {
+		t.Errorf("expected length %d, got %d", bfdPacketLength, data[3])
+	}
+
+	// Verify my discriminator
+	myDiscr := binary.BigEndian.Uint32(data[4:8])
+	if myDiscr != 42 {
+		t.Errorf("expected my discriminator 42, got %d", myDiscr)
+	}
+
+	// Verify your discriminator
+	yourDiscr := binary.BigEndian.Uint32(data[8:12])
+	if yourDiscr != 99 {
+		t.Errorf("expected your discriminator 99, got %d", yourDiscr)
+	}
+
+	// Verify desired min TX interval
+	desiredMinTx := binary.BigEndian.Uint32(data[12:16])
+	if desiredMinTx != 300000 {
+		t.Errorf("expected desired min TX 300000, got %d", desiredMinTx)
+	}
+
+	// Verify required min RX interval
+	requiredMinRx := binary.BigEndian.Uint32(data[16:20])
+	if requiredMinRx != 300000 {
+		t.Errorf("expected required min RX 300000, got %d", requiredMinRx)
+	}
+
+	// Verify required min echo RX interval = 0 (default)
+	echoRx := binary.BigEndian.Uint32(data[20:24])
+	if echoRx != 0 {
+		t.Errorf("expected echo RX 0, got %d", echoRx)
+	}
+}
+
+func TestEncodeBFDPacket_NilPacket(t *testing.T) {
+	_, err := encodeBFDPacket(nil)
+	if err == nil {
+		t.Fatal("expected error for nil packet")
+	}
+}
+
+func TestDecodeBFDPacket_TooShort(t *testing.T) {
+	_, err := decodeBFDPacket(make([]byte, 10))
+	if err == nil {
+		t.Fatal("expected error for short packet")
+	}
+	if !errors.Is(err, errBFDPacketTooShort) {
+		t.Errorf("expected errBFDPacketTooShort, got %v", err)
+	}
+}
+
+func TestDecodeBFDPacket_InvalidVersion(t *testing.T) {
+	data := make([]byte, bfdPacketLength)
+	// Set version to 2 (invalid)
+	data[0] = 2 << 5
+	data[3] = bfdPacketLength
+
+	_, err := decodeBFDPacket(data)
+	if err == nil {
+		t.Fatal("expected error for invalid version")
+	}
+	if !errors.Is(err, errBFDInvalidVersion) {
+		t.Errorf("expected errBFDInvalidVersion, got %v", err)
+	}
+}
+
+func TestDecodeBFDPacket_InvalidLength(t *testing.T) {
+	data := make([]byte, bfdPacketLength)
+	// Set version to 1
+	data[0] = 1 << 5
+	// Set length field larger than actual data
+	data[3] = 48
+
+	_, err := decodeBFDPacket(data)
+	if err == nil {
+		t.Fatal("expected error for mismatched length")
+	}
+	if !errors.Is(err, errBFDInvalidLength) {
+		t.Errorf("expected errBFDInvalidLength, got %v", err)
+	}
+}
+
+func TestBFDPacket_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		pkt  *bfdControlPacket
+	}{
+		{
+			name: "AdminDown state",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				Diagnostic:            bfdDiagAdminDown,
+				State:                 BFDStateAdminDown,
+				DetectMult:            3,
+				MyDiscriminator:       1,
+				YourDiscriminator:     0,
+				DesiredMinTxInterval:  1000000,
+				RequiredMinRxInterval: 1000000,
+			},
+		},
+		{
+			name: "Down state",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				Diagnostic:            bfdDiagNone,
+				State:                 BFDStateDown,
+				DetectMult:            5,
+				MyDiscriminator:       100,
+				YourDiscriminator:     0,
+				DesiredMinTxInterval:  300000,
+				RequiredMinRxInterval: 300000,
+			},
+		},
+		{
+			name: "Init state",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				Diagnostic:            bfdDiagNone,
+				State:                 BFDStateInit,
+				DetectMult:            3,
+				MyDiscriminator:       200,
+				YourDiscriminator:     100,
+				DesiredMinTxInterval:  300000,
+				RequiredMinRxInterval: 300000,
+			},
+		},
+		{
+			name: "Up state with all flags",
+			pkt: &bfdControlPacket{
+				Version:                   bfdVersion,
+				Diagnostic:                bfdDiagNone,
+				State:                     BFDStateUp,
+				Poll:                      true,
+				Final:                     true,
+				ControlPlaneIndependent:   true,
+				AuthPresent:               true,
+				Demand:                    true,
+				Multipoint:                true,
+				DetectMult:                3,
+				MyDiscriminator:           500,
+				YourDiscriminator:         600,
+				DesiredMinTxInterval:      300000,
+				RequiredMinRxInterval:     300000,
+				RequiredMinEchoRxInterval: 50000,
+			},
+		},
+		{
+			name: "Poll flag only",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				State:                 BFDStateUp,
+				Poll:                  true,
+				DetectMult:            3,
+				MyDiscriminator:       1,
+				YourDiscriminator:     2,
+				DesiredMinTxInterval:  300000,
+				RequiredMinRxInterval: 300000,
+			},
+		},
+		{
+			name: "Final flag only",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				State:                 BFDStateUp,
+				Final:                 true,
+				DetectMult:            3,
+				MyDiscriminator:       1,
+				YourDiscriminator:     2,
+				DesiredMinTxInterval:  300000,
+				RequiredMinRxInterval: 300000,
+			},
+		},
+		{
+			name: "Control plane independent flag only",
+			pkt: &bfdControlPacket{
+				Version:                 bfdVersion,
+				State:                   BFDStateDown,
+				ControlPlaneIndependent: true,
+				DetectMult:              3,
+				MyDiscriminator:         1,
+				DesiredMinTxInterval:    300000,
+				RequiredMinRxInterval:   300000,
+			},
+		},
+		{
+			name: "Large discriminator values",
+			pkt: &bfdControlPacket{
+				Version:                   bfdVersion,
+				State:                     BFDStateUp,
+				DetectMult:                255,
+				MyDiscriminator:           0xFFFFFFFF,
+				YourDiscriminator:         0xDEADBEEF,
+				DesiredMinTxInterval:      0xFFFFFFFF,
+				RequiredMinRxInterval:     0xFFFFFFFF,
+				RequiredMinEchoRxInterval: 0xFFFFFFFF,
+			},
+		},
+		{
+			name: "Diagnostic - control detect expired",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				Diagnostic:            bfdDiagControlDetectExpired,
+				State:                 BFDStateDown,
+				DetectMult:            3,
+				MyDiscriminator:       10,
+				DesiredMinTxInterval:  300000,
+				RequiredMinRxInterval: 300000,
+			},
+		},
+		{
+			name: "Diagnostic - neighbor down",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				Diagnostic:            bfdDiagNeighborDown,
+				State:                 BFDStateDown,
+				DetectMult:            3,
+				MyDiscriminator:       10,
+				DesiredMinTxInterval:  300000,
+				RequiredMinRxInterval: 300000,
+			},
+		},
+		{
+			name: "Diagnostic - path down",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				Diagnostic:            bfdDiagPathDown,
+				State:                 BFDStateDown,
+				DetectMult:            3,
+				MyDiscriminator:       10,
+				DesiredMinTxInterval:  300000,
+				RequiredMinRxInterval: 300000,
+			},
+		},
+		{
+			name: "Diagnostic - forwarding reset",
+			pkt: &bfdControlPacket{
+				Version:               bfdVersion,
+				Diagnostic:            bfdDiagForwardingReset,
+				State:                 BFDStateDown,
+				DetectMult:            3,
+				MyDiscriminator:       10,
+				DesiredMinTxInterval:  300000,
+				RequiredMinRxInterval: 300000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := encodeBFDPacket(tt.pkt)
+			if err != nil {
+				t.Fatalf("encodeBFDPacket failed: %v", err)
+			}
+
+			decoded, err := decodeBFDPacket(data)
+			if err != nil {
+				t.Fatalf("decodeBFDPacket failed: %v", err)
+			}
+
+			if decoded.Version != tt.pkt.Version {
+				t.Errorf("Version: got %d, want %d", decoded.Version, tt.pkt.Version)
+			}
+			if decoded.Diagnostic != tt.pkt.Diagnostic {
+				t.Errorf("Diagnostic: got %d, want %d", decoded.Diagnostic, tt.pkt.Diagnostic)
+			}
+			if decoded.State != tt.pkt.State {
+				t.Errorf("State: got %v, want %v", decoded.State, tt.pkt.State)
+			}
+			if decoded.Poll != tt.pkt.Poll {
+				t.Errorf("Poll: got %v, want %v", decoded.Poll, tt.pkt.Poll)
+			}
+			if decoded.Final != tt.pkt.Final {
+				t.Errorf("Final: got %v, want %v", decoded.Final, tt.pkt.Final)
+			}
+			if decoded.ControlPlaneIndependent != tt.pkt.ControlPlaneIndependent {
+				t.Errorf("ControlPlaneIndependent: got %v, want %v", decoded.ControlPlaneIndependent, tt.pkt.ControlPlaneIndependent)
+			}
+			if decoded.AuthPresent != tt.pkt.AuthPresent {
+				t.Errorf("AuthPresent: got %v, want %v", decoded.AuthPresent, tt.pkt.AuthPresent)
+			}
+			if decoded.Demand != tt.pkt.Demand {
+				t.Errorf("Demand: got %v, want %v", decoded.Demand, tt.pkt.Demand)
+			}
+			if decoded.Multipoint != tt.pkt.Multipoint {
+				t.Errorf("Multipoint: got %v, want %v", decoded.Multipoint, tt.pkt.Multipoint)
+			}
+			if decoded.DetectMult != tt.pkt.DetectMult {
+				t.Errorf("DetectMult: got %d, want %d", decoded.DetectMult, tt.pkt.DetectMult)
+			}
+			if decoded.MyDiscriminator != tt.pkt.MyDiscriminator {
+				t.Errorf("MyDiscriminator: got %d, want %d", decoded.MyDiscriminator, tt.pkt.MyDiscriminator)
+			}
+			if decoded.YourDiscriminator != tt.pkt.YourDiscriminator {
+				t.Errorf("YourDiscriminator: got %d, want %d", decoded.YourDiscriminator, tt.pkt.YourDiscriminator)
+			}
+			if decoded.DesiredMinTxInterval != tt.pkt.DesiredMinTxInterval {
+				t.Errorf("DesiredMinTxInterval: got %d, want %d", decoded.DesiredMinTxInterval, tt.pkt.DesiredMinTxInterval)
+			}
+			if decoded.RequiredMinRxInterval != tt.pkt.RequiredMinRxInterval {
+				t.Errorf("RequiredMinRxInterval: got %d, want %d", decoded.RequiredMinRxInterval, tt.pkt.RequiredMinRxInterval)
+			}
+			if decoded.RequiredMinEchoRxInterval != tt.pkt.RequiredMinEchoRxInterval {
+				t.Errorf("RequiredMinEchoRxInterval: got %d, want %d", decoded.RequiredMinEchoRxInterval, tt.pkt.RequiredMinEchoRxInterval)
+			}
+		})
+	}
+}
+
+func TestBFDPacket_ByteLevelEncoding(t *testing.T) {
+	// Manually construct a packet and verify exact byte layout per RFC 5880
+	pkt := &bfdControlPacket{
+		Version:                   1,
+		Diagnostic:                bfdDiagControlDetectExpired, // 1
+		State:                     BFDStateUp,                  // 3
+		Poll:                      true,
+		Final:                     false,
+		ControlPlaneIndependent:   false,
+		AuthPresent:               false,
+		Demand:                    false,
+		Multipoint:                false,
+		DetectMult:                3,
+		MyDiscriminator:           0x00000001,
+		YourDiscriminator:         0x00000002,
+		DesiredMinTxInterval:      300000, // 0x000493E0
+		RequiredMinRxInterval:     300000, // 0x000493E0
+		RequiredMinEchoRxInterval: 0,
+	}
+
+	data, err := encodeBFDPacket(pkt)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	// Byte 0: version=1 (001 in bits 7-5) | diagnostic=1 (00001 in bits 4-0) = 0x21
+	expectedByte0 := byte(0x21)
+	if data[0] != expectedByte0 {
+		t.Errorf("byte 0: got 0x%02X, want 0x%02X", data[0], expectedByte0)
+	}
+
+	// Byte 1: state=3 (11 in bits 7-6) | P=1 | F=0 | C=0 | A=0 | D=0 | M=0 = 0xE0
+	expectedByte1 := byte(0xE0)
+	if data[1] != expectedByte1 {
+		t.Errorf("byte 1: got 0x%02X, want 0x%02X", data[1], expectedByte1)
+	}
+
+	// Byte 2: detect multiplier = 3
+	if data[2] != 3 {
+		t.Errorf("byte 2: got %d, want 3", data[2])
+	}
+
+	// Byte 3: length = 24
+	if data[3] != 24 {
+		t.Errorf("byte 3: got %d, want 24", data[3])
+	}
+}
+
+func TestDecodeBFDPacket_EmptyData(t *testing.T) {
+	_, err := decodeBFDPacket(nil)
+	if err == nil {
+		t.Fatal("expected error for nil data")
+	}
+
+	_, err = decodeBFDPacket([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty data")
+	}
+}
+
+func TestBFDPacket_ExtraDataAfterPacket(t *testing.T) {
+	// A valid packet with extra bytes appended should still decode correctly
+	pkt := &bfdControlPacket{
+		Version:               bfdVersion,
+		State:                 BFDStateDown,
+		DetectMult:            3,
+		MyDiscriminator:       42,
+		DesiredMinTxInterval:  300000,
+		RequiredMinRxInterval: 300000,
+	}
+
+	data, err := encodeBFDPacket(pkt)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	// Append extra bytes
+	dataWithExtra := make([]byte, len(data)+10)
+	copy(dataWithExtra, data)
+
+	decoded, err := decodeBFDPacket(dataWithExtra)
+	if err != nil {
+		t.Fatalf("decode with extra data failed: %v", err)
+	}
+
+	if decoded.MyDiscriminator != 42 {
+		t.Errorf("MyDiscriminator: got %d, want 42", decoded.MyDiscriminator)
+	}
+}

--- a/internal/agent/vip/bfd_test.go
+++ b/internal/agent/vip/bfd_test.go
@@ -235,6 +235,8 @@ func TestBFDManager_DetectionTimeout(t *testing.T) {
 func TestBFDManager_StartStop(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	manager := NewBFDManager(logger, nil)
+	// Use port 0 so the OS assigns an ephemeral port
+	manager.ListenPort = 0
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -325,4 +327,241 @@ func TestBFDManager_ConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// Transport tests
+
+func TestBFDTransport_StartStop(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	manager := NewBFDManager(logger, nil)
+
+	transport := newBFDTransport(logger, manager, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := transport.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start transport: %v", err)
+	}
+
+	port := transport.LocalPort()
+	if port == 0 {
+		t.Fatal("Expected non-zero local port after start")
+	}
+
+	transport.Stop()
+}
+
+func TestBFDTransport_SendReceive(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Create a manager and transport that receives packets
+	receivedCh := make(chan struct{}, 1)
+	manager := NewBFDManager(logger, nil)
+
+	// Add a session so ProcessPacket actually processes incoming data
+	peerIP := net.IPv4(127, 0, 0, 1)
+	err := manager.AddSession(peerIP, BFDConfig{DetectMultiplier: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap onStateChange to signal receipt
+	manager.mu.Lock()
+	session := manager.sessions[peerIP.String()]
+	origOnStateChange := session.onStateChange
+	session.onStateChange = func(peer net.IP, oldState, newState BFDSessionState) {
+		if origOnStateChange != nil {
+			origOnStateChange(peer, oldState, newState)
+		}
+		select {
+		case receivedCh <- struct{}{}:
+		default:
+		}
+	}
+	manager.mu.Unlock()
+
+	// Start receiving transport
+	rxTransport := newBFDTransport(logger, manager, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = rxTransport.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start rx transport: %v", err)
+	}
+	defer rxTransport.Stop()
+
+	rxPort := rxTransport.LocalPort()
+
+	// Start sending transport
+	txTransport := newBFDTransport(logger, nil, 0)
+	err = txTransport.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start tx transport: %v", err)
+	}
+	defer txTransport.Stop()
+
+	// Send a BFD Down packet (triggers Down -> Init transition)
+	pkt := &bfdControlPacket{
+		Version:               bfdVersion,
+		State:                 BFDStateDown,
+		DetectMult:            3,
+		MyDiscriminator:       999,
+		DesiredMinTxInterval:  300000,
+		RequiredMinRxInterval: 300000,
+	}
+
+	err = txTransport.Send(net.IPv4(127, 0, 0, 1), rxPort, pkt)
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Wait for the packet to be received and processed
+	select {
+	case <-receivedCh:
+		// Packet received, state should have changed
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for packet receipt")
+	}
+
+	// Verify the session transitioned from Down to Init
+	state := manager.GetSessionState(peerIP)
+	if state != BFDStateInit {
+		t.Errorf("Expected Init after receiving Down packet, got %s", state.String())
+	}
+}
+
+func TestBFDTransport_SendWithoutStart(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	transport := newBFDTransport(logger, nil, 0)
+
+	pkt := &bfdControlPacket{
+		Version:    bfdVersion,
+		State:      BFDStateDown,
+		DetectMult: 3,
+	}
+
+	err := transport.Send(net.IPv4(127, 0, 0, 1), 3784, pkt)
+	if err == nil {
+		t.Fatal("Expected error when sending without starting transport")
+	}
+}
+
+func TestBFDManager_TwoPeersIntegration(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Create two BFD managers simulating two peers on localhost
+	manager1 := NewBFDManager(logger.Named("peer1"), nil)
+	manager1.ListenPort = 0
+
+	manager2 := NewBFDManager(logger.Named("peer2"), nil)
+	manager2.ListenPort = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Start both managers
+	err := manager1.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start manager1: %v", err)
+	}
+	defer manager1.Stop()
+
+	err = manager2.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start manager2: %v", err)
+	}
+	defer manager2.Stop()
+
+	// Get the actual ports each manager is listening on
+	manager1.mu.RLock()
+	port1 := manager1.transport.LocalPort()
+	manager1.mu.RUnlock()
+
+	manager2.mu.RLock()
+	port2 := manager2.transport.LocalPort()
+	manager2.mu.RUnlock()
+
+	// Configure each manager to send to the other's port
+	manager1.mu.Lock()
+	manager1.PeerPort = port2
+	manager1.mu.Unlock()
+
+	manager2.mu.Lock()
+	manager2.PeerPort = port1
+	manager2.mu.Unlock()
+
+	loopback := net.IPv4(127, 0, 0, 1)
+	config := BFDConfig{
+		DetectMultiplier:      3,
+		DesiredMinTxInterval:  50 * time.Millisecond,
+		RequiredMinRxInterval: 50 * time.Millisecond,
+	}
+
+	err = manager1.AddSession(loopback, config)
+	if err != nil {
+		t.Fatalf("Failed to add session to manager1: %v", err)
+	}
+
+	err = manager2.AddSession(loopback, config)
+	if err != nil {
+		t.Fatalf("Failed to add session to manager2: %v", err)
+	}
+
+	// Both sessions start in Down state. The BFD state machine should
+	// transition: Down -> Init (on receiving Down from peer) -> Up (on
+	// receiving Init from peer). Wait for both to reach Up.
+	deadline := time.After(5 * time.Second)
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			state1 := manager1.GetSessionState(loopback)
+			state2 := manager2.GetSessionState(loopback)
+			t.Fatalf("Timed out waiting for sessions to reach Up: manager1=%s, manager2=%s",
+				state1.String(), state2.String())
+		case <-ticker.C:
+			state1 := manager1.GetSessionState(loopback)
+			state2 := manager2.GetSessionState(loopback)
+			if state1 == BFDStateUp && state2 == BFDStateUp {
+				// Both peers are Up
+				t.Logf("Both BFD sessions reached Up state")
+				return
+			}
+		}
+	}
+}
+
+func TestBFDManager_NilTransportSkipsSending(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	manager := NewBFDManager(logger, nil)
+	// transport is nil by default (no Start called)
+
+	peerIP := net.ParseIP("10.0.0.1")
+	config := BFDConfig{
+		DetectMultiplier:      3,
+		DesiredMinTxInterval:  50 * time.Millisecond,
+		RequiredMinRxInterval: 50 * time.Millisecond,
+	}
+
+	err := manager.AddSession(peerIP, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call sendControlPackets directly - should not panic with nil transport
+	manager.sendControlPackets()
+
+	// Verify metrics were still updated
+	_, tx, _, ok := manager.GetSessionStats(peerIP)
+	if !ok {
+		t.Fatal("Session should exist")
+	}
+	if tx != 1 {
+		t.Errorf("Expected 1 packet TX (metrics-only), got %d", tx)
+	}
 }

--- a/internal/agent/vip/bfd_transport.go
+++ b/internal/agent/vip/bfd_transport.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// bfdTransport handles BFD UDP packet I/O per RFC 5881.
+//
+// It listens for incoming BFD control packets on the configured port and
+// provides a Send method for transmitting packets to peers. Received
+// packets are dispatched to the BFDManager for state machine processing.
+type bfdTransport struct {
+	logger     *zap.Logger
+	conn       *net.UDPConn
+	manager    *BFDManager
+	listenPort int
+	localPort  int // actual bound port (may differ from listenPort when using port 0)
+
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// newBFDTransport creates a new BFD UDP transport.
+// Use listenPort=0 to let the OS assign an ephemeral port (useful for testing).
+func newBFDTransport(logger *zap.Logger, manager *BFDManager, listenPort int) *bfdTransport {
+	return &bfdTransport{
+		logger:     logger.Named("bfd-transport"),
+		manager:    manager,
+		listenPort: listenPort,
+	}
+}
+
+// Start opens the UDP socket and begins the receive loop.
+func (t *bfdTransport) Start(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	listenAddr := &net.UDPAddr{
+		IP:   net.IPv4zero,
+		Port: t.listenPort,
+	}
+
+	conn, err := net.ListenUDP("udp4", listenAddr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on UDP port %d: %w", t.listenPort, err)
+	}
+
+	// Record the actual bound port (important when listenPort is 0)
+	localAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		_ = conn.Close()
+		return errors.New("failed to get local UDP address")
+	}
+	t.localPort = localAddr.Port
+
+	t.conn = conn
+	t.ctx, t.cancel = context.WithCancel(ctx)
+
+	t.logger.Info("BFD transport started",
+		zap.Int("listen_port", t.localPort),
+	)
+
+	go t.receiveLoop()
+
+	return nil
+}
+
+// Stop closes the UDP socket and stops the receive loop.
+func (t *bfdTransport) Stop() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.cancel != nil {
+		t.cancel()
+	}
+
+	if t.conn != nil {
+		_ = t.conn.Close()
+		t.conn = nil
+	}
+
+	t.logger.Info("BFD transport stopped")
+}
+
+// LocalPort returns the actual port the transport is listening on.
+// This is useful when listenPort was 0 (OS-assigned).
+func (t *bfdTransport) LocalPort() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.localPort
+}
+
+// Send transmits a BFD control packet to a peer.
+// The destination port is the peer's BFD control port.
+func (t *bfdTransport) Send(peerAddr net.IP, peerPort int, pkt *bfdControlPacket) error {
+	t.mu.Lock()
+	conn := t.conn
+	t.mu.Unlock()
+
+	if conn == nil {
+		return errors.New("BFD transport not started")
+	}
+
+	data, err := encodeBFDPacket(pkt)
+	if err != nil {
+		return fmt.Errorf("failed to encode BFD packet: %w", err)
+	}
+
+	dst := &net.UDPAddr{
+		IP:   peerAddr,
+		Port: peerPort,
+	}
+
+	_, err = conn.WriteToUDP(data, dst)
+	if err != nil {
+		return fmt.Errorf("failed to send BFD packet to %s:%d: %w", peerAddr, peerPort, err)
+	}
+
+	return nil
+}
+
+// receiveLoop reads BFD control packets from the UDP socket and dispatches
+// them to the BFDManager for processing.
+func (t *bfdTransport) receiveLoop() {
+	buf := make([]byte, 256) // BFD control packets are 24 bytes minimum
+
+	for {
+		select {
+		case <-t.ctx.Done():
+			return
+		default:
+		}
+
+		n, remoteAddr, err := t.conn.ReadFromUDP(buf)
+		if err != nil {
+			// Check if the context was cancelled (normal shutdown)
+			select {
+			case <-t.ctx.Done():
+				return
+			default:
+			}
+			t.logger.Warn("Error reading BFD packet",
+				zap.Error(err),
+			)
+			continue
+		}
+
+		if n < bfdPacketLength {
+			t.logger.Debug("Ignoring short BFD packet",
+				zap.Int("bytes", n),
+				zap.String("from", remoteAddr.String()),
+			)
+			continue
+		}
+
+		pkt, err := decodeBFDPacket(buf[:n])
+		if err != nil {
+			t.logger.Debug("Failed to decode BFD packet",
+				zap.Error(err),
+				zap.String("from", remoteAddr.String()),
+			)
+			continue
+		}
+
+		if t.manager != nil {
+			t.manager.ProcessPacket(remoteAddr.IP, pkt.State, pkt.MyDiscriminator)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Implement actual BFD control packet encoding/decoding per RFC 5880 Section 4.1 (24-byte wire format)
- Add UDP transport layer (listen on port 3784, send/receive BFD control packets)
- Wire transport into existing BFDManager, replacing the stubbed `sendControlPackets()`
- Sub-second failure detection now works end-to-end via real UDP packets

## Changes
- **New** `internal/agent/vip/bfd_packet.go` — `bfdControlPacket` struct with `encodeBFDPacket()`/`decodeBFDPacket()`, diagnostic constants, sentinel errors
- **New** `internal/agent/vip/bfd_transport.go` — `bfdTransport` with UDP listener, receive loop, and Send() method
- **New** `internal/agent/vip/bfd_packet_test.go` — 12 test cases including round-trip encoding, byte-level RFC verification, error cases
- **Modified** `internal/agent/vip/bfd.go` — Added transport field, ListenPort/PeerPort config, real packet building in sendControlPackets()
- **Modified** `internal/agent/vip/bfd_test.go` — Added transport lifecycle, UDP send/receive, two-peer integration (Down→Init→Up), nil transport safety tests

## Test plan
- [x] All existing BFD tests pass (state machine, detection timeout, concurrent access)
- [x] Packet encoding/decoding round-trip for all states, flags, and diagnostic codes
- [x] Byte-level encoding matches RFC 5880 specification
- [x] Transport start/stop lifecycle
- [x] UDP send/receive via loopback
- [x] Two BFDManagers reach Up state exchanging real UDP packets
- [x] Nil transport graceful degradation
- [x] 0 golangci-lint issues
- [x] All 5 binaries build

Resolves #242