### PR TITLE
[Fix] BFD transport sets TTL=255 per RFC 5881

### DIFF
--- a/internal/agent/vip/bfd_transport.go
+++ b/internal/agent/vip/bfd_transport.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"syscall"
 
 	"go.uber.org/zap"
 )
@@ -66,6 +67,26 @@ func (t *bfdTransport) Start(ctx context.Context) error {
 	conn, err := net.ListenUDP("udp4", listenAddr)
 	if err != nil {
 		return fmt.Errorf("failed to listen on UDP port %d: %w", t.listenPort, err)
+	}
+
+	// RFC 5881 Section 4: BFD Control packets MUST be transmitted with a
+	// TTL/Hop Limit value of 255. Single-hop receivers MUST verify TTL >= 254.
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("failed to get raw connection for TTL: %w", err)
+	}
+	var setsockoptErr error
+	if controlErr := rawConn.Control(func(fd uintptr) {
+		setsockoptErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TTL, 255)
+	}); controlErr != nil {
+		_ = conn.Close()
+		return fmt.Errorf("failed to set BFD socket options: %w", controlErr)
+	}
+	if setsockoptErr != nil {
+		t.logger.Warn("Failed to set BFD TTL socket option, BFD may not work with strict peers",
+			zap.Error(setsockoptErr),
+		)
 	}
 
 	// Record the actual bound port (important when listenPort is 0)


### PR DESCRIPTION
## Summary
- BFD control packets must be transmitted with TTL=255 for single-hop sessions (RFC 5881 Section 4)
- Without this, strict receivers (e.g., MikroTik RouterOS) drop BFD packets due to GTSM TTL check failure
- Sets `IP_TTL=255` via `syscall.SetsockoptInt` on the raw UDP socket after binding

## Test plan
- [x] Verified with tcpdump: outgoing BFD packets now have TTL=255
- [x] Tested with MikroTik RouterOS 7: BFD sessions go UP on all nodes  
- [x] All 6 BGP sessions (3 per router) with BFD confirmed operational
- [ ] Unit tests pass
- [ ] Build succeeds

Resolves #249