### PR TITLE
[Fix] Run agent container as root for privileged network operations

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -32,9 +32,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
 
 # Use distroless as minimal base image to package the agent binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Agent requires root for privileged network operations (VIP binding, BGP port 179, ARP/NDP)
+FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/novaedge-agent .
-USER 65532:65532
 
 ENTRYPOINT ["/novaedge-agent"]


### PR DESCRIPTION
## Summary
- Switch agent base image from `gcr.io/distroless/static:nonroot` to `gcr.io/distroless/static:latest`
- Remove `USER 65532:65532` directive that prevented privileged port binding
- Agent requires root for BGP port 179, VIP binding, ARP/NDP, and network interface management

## Root Cause
Container ran as UID 65532 with zero effective capabilities (`CapEff: 0000000000000000`), even though the pod had `privileged: true`. The Dockerfile's `USER` directive overrides the pod security context at the process level.

## Test plan
- [ ] Build agent image and verify it runs as root (UID 0)
- [ ] Deploy DaemonSet without `runAsUser: 0` patch
- [ ] Verify BGP server binds port 179 successfully
- [ ] Verify VIP management works (ARP, BGP, interface binding)

Resolves #263