### PR TITLE
[Fix] BGP/BFD session self-healing after neighbor recovery

### DIFF
--- a/internal/agent/vip/bfd.go
+++ b/internal/agent/vip/bfd.go
@@ -39,8 +39,8 @@ const (
 
 // BFD protocol constants
 const (
-	bfdDefaultDesiredMinTx  = 300 * time.Millisecond
-	bfdDefaultRequiredMinRx = 300 * time.Millisecond
+	bfdDefaultDesiredMinTx  = 500 * time.Millisecond
+	bfdDefaultRequiredMinRx = 500 * time.Millisecond
 	bfdDefaultDetectMult    = 3
 	bfdControlPort          = 3784
 	bfdEchoPort             = 3785
@@ -136,6 +136,9 @@ type BFDManager struct {
 	// Callback when BFD detects a neighbor is down
 	onNeighborDown func(peerIP net.IP)
 
+	// Callback when BFD detects a neighbor has recovered (session transitions to Up)
+	onNeighborUp func(peerIP net.IP)
+
 	// UDP transport for BFD control packets
 	transport *bfdTransport
 
@@ -185,7 +188,7 @@ var (
 )
 
 // NewBFDManager creates a new BFD manager
-func NewBFDManager(logger *zap.Logger, onNeighborDown func(peerIP net.IP)) *BFDManager {
+func NewBFDManager(logger *zap.Logger, onNeighborDown, onNeighborUp func(peerIP net.IP)) *BFDManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &BFDManager{
 		logger:            logger.Named("bfd"),
@@ -194,6 +197,7 @@ func NewBFDManager(logger *zap.Logger, onNeighborDown func(peerIP net.IP)) *BFDM
 		ctx:               ctx,
 		cancel:            cancel,
 		onNeighborDown:    onNeighborDown,
+		onNeighborUp:      onNeighborUp,
 		ListenPort:        bfdControlPort,
 		PeerPort:          bfdControlPort,
 	}
@@ -474,6 +478,16 @@ func (m *BFDManager) handleStateChange(peerIP net.IP, oldState, newState BFDSess
 		)
 		if m.onNeighborDown != nil {
 			m.onNeighborDown(peerIP)
+		}
+	}
+
+	// If session recovered to Up, notify BGP handler to re-announce routes
+	if newState == BFDStateUp && oldState != BFDStateUp {
+		m.logger.Info("BFD detected neighbor recovery, triggering route re-announcement",
+			zap.String("peer", peerIP.String()),
+		)
+		if m.onNeighborUp != nil {
+			m.onNeighborUp(peerIP)
 		}
 	}
 }

--- a/internal/agent/vip/bfd_test.go
+++ b/internal/agent/vip/bfd_test.go
@@ -48,7 +48,7 @@ func TestBFDSessionState_String(t *testing.T) {
 
 func TestBFDManager_AddRemoveSession(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 
 	peerIP := net.ParseIP("10.0.0.1")
 	config := BFDConfig{
@@ -104,7 +104,7 @@ func TestBFDManager_StateMachine(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	t.Run("Down -> Init -> Up", func(t *testing.T) {
-		manager := NewBFDManager(logger, nil)
+		manager := NewBFDManager(logger, nil, nil)
 		peerIP := net.ParseIP("10.0.0.1")
 		config := BFDConfig{DetectMultiplier: 3}
 
@@ -135,7 +135,7 @@ func TestBFDManager_StateMachine(t *testing.T) {
 			mu.Lock()
 			neighborDownCalled = true
 			mu.Unlock()
-		})
+		}, nil)
 
 		peerIP := net.ParseIP("10.0.0.2")
 		config := BFDConfig{DetectMultiplier: 3}
@@ -171,7 +171,7 @@ func TestBFDManager_StateMachine(t *testing.T) {
 	})
 
 	t.Run("session flap counting", func(t *testing.T) {
-		manager := NewBFDManager(logger, nil)
+		manager := NewBFDManager(logger, nil, nil)
 		peerIP := net.ParseIP("10.0.0.3")
 		config := BFDConfig{DetectMultiplier: 3}
 
@@ -199,7 +199,7 @@ func TestBFDManager_StateMachine(t *testing.T) {
 
 func TestBFDManager_DetectionTimeout(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 
 	peerIP := net.ParseIP("10.0.0.1")
 	config := BFDConfig{
@@ -234,7 +234,7 @@ func TestBFDManager_DetectionTimeout(t *testing.T) {
 
 func TestBFDManager_StartStop(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 	// Use port 0 so the OS assigns an ephemeral port
 	manager.ListenPort = 0
 
@@ -255,7 +255,7 @@ func TestBFDManager_StartStop(t *testing.T) {
 
 func TestBFDManager_GetAllSessionStates(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 	config := BFDConfig{DetectMultiplier: 3}
 
 	peers := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
@@ -280,7 +280,7 @@ func TestBFDManager_GetAllSessionStates(t *testing.T) {
 
 func TestBFDManager_DefaultConfig(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 
 	peerIP := net.ParseIP("10.0.0.1")
 	// Pass zero-value config to verify defaults are applied
@@ -308,7 +308,7 @@ func TestBFDManager_DefaultConfig(t *testing.T) {
 
 func TestBFDManager_ConcurrentAccess(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 	config := BFDConfig{DetectMultiplier: 3}
 
 	var wg sync.WaitGroup
@@ -333,7 +333,7 @@ func TestBFDManager_ConcurrentAccess(t *testing.T) {
 
 func TestBFDTransport_StartStop(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 
 	transport := newBFDTransport(logger, manager, 0)
 
@@ -358,7 +358,7 @@ func TestBFDTransport_SendReceive(t *testing.T) {
 
 	// Create a manager and transport that receives packets
 	receivedCh := make(chan struct{}, 1)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 
 	// Add a session so ProcessPacket actually processes incoming data
 	peerIP := net.IPv4(127, 0, 0, 1)
@@ -453,10 +453,10 @@ func TestBFDManager_TwoPeersIntegration(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	// Create two BFD managers simulating two peers on localhost
-	manager1 := NewBFDManager(logger.Named("peer1"), nil)
+	manager1 := NewBFDManager(logger.Named("peer1"), nil, nil)
 	manager1.ListenPort = 0
 
-	manager2 := NewBFDManager(logger.Named("peer2"), nil)
+	manager2 := NewBFDManager(logger.Named("peer2"), nil, nil)
 	manager2.ListenPort = 0
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -538,7 +538,7 @@ func TestBFDManager_TwoPeersIntegration(t *testing.T) {
 
 func TestBFDManager_NilTransportSkipsSending(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 	// transport is nil by default (no Start called)
 
 	peerIP := net.ParseIP("10.0.0.1")
@@ -563,5 +563,131 @@ func TestBFDManager_NilTransportSkipsSending(t *testing.T) {
 	}
 	if tx != 1 {
 		t.Errorf("Expected 1 packet TX (metrics-only), got %d", tx)
+	}
+}
+
+func TestBFDManager_NeighborUpCallback(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	var mu sync.Mutex
+	neighborUpCalled := false
+	var upPeerIP net.IP
+
+	manager := NewBFDManager(logger, nil, func(peerIP net.IP) {
+		mu.Lock()
+		neighborUpCalled = true
+		upPeerIP = peerIP
+		mu.Unlock()
+	})
+
+	peerIP := net.ParseIP("10.0.0.5")
+	config := BFDConfig{DetectMultiplier: 3}
+
+	err := manager.AddSession(peerIP, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Transition Down -> Init -> Up
+	manager.ProcessPacket(peerIP, BFDStateDown, 500)
+	state := manager.GetSessionState(peerIP)
+	if state != BFDStateInit {
+		t.Fatalf("Expected Init, got %s", state.String())
+	}
+
+	manager.ProcessPacket(peerIP, BFDStateInit, 500)
+	state = manager.GetSessionState(peerIP)
+	if state != BFDStateUp {
+		t.Fatalf("Expected Up, got %s", state.String())
+	}
+
+	// Verify onNeighborUp was called
+	mu.Lock()
+	if !neighborUpCalled {
+		t.Error("Expected onNeighborUp callback to be called when session transitions to Up")
+	}
+	if !upPeerIP.Equal(peerIP) {
+		t.Errorf("Expected callback with peer %s, got %s", peerIP.String(), upPeerIP.String())
+	}
+	mu.Unlock()
+}
+
+func TestBFDManager_FullRecoveryCycle(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	var mu sync.Mutex
+	downCount := 0
+	upCount := 0
+
+	manager := NewBFDManager(logger,
+		func(peerIP net.IP) {
+			mu.Lock()
+			downCount++
+			mu.Unlock()
+		},
+		func(peerIP net.IP) {
+			mu.Lock()
+			upCount++
+			mu.Unlock()
+		},
+	)
+
+	peerIP := net.ParseIP("10.0.0.6")
+	config := BFDConfig{DetectMultiplier: 3}
+
+	err := manager.AddSession(peerIP, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Bring session Up: Down -> Init -> Up
+	manager.ProcessPacket(peerIP, BFDStateDown, 600)
+	manager.ProcessPacket(peerIP, BFDStateInit, 600)
+
+	state := manager.GetSessionState(peerIP)
+	if state != BFDStateUp {
+		t.Fatalf("Expected Up, got %s", state.String())
+	}
+
+	// 2. Peer goes Down: Up -> Down (triggers onNeighborDown)
+	manager.ProcessPacket(peerIP, BFDStateDown, 600)
+
+	state = manager.GetSessionState(peerIP)
+	if state != BFDStateDown {
+		t.Fatalf("Expected Down, got %s", state.String())
+	}
+
+	// Wait for async callback
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	if downCount != 1 {
+		t.Errorf("Expected 1 onNeighborDown call, got %d", downCount)
+	}
+	mu.Unlock()
+
+	// 3. Peer recovers: Down -> Init -> Up (triggers onNeighborUp)
+	manager.ProcessPacket(peerIP, BFDStateDown, 600) // Both Down -> Init
+	manager.ProcessPacket(peerIP, BFDStateInit, 600) // Init -> Up
+
+	state = manager.GetSessionState(peerIP)
+	if state != BFDStateUp {
+		t.Fatalf("Expected Up after recovery, got %s", state.String())
+	}
+
+	mu.Lock()
+	if upCount != 2 {
+		// upCount is 2: once for initial Up, once for recovery Up
+		t.Errorf("Expected 2 onNeighborUp calls (initial + recovery), got %d", upCount)
+	}
+	mu.Unlock()
+
+	// 4. Verify flap count
+	_, _, flaps, ok := manager.GetSessionStats(peerIP)
+	if !ok {
+		t.Fatal("Session should exist")
+	}
+	if flaps != 1 {
+		t.Errorf("Expected 1 flap, got %d", flaps)
 	}
 }

--- a/internal/agent/vip/bgp.go
+++ b/internal/agent/vip/bgp.go
@@ -76,8 +76,8 @@ func NewBGPHandler(logger *zap.Logger) (*BGPHandler, error) {
 		started:    false,
 	}
 
-	// Create BFD manager with callback to withdraw routes on neighbor failure
-	handler.bfdManager = NewBFDManager(logger, handler.onBFDNeighborDown)
+	// Create BFD manager with callbacks for neighbor failure and recovery
+	handler.bfdManager = NewBFDManager(logger, handler.onBFDNeighborDown, handler.onBFDNeighborUp)
 
 	return handler, nil
 }
@@ -709,12 +709,97 @@ func (h *BGPHandler) onBFDNeighborDown(peerIP net.IP) {
 	}
 
 	if withdrawn > 0 {
-		metrics.BGPAnnouncedRoutes.Set(float64(len(h.activeVIPs) - withdrawn))
+		metrics.BGPAnnouncedRoutes.Set(float64(h.countAnnouncedVIPs()))
 		h.logger.Warn("Routes withdrawn due to BFD neighbor failure",
 			zap.String("peer", peerStr),
 			zap.Int("withdrawn_count", withdrawn),
 		)
 	}
+}
+
+// onBFDNeighborUp is called when BFD detects a neighbor has recovered.
+// It re-announces all routes that were previously withdrawn due to BFD failure,
+// providing automatic self-healing of BGP sessions.
+func (h *BGPHandler) onBFDNeighborUp(peerIP net.IP) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	peerStr := peerIP.String()
+	h.logger.Info("BFD detected neighbor recovery, re-announcing withdrawn routes",
+		zap.String("peer", peerStr),
+	)
+
+	if h.bgpServer == nil {
+		h.logger.Warn("BGP server not running, cannot re-announce routes",
+			zap.String("peer", peerStr),
+		)
+		return
+	}
+
+	ctx := context.Background()
+	reannounced := 0
+
+	for vipName, state := range h.activeVIPs {
+		if state.Assignment.BgpConfig == nil {
+			continue
+		}
+
+		// Check if this VIP has the recovered peer in its BGP config
+		peerFound := false
+		for _, peer := range state.Assignment.BgpConfig.Peers {
+			if peer.Address == peerStr {
+				peerFound = true
+				break
+			}
+		}
+
+		if !peerFound {
+			continue
+		}
+
+		// Only re-announce routes that were previously withdrawn
+		if state.Announced {
+			continue
+		}
+
+		h.logger.Info("Re-announcing route for VIP after BFD neighbor recovery",
+			zap.String("vip", vipName),
+			zap.String("address", state.Assignment.Address),
+			zap.String("recovered_peer", peerStr),
+		)
+
+		if err := h.announceRoute(ctx, state.IP, state.Assignment.BgpConfig, state.IsIPv6); err != nil {
+			h.logger.Error("Failed to re-announce route on BFD neighbor recovery",
+				zap.String("vip", vipName),
+				zap.String("peer", peerStr),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		state.Announced = true
+		reannounced++
+	}
+
+	if reannounced > 0 {
+		metrics.BGPAnnouncedRoutes.Set(float64(h.countAnnouncedVIPs()))
+		h.logger.Info("Routes re-announced after BFD neighbor recovery",
+			zap.String("peer", peerStr),
+			zap.Int("reannounced_count", reannounced),
+		)
+	}
+}
+
+// countAnnouncedVIPs returns the number of VIPs with Announced=true.
+// Called with h.mu held.
+func (h *BGPHandler) countAnnouncedVIPs() int {
+	count := 0
+	for _, state := range h.activeVIPs {
+		if state.Announced {
+			count++
+		}
+	}
+	return count
 }
 
 // startBGPServer initializes and starts the BGP server
@@ -902,7 +987,7 @@ func (h *BGPHandler) announceRoute(ctx context.Context, ip net.IP, config *pb.BG
 }
 
 // withdrawRoute withdraws a route for a VIP (IPv4 or IPv6)
-func (h *BGPHandler) withdrawRoute(ctx context.Context, ip net.IP, _ *pb.BGPConfig, isIPv6 bool) error {
+func (h *BGPHandler) withdrawRoute(ctx context.Context, ip net.IP, config *pb.BGPConfig, isIPv6 bool) error {
 	var prefixLen uint32
 	var family *api.Family
 
@@ -931,10 +1016,45 @@ func (h *BGPHandler) withdrawRoute(ctx context.Context, ip net.IP, _ *pb.BGPConf
 		return fmt.Errorf("failed to marshal NLRI: %w", err)
 	}
 
+	// Build path attributes matching what was announced, so GoBGP can
+	// identify the exact path to delete. Without these, DeletePath fails
+	// with "nexthop not found".
+	attrs := []*anypb.Any{}
+
+	originAttr, err := anypb.New(&api.OriginAttribute{
+		Origin: 0, // IGP
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal origin attribute for withdrawal: %w", err)
+	}
+	attrs = append(attrs, originAttr)
+
+	if config != nil {
+		if isIPv6 {
+			mpReachAttr, err := anypb.New(&api.MpReachNLRIAttribute{
+				Family:   family,
+				NextHops: []string{config.RouterId},
+			})
+			if err != nil {
+				return fmt.Errorf("failed to marshal MP_REACH_NLRI for withdrawal: %w", err)
+			}
+			attrs = append(attrs, mpReachAttr)
+		} else {
+			nexthopAttr, err := anypb.New(&api.NextHopAttribute{
+				NextHop: config.RouterId,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to marshal nexthop for withdrawal: %w", err)
+			}
+			attrs = append(attrs, nexthopAttr)
+		}
+	}
+
 	err = h.bgpServer.DeletePath(ctx, &api.DeletePathRequest{
 		TableType: api.TableType_GLOBAL,
 		Path: &api.Path{
 			Nlri:   nlri,
+			Pattrs: attrs,
 			Family: family,
 		},
 	})

--- a/internal/agent/vip/manager_test.go
+++ b/internal/agent/vip/manager_test.go
@@ -874,7 +874,7 @@ func TestOSPFHandler_ReconfigureVIP(t *testing.T) {
 
 func TestBFDManager_UpdateSession(t *testing.T) {
 	logger := zap.NewNop()
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 
 	peerIP := net.ParseIP("10.0.0.2")
 
@@ -928,7 +928,7 @@ func TestBFDManager_UpdateSession(t *testing.T) {
 
 func TestBFDManager_UpdateSession_NonExistent(t *testing.T) {
 	logger := zap.NewNop()
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 
 	peerIP := net.ParseIP("10.0.0.2")
 
@@ -950,7 +950,7 @@ func TestBFDManager_UpdateSession_NonExistent(t *testing.T) {
 
 func TestBFDManager_RemoveSession(t *testing.T) {
 	logger := zap.NewNop()
-	manager := NewBFDManager(logger, nil)
+	manager := NewBFDManager(logger, nil, nil)
 
 	peerIP := net.ParseIP("10.0.0.2")
 


### PR DESCRIPTION
## Summary

- Add `onNeighborUp` callback to BFDManager so BGP handler is notified when BFD sessions recover to Up state
- Implement `onBFDNeighborUp` in BGP handler to automatically re-announce routes that were withdrawn during BFD-detected failure
- Increase BFD default timing from 300ms to 500ms (detection_time = 1.5s) to prevent false timeouts from scheduling jitter on ARM nodes
- Fix `withdrawRoute` to include nexthop in path attributes, eliminating "nexthop not found" errors from GoBGP

## Root Cause

When BFD detected a neighbor failure, `onBFDNeighborDown` withdrew all routes and set `state.Announced = false`. However, the BFD `handleStateChange` only handled Down transitions — when the session recovered to Up, no callback fired, leaving routes permanently withdrawn until manual reset.

## Test Plan

- [x] Unit tests for BFD `onNeighborUp` callback firing on session recovery
- [x] Full recovery cycle test: Up → Down (withdraw) → Up (re-announce)
- [x] All existing tests pass with race detector
- [x] All 5 binaries build
- [x] golangci-lint: 0 issues

Resolves #258