### PR TITLE
[Fix] CP VIP health check: switch to /livez with SA token auth

### DIFF
--- a/internal/agent/cpvip/manager.go
+++ b/internal/agent/cpvip/manager.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -51,8 +53,17 @@ const (
 	// cpVIPName is the internal name used for the control-plane VIP assignment.
 	cpVIPName = "control-plane-vip"
 
-	// healthzPath is the kube-apiserver health check endpoint.
-	healthzPath = "/healthz"
+	// livezPath is the kube-apiserver liveness endpoint (replaces deprecated /healthz).
+	livezPath = "/livez"
+
+	// defaultSATokenPath is the default path for the ServiceAccount token
+	// mounted in Kubernetes pods.
+	defaultSATokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec // not a credential, just a file path constant
+
+	// tokenRefreshInterval controls how often the SA token is re-read from disk.
+	// Kubernetes rotates projected SA tokens periodically (default ~1h), so we
+	// refresh well within that window.
+	tokenRefreshInterval = 5 * time.Minute
 )
 
 // Config holds the configuration for the control-plane VIP manager.
@@ -75,6 +86,11 @@ type Config struct {
 
 	// FailThreshold is the number of consecutive failures before releasing the VIP (default: 3).
 	FailThreshold int
+
+	// SATokenPath is the path to the ServiceAccount token file for
+	// authenticating health check requests. Defaults to the standard
+	// Kubernetes projected token path. Set to empty string to disable.
+	SATokenPath string
 }
 
 // Validate checks that the configuration is valid.
@@ -121,6 +137,9 @@ func (c *Config) applyDefaults() {
 	if c.FailThreshold == 0 {
 		c.FailThreshold = DefaultFailThreshold
 	}
+	if c.SATokenPath == "" {
+		c.SATokenPath = defaultSATokenPath
+	}
 }
 
 // Manager manages a single control-plane VIP based on kube-apiserver health.
@@ -135,6 +154,11 @@ type Manager struct {
 	mu        sync.Mutex
 	vipActive bool
 	failCount int
+
+	// tokenMu protects the cached SA token fields.
+	tokenMu       sync.RWMutex
+	cachedToken   string
+	tokenLoadedAt time.Time
 }
 
 // NewManager creates a new control-plane VIP manager.
@@ -253,14 +277,25 @@ func (m *Manager) healthCheckTick(ctx context.Context) {
 	}
 }
 
-// checkAPIServerHealth performs an HTTP GET to the apiserver /healthz endpoint.
+// checkAPIServerHealth performs an HTTP GET to the apiserver /livez endpoint.
+// When a ServiceAccount token is available, it sends an authenticated request
+// and treats 200 as healthy. When no token is available (pre-bootstrap), it
+// falls back to treating both 200 and 401 as healthy (any HTTP response means
+// the API server is accepting connections).
 func (m *Manager) checkAPIServerHealth(ctx context.Context) bool {
-	url := fmt.Sprintf("https://localhost:%d%s", m.config.APIPort, healthzPath)
+	url := fmt.Sprintf("https://localhost:%d%s", m.config.APIPort, livezPath)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		m.logger.Error("Failed to create health check request", zap.Error(err))
 		return false
+	}
+
+	// Attach Bearer token if available
+	token := m.getSAToken()
+	hasToken := token != ""
+	if hasToken {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	resp, err := m.httpClient.Do(req)
@@ -270,7 +305,67 @@ func (m *Manager) checkAPIServerHealth(ctx context.Context) bool {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode == http.StatusOK {
+		return true
+	}
+
+	// When no token is available, treat 401 as healthy: the API server is
+	// running and accepting connections, we just can't authenticate yet
+	// (pre-bootstrap or SA token not mounted).
+	if !hasToken && resp.StatusCode == http.StatusUnauthorized {
+		m.logger.Debug("API server returned 401 without token, treating as healthy (pre-bootstrap)")
+		return true
+	}
+
+	return false
+}
+
+// getSAToken returns the cached ServiceAccount token, refreshing from disk
+// if the cache has expired. Returns empty string if the token file is not
+// available (e.g., running outside a pod or during pre-bootstrap).
+func (m *Manager) getSAToken() string {
+	m.tokenMu.RLock()
+	token := m.cachedToken
+	loadedAt := m.tokenLoadedAt
+	m.tokenMu.RUnlock()
+
+	// Return cached token if still fresh
+	if token != "" && time.Since(loadedAt) < tokenRefreshInterval {
+		return token
+	}
+
+	// Refresh token from disk
+	return m.refreshSAToken()
+}
+
+// refreshSAToken reads the SA token from disk and updates the cache.
+func (m *Manager) refreshSAToken() string {
+	tokenPath := filepath.Clean(m.config.SATokenPath)
+
+	data, err := os.ReadFile(tokenPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			m.logger.Debug("Failed to read SA token file",
+				zap.String("path", tokenPath),
+				zap.Error(err),
+			)
+		}
+		// Clear cached token so we fall back to unauthenticated mode
+		m.tokenMu.Lock()
+		m.cachedToken = ""
+		m.tokenLoadedAt = time.Now()
+		m.tokenMu.Unlock()
+		return ""
+	}
+
+	token := string(data)
+
+	m.tokenMu.Lock()
+	m.cachedToken = token
+	m.tokenLoadedAt = time.Now()
+	m.tokenMu.Unlock()
+
+	return token
 }
 
 // buildVIPAssignment creates a protobuf VIPAssignment for the control-plane VIP.

--- a/internal/agent/cpvip/manager_test.go
+++ b/internal/agent/cpvip/manager_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -239,7 +241,7 @@ func TestCheckAPIServerHealth_Healthy(t *testing.T) {
 	// context that targets the test server.
 	// Since checkAPIServerHealth hardcodes "localhost", we need to create our
 	// own test approach: call the test server directly.
-	healthy := checkHealthAgainstURL(m, ts.URL+healthzPath)
+	healthy := checkHealthAgainstURL(m, ts.URL+livezPath)
 	if !healthy {
 		t.Error("expected healthy response from test server")
 	}
@@ -260,7 +262,7 @@ func TestCheckAPIServerHealth_Unhealthy(t *testing.T) {
 		httpClient: ts.Client(),
 	}
 
-	healthy := checkHealthAgainstURL(m, ts.URL+healthzPath)
+	healthy := checkHealthAgainstURL(m, ts.URL+livezPath)
 	if healthy {
 		t.Error("expected unhealthy response from test server")
 	}
@@ -310,7 +312,7 @@ func TestHealthCheckTick_HealthyBindsVIP(t *testing.T) {
 
 	// Verify state transitions by testing the internal logic
 	// (bindVIPLocked would fail without root, so we test the decision logic)
-	healthy := checkHealthAgainstURL(m, ts.URL+healthzPath)
+	healthy := checkHealthAgainstURL(m, ts.URL+livezPath)
 	if !healthy {
 		t.Fatal("expected healthy check to succeed")
 	}
@@ -342,7 +344,7 @@ func TestHealthCheckTick_FailThresholdReached(t *testing.T) {
 
 	// Simulate consecutive unhealthy checks
 	for i := 0; i < 3; i++ {
-		healthy := checkHealthAgainstURL(m, ts.URL+healthzPath)
+		healthy := checkHealthAgainstURL(m, ts.URL+livezPath)
 		if healthy {
 			t.Fatal("expected unhealthy check")
 		}
@@ -391,7 +393,7 @@ func TestHealthCheckTick_RecoveryAfterFailure(t *testing.T) {
 	// Simulate failures below threshold
 	healthy = false
 	for i := 0; i < 2; i++ {
-		result := checkHealthAgainstURL(m, ts.URL+healthzPath)
+		result := checkHealthAgainstURL(m, ts.URL+livezPath)
 		if result {
 			t.Fatal("expected unhealthy check")
 		}
@@ -408,7 +410,7 @@ func TestHealthCheckTick_RecoveryAfterFailure(t *testing.T) {
 
 	// Recovery: apiserver becomes healthy again
 	healthy = true
-	result := checkHealthAgainstURL(m, ts.URL+healthzPath)
+	result := checkHealthAgainstURL(m, ts.URL+livezPath)
 	if !result {
 		t.Fatal("expected healthy check after recovery")
 	}
@@ -580,14 +582,218 @@ func TestStartContextCancellation(t *testing.T) {
 	_ = m // avoid unused variable
 }
 
+// --- SA Token and Auth Tests ---
+
+func TestCheckAPIServerHealth_AuthenticatedWithToken(t *testing.T) {
+	// Create a temp token file
+	tokenDir := t.TempDir()
+	tokenFile := filepath.Join(tokenDir, "token")
+	if err := os.WriteFile(tokenFile, []byte("test-bearer-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Server that validates the Bearer token
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "Bearer test-bearer-token" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		} else {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer ts.Close()
+
+	m := &Manager{
+		config: Config{
+			APIPort:     extractPort(t, ts.URL),
+			SATokenPath: tokenFile,
+		},
+		logger:     newTestLogger().Named("cpvip"),
+		httpClient: ts.Client(),
+	}
+
+	healthy := checkHealthAgainstURL(m, ts.URL+livezPath)
+	if !healthy {
+		t.Error("expected healthy response with valid Bearer token")
+	}
+}
+
+func TestCheckAPIServerHealth_401WithoutToken(t *testing.T) {
+	// Server that always returns 401
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	m := &Manager{
+		config: Config{
+			APIPort:     extractPort(t, ts.URL),
+			SATokenPath: "/nonexistent/path/token",
+		},
+		logger:     newTestLogger().Named("cpvip"),
+		httpClient: ts.Client(),
+	}
+
+	// Without token, 401 should be treated as healthy (pre-bootstrap fallback)
+	healthy := checkHealthAgainstURL(m, ts.URL+livezPath)
+	if !healthy {
+		t.Error("expected 401 to be treated as healthy when no SA token is available")
+	}
+}
+
+func TestCheckAPIServerHealth_401WithToken(t *testing.T) {
+	// Create a temp token file with an invalid token
+	tokenDir := t.TempDir()
+	tokenFile := filepath.Join(tokenDir, "token")
+	if err := os.WriteFile(tokenFile, []byte("invalid-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Server that rejects the token
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	m := &Manager{
+		config: Config{
+			APIPort:     extractPort(t, ts.URL),
+			SATokenPath: tokenFile,
+		},
+		logger:     newTestLogger().Named("cpvip"),
+		httpClient: ts.Client(),
+	}
+
+	// With a token present but invalid, 401 should NOT be treated as healthy
+	healthy := checkHealthAgainstURL(m, ts.URL+livezPath)
+	if healthy {
+		t.Error("expected 401 to be treated as unhealthy when SA token is present but rejected")
+	}
+}
+
+func TestCheckAPIServerHealth_503WithoutToken(t *testing.T) {
+	// Server that returns 503
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	m := &Manager{
+		config: Config{
+			APIPort:     extractPort(t, ts.URL),
+			SATokenPath: "/nonexistent/path/token",
+		},
+		logger:     newTestLogger().Named("cpvip"),
+		httpClient: ts.Client(),
+	}
+
+	// 503 should always be unhealthy, even without token
+	healthy := checkHealthAgainstURL(m, ts.URL+livezPath)
+	if healthy {
+		t.Error("expected 503 to be treated as unhealthy")
+	}
+}
+
+func TestGetSAToken_CachesToken(t *testing.T) {
+	tokenDir := t.TempDir()
+	tokenFile := filepath.Join(tokenDir, "token")
+	if err := os.WriteFile(tokenFile, []byte("cached-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{
+		config: Config{
+			SATokenPath: tokenFile,
+		},
+		logger: newTestLogger().Named("cpvip"),
+	}
+
+	// First call reads from disk
+	token1 := m.getSAToken()
+	if token1 != "cached-token" {
+		t.Errorf("expected 'cached-token', got %q", token1)
+	}
+
+	// Write a different token to disk
+	if err := os.WriteFile(tokenFile, []byte("new-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call should return cached token (within refresh interval)
+	token2 := m.getSAToken()
+	if token2 != "cached-token" {
+		t.Errorf("expected cached 'cached-token', got %q", token2)
+	}
+}
+
+func TestGetSAToken_RefreshesExpiredCache(t *testing.T) {
+	tokenDir := t.TempDir()
+	tokenFile := filepath.Join(tokenDir, "token")
+	if err := os.WriteFile(tokenFile, []byte("original-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{
+		config: Config{
+			SATokenPath: tokenFile,
+		},
+		logger: newTestLogger().Named("cpvip"),
+	}
+
+	// Load initial token
+	token1 := m.getSAToken()
+	if token1 != "original-token" {
+		t.Fatalf("expected 'original-token', got %q", token1)
+	}
+
+	// Simulate cache expiry by backdating tokenLoadedAt
+	m.tokenMu.Lock()
+	m.tokenLoadedAt = time.Now().Add(-tokenRefreshInterval - time.Second)
+	m.tokenMu.Unlock()
+
+	// Write new token
+	if err := os.WriteFile(tokenFile, []byte("rotated-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should pick up the new token
+	token2 := m.getSAToken()
+	if token2 != "rotated-token" {
+		t.Errorf("expected 'rotated-token' after cache expiry, got %q", token2)
+	}
+}
+
+func TestGetSAToken_MissingFile(t *testing.T) {
+	m := &Manager{
+		config: Config{
+			SATokenPath: "/nonexistent/path/to/token",
+		},
+		logger: newTestLogger().Named("cpvip"),
+	}
+
+	token := m.getSAToken()
+	if token != "" {
+		t.Errorf("expected empty token for missing file, got %q", token)
+	}
+}
+
 // --- Helper Functions ---
 
 // checkHealthAgainstURL performs a health check against a specific URL instead of localhost.
 // This allows testing the health check logic against a httptest.Server.
+// It mirrors the logic in checkAPIServerHealth: attach token if available,
+// accept 200 always, accept 401 only when no token is present.
 func checkHealthAgainstURL(m *Manager, url string) bool {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 	if err != nil {
 		return false
+	}
+
+	token := m.getSAToken()
+	hasToken := token != ""
+	if hasToken {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	resp, err := m.httpClient.Do(req)
@@ -596,7 +802,13 @@ func checkHealthAgainstURL(m *Manager, url string) bool {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode == http.StatusOK {
+		return true
+	}
+	if !hasToken && resp.StatusCode == http.StatusUnauthorized {
+		return true
+	}
+	return false
 }
 
 // extractPort extracts the port number from a URL string like "https://127.0.0.1:12345".


### PR DESCRIPTION
## Summary

- Switch from deprecated `/healthz` to `/livez` endpoint (deprecated since K8s v1.16)
- Add ServiceAccount token authentication for health check requests
- Token is read from `/var/run/secrets/kubernetes.io/serviceaccount/token` and cached with 5-minute refresh interval to handle Kubernetes token rotation
- Graceful fallback: when no SA token is available (pre-bootstrap), 401 is treated as healthy since any HTTP response proves the API server is running
- When a token IS present but rejected (401), the check correctly reports unhealthy

## Why

Kubernetes 1.34+ introduced scoped anonymous auth (KEP-4633), allowing admins to disable anonymous access to API server endpoints. This broke our unauthenticated `/healthz` check which only accepted `200 OK`. The proper fix is to authenticate using the pod's SA token rather than relying on anonymous access.

## Auth Logic

| Token Available | Response | Result |
|----------------|----------|--------|
| Yes | 200 | Healthy |
| Yes | 401 | **Unhealthy** (auth failure) |
| Yes | 5xx | Unhealthy |
| No | 200 | Healthy |
| No | 401 | **Healthy** (pre-bootstrap fallback) |
| No | 5xx | Unhealthy |
| N/A | Connection refused | Unhealthy |

## Test Plan

- [x] Authenticated health check with valid token returns healthy
- [x] 401 without token treated as healthy (pre-bootstrap fallback)
- [x] 401 with invalid token treated as unhealthy
- [x] 503 always treated as unhealthy
- [x] Token caching works (returns cached within interval)
- [x] Token refresh after cache expiry picks up rotated token
- [x] Missing token file returns empty string gracefully
- [x] All 29 tests pass with race detector
- [x] golangci-lint: 0 issues
- [x] All 5 binaries build

Resolves #260