### PR TITLE
[Feature] Multi-arch release and nightly CI/CD workflows (#244)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,168 @@
+name: Nightly Build
+
+on:
+  schedule:
+    # Run at midnight UTC daily
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  # Build multi-arch binaries
+  build-binaries:
+    name: Build Binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        binary:
+          - name: novaedge-controller
+            path: ./cmd/novaedge-controller
+          - name: novaedge-agent
+            path: ./cmd/novaedge-agent
+          - name: novactl
+            path: ./cmd/novactl
+          - name: novaedge-standalone
+            path: ./cmd/novaedge-standalone
+          - name: novaedge-operator
+            path: ./cmd/novaedge-operator
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Build binary
+        env:
+          CGO_ENABLED: 0
+          GOOS: linux
+          GOARCH: ${{ matrix.arch }}
+          BINARY_NAME: ${{ matrix.binary.name }}
+          BINARY_PATH: ${{ matrix.binary.path }}
+        run: |
+          VERSION="nightly-$(date -u '+%Y%m%d')"
+          COMMIT="${GITHUB_SHA::8}"
+          DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          go build -trimpath \
+            -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+            -o "${BINARY_NAME}-linux-${GOARCH}" \
+            "${BINARY_PATH}"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.binary.name }}-linux-${{ matrix.arch }}
+          path: ${{ matrix.binary.name }}-linux-${{ matrix.arch }}
+          retention-days: 1
+
+  # Create or update nightly pre-release
+  nightly-release:
+    name: Update Nightly Release
+    runs-on: ubuntu-latest
+    needs: build-binaries
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release
+          for dir in artifacts/*/; do
+            cp "${dir}"* release/
+          done
+          chmod +x release/*
+          cd release
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Delete existing nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+
+      - name: Create nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
+          SHORT_SHA="${GITHUB_SHA::8}"
+          gh release create nightly \
+            --title "Nightly Build (${DATE})" \
+            --notes "Automated nightly build from main branch.
+
+          **Commit:** ${SHORT_SHA}
+          **Date:** ${DATE}
+
+          > These builds are from the latest main branch and may be unstable.
+          > For stable releases, use a versioned tag." \
+            --prerelease \
+            --target main \
+            release/*
+
+  # Build and push multi-arch Docker images
+  docker:
+    name: Docker Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - name: novaedge-controller
+            dockerfile: Dockerfile.controller
+          - name: novaedge-agent
+            dockerfile: Dockerfile.agent
+          - name: novactl
+            dockerfile: Dockerfile.novactl
+          - name: novaedge-standalone
+            dockerfile: Dockerfile.standalone
+          - name: novaedge-operator
+            dockerfile: Dockerfile.operator
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}/${{ matrix.image.name }}:nightly
+          build-args: |
+            VERSION=nightly
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,162 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  # Build multi-arch binaries
+  build-binaries:
+    name: Build Binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        binary:
+          - name: novaedge-controller
+            path: ./cmd/novaedge-controller
+          - name: novaedge-agent
+            path: ./cmd/novaedge-agent
+          - name: novactl
+            path: ./cmd/novactl
+          - name: novaedge-standalone
+            path: ./cmd/novaedge-standalone
+          - name: novaedge-operator
+            path: ./cmd/novaedge-operator
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Build binary
+        env:
+          CGO_ENABLED: 0
+          GOOS: linux
+          GOARCH: ${{ matrix.arch }}
+          BINARY_NAME: ${{ matrix.binary.name }}
+          BINARY_PATH: ${{ matrix.binary.path }}
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          COMMIT="${GITHUB_SHA::8}"
+          DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          go build -trimpath \
+            -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+            -o "${BINARY_NAME}-linux-${GOARCH}" \
+            "${BINARY_PATH}"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.binary.name }}-linux-${{ matrix.arch }}
+          path: ${{ matrix.binary.name }}-linux-${{ matrix.arch }}
+          retention-days: 1
+
+  # Create GitHub Release with all binaries
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build-binaries
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release
+          for dir in artifacts/*/; do
+            cp "${dir}"* release/
+          done
+          chmod +x release/*
+          cd release
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: release/*
+          fail_on_unmatched_files: true
+
+  # Build and push multi-arch Docker images
+  docker:
+    name: Docker Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - name: novaedge-controller
+            dockerfile: Dockerfile.controller
+          - name: novaedge-agent
+            dockerfile: Dockerfile.agent
+          - name: novactl
+            dockerfile: Dockerfile.novactl
+          - name: novaedge-standalone
+            dockerfile: Dockerfile.standalone
+          - name: novaedge-operator
+            dockerfile: Dockerfile.operator
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/${{ matrix.image.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -20,8 +20,15 @@ COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 
+# Build args for version injection
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o novaedge-agent cmd/novaedge-agent/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+    -o novaedge-agent cmd/novaedge-agent/main.go
 
 # Use distroless as minimal base image to package the agent binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -20,8 +20,15 @@ COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 
+# Build args for version injection
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o novaedge-controller cmd/novaedge-controller/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+    -o novaedge-controller cmd/novaedge-controller/main.go
 
 # Use distroless as minimal base image to package the controller binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.novactl
+++ b/Dockerfile.novactl
@@ -20,8 +20,15 @@ COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 
+# Build args for version injection
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o novactl cmd/novactl/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+    -o novactl cmd/novactl/main.go
 
 # Use distroless as minimal base image to package the novactl binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -19,8 +19,15 @@ RUN go mod download
 # Copy source code
 COPY . .
 
+# Build args for version injection
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 # Build the operator
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o novaedge-operator cmd/novaedge-operator/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+    -o novaedge-operator cmd/novaedge-operator/main.go
 
 # Runtime stage
 FROM gcr.io/distroless/static:nonroot

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -20,8 +20,15 @@ COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 
+# Build args for version injection
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o novaedge-standalone cmd/novaedge-standalone/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+    -o novaedge-standalone cmd/novaedge-standalone/main.go
 
 # Use distroless as minimal base image to package the standalone binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/cmd/novactl/cmd/root.go
+++ b/cmd/novactl/cmd/root.go
@@ -10,6 +10,20 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// Build-time version info set from main via SetVersionInfo.
+var (
+	cliVersion = "dev"
+	cliCommit  = "unknown"
+	cliDate    = "unknown"
+)
+
+// SetVersionInfo sets the build-time version information from ldflags.
+func SetVersionInfo(ver, com, dt string) {
+	cliVersion = ver
+	cliCommit = com
+	cliDate = dt
+}
+
 var (
 	kubeconfig string
 	namespace  string
@@ -79,4 +93,16 @@ func init() {
 
 	// Generation commands
 	rootCmd.AddCommand(newGenerateCommand())
+
+	// Version command
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Print the version information",
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return nil // Skip kubeconfig loading
+		},
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Printf("novactl %s (commit: %s, built: %s)\n", cliVersion, cliCommit, cliDate)
+		},
+	})
 }

--- a/cmd/novactl/main.go
+++ b/cmd/novactl/main.go
@@ -7,7 +7,15 @@ import (
 	"github.com/piwi3910/novaedge/cmd/novactl/cmd"
 )
 
+// Build-time variables set via ldflags.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
 func main() {
+	cmd.SetVersionInfo(version, commit, date)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -39,10 +39,16 @@ import (
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
+// Build-time variables set via ldflags.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
 var (
 	nodeName        string
 	controllerAddr  string
-	agentVersion    = "0.1.0"
 	logLevel        string
 	healthProbePort int
 	metricsPort     int
@@ -115,7 +121,9 @@ func main() {
 
 	logger.Info("Starting NovaEdge agent",
 		zap.String("node", nodeName),
-		zap.String("version", agentVersion),
+		zap.String("version", version),
+		zap.String("commit", commit),
+		zap.String("date", date),
 		zap.String("controller", controllerAddr),
 	)
 
@@ -136,7 +144,7 @@ func main() {
 		Endpoint:       tracingEndpoint,
 		SampleRate:     tracingSampleRate,
 		ServiceName:    "novaedge-agent",
-		ServiceVersion: agentVersion,
+		ServiceVersion: version,
 	}, logger)
 	if err != nil {
 		logger.Fatal("Failed to initialize tracing", zap.Error(err))
@@ -161,7 +169,7 @@ func main() {
 				zap.String("cluster", clusterName))
 		}
 		// Create remote watcher with mTLS and cluster identification
-		watcher, err = config.NewRemoteWatcher(ctx, nodeName, agentVersion, controllerAddr,
+		watcher, err = config.NewRemoteWatcher(ctx, nodeName, version, controllerAddr,
 			&config.TLSConfig{
 				CertFile: grpcTLSCert,
 				KeyFile:  grpcTLSKey,
@@ -183,7 +191,7 @@ func main() {
 			zap.String("ca", grpcTLSCA))
 	case grpcTLSCert != "" && grpcTLSKey != "" && grpcTLSCA != "":
 		// Local agent with mTLS enabled
-		watcher, err = config.NewWatcherWithTLS(ctx, nodeName, agentVersion, controllerAddr,
+		watcher, err = config.NewWatcherWithTLS(ctx, nodeName, version, controllerAddr,
 			&config.TLSConfig{
 				CertFile: grpcTLSCert,
 				KeyFile:  grpcTLSKey,
@@ -197,7 +205,7 @@ func main() {
 			zap.String("ca", grpcTLSCA))
 	default:
 		// Local agent without TLS (insecure, development only)
-		watcher, err = config.NewWatcher(ctx, nodeName, agentVersion, controllerAddr, logger)
+		watcher, err = config.NewWatcher(ctx, nodeName, version, controllerAddr, logger)
 		if err != nil {
 			logger.Fatal("Failed to create config watcher", zap.Error(err))
 		}

--- a/cmd/novaedge-controller/main.go
+++ b/cmd/novaedge-controller/main.go
@@ -49,6 +49,13 @@ import (
 	"github.com/piwi3910/novaedge/internal/pkg/tlsutil"
 )
 
+// Build-time variables set via ldflags.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
@@ -105,6 +112,9 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("Starting NovaEdge controller",
+		"version", version, "commit", commit, "date", date)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,

--- a/cmd/novaedge-operator/main.go
+++ b/cmd/novaedge-operator/main.go
@@ -35,6 +35,13 @@ import (
 	"github.com/piwi3910/novaedge/internal/operator/controller"
 )
 
+// Build-time variables set via ldflags.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
@@ -63,6 +70,9 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("Starting NovaEdge operator",
+		"version", version, "commit", commit, "date", date)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,

--- a/cmd/novaedge-standalone/main.go
+++ b/cmd/novaedge-standalone/main.go
@@ -36,13 +36,19 @@ import (
 	"github.com/piwi3910/novaedge/internal/standalone"
 )
 
+// Build-time variables set via ldflags.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
 var (
 	configFile      string
 	nodeName        string
 	metricsPort     int
 	healthProbePort int
 	logLevel        string
-	version         = "dev"
 )
 
 func main() {
@@ -59,6 +65,8 @@ func main() {
 
 	logger.Info("Starting NovaEdge Standalone Load Balancer",
 		zap.String("version", version),
+		zap.String("commit", commit),
+		zap.String("date", date),
 		zap.String("config", configFile))
 
 	// Get node name


### PR DESCRIPTION
## Summary
- Add `release.yml` workflow: triggered on `v*` tags, builds all 5 binaries for linux/amd64 + linux/arm64, creates GitHub Release with SHA256SUMS, pushes multi-arch Docker images to ghcr.io
- Add `nightly.yml` workflow: daily at midnight UTC + manual dispatch, same multi-arch builds, creates/updates `nightly` pre-release, pushes `:nightly` Docker images
- Add version/commit/date ldflags to all 5 binaries and Dockerfiles
- Add `novactl version` command

## Files changed
- **New**: `.github/workflows/release.yml`, `.github/workflows/nightly.yml`
- **Modified**: All 5 Dockerfiles (version build args + trimpath)
- **Modified**: All 5 `cmd/*/main.go` (ldflags variables + startup logging)
- **Modified**: `cmd/novactl/cmd/root.go` (version command)

## What gets published

**Binaries** (GitHub Releases):
| Binary | amd64 | arm64 |
|--------|-------|-------|
| novaedge-controller | ✅ | ✅ |
| novaedge-agent | ✅ | ✅ |
| novactl | ✅ | ✅ |
| novaedge-standalone | ✅ | ✅ |
| novaedge-operator | ✅ | ✅ |

**Docker images** (ghcr.io, multi-arch manifests):
- `ghcr.io/piwi3910/novaedge-controller`
- `ghcr.io/piwi3910/novaedge-agent`
- `ghcr.io/piwi3910/novactl`
- `ghcr.io/piwi3910/novaedge-standalone`
- `ghcr.io/piwi3910/novaedge-operator`

**Tags**: Release gets `v1.2.3`, `1.2`, `latest`. Nightly gets `nightly`.

## Test plan
- [x] All 5 binaries build with ldflags
- [x] 0 golangci-lint issues
- [x] All existing tests pass
- [x] Workflow YAML validates
- [x] No untrusted input in workflow `run:` blocks

Resolves #244