### PR TITLE
[Fix] Add catch-all routing and configurable default VIP ref

### DIFF
--- a/cmd/novaedge-controller/main.go
+++ b/cmd/novaedge-controller/main.go
@@ -87,6 +87,7 @@ func main() {
 	flag.StringVar(&controllerClass, "controller-class", "novaedge.io/proxy",
 		"The loadBalancerClass this controller handles. Only gateways matching this class will be reconciled.")
 
+	var defaultVIPRef string
 	var enableServiceLB bool
 
 	var enableCertManager string
@@ -94,6 +95,8 @@ func main() {
 	var vaultAddr string
 	var vaultAuthMethod string
 	var vaultRole string
+	flag.StringVar(&defaultVIPRef, "default-vip-ref", "default-vip",
+		"Default VIP reference name for Ingress resources that don't specify the novaedge.io/vip-ref annotation.")
 	flag.BoolVar(&enableServiceLB, "enable-service-lb", false,
 		"Enable ServiceLB controller that watches type:LoadBalancer Services and creates ProxyVIP resources with IPAM allocation.")
 	flag.StringVar(&enableCertManager, "enable-cert-manager", "auto", "Enable cert-manager integration (auto|true|false)")
@@ -186,8 +189,9 @@ func main() {
 	}
 
 	if err = (&controller.IngressReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		DefaultVIPRef: defaultVIPRef,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Ingress")
 		os.Exit(1)

--- a/internal/agent/router/router.go
+++ b/internal/agent/router/router.go
@@ -199,7 +199,12 @@ func (r *Router) ApplyConfig(ctx context.Context, snapshot *config.Snapshot) err
 
 	// Build routing table
 	for _, route := range snapshot.Routes {
-		for _, hostname := range route.Hostnames {
+		// Routes without hostnames act as catch-all: use "" as the key
+		hostnames := route.Hostnames
+		if len(hostnames) == 0 {
+			hostnames = []string{""}
+		}
+		for _, hostname := range hostnames {
 			for _, rule := range route.Rules {
 				entry := &RouteEntry{
 					Route:          route,
@@ -547,8 +552,12 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		span.SetAttributes(attribute.String("http.hostname", hostname))
 	}
 
-	// Find matching route using radix tree index for O(log n) path lookup
+	// Find matching route using radix tree index for O(log n) path lookup.
+	// If no hostname-specific routes exist, fall back to catch-all routes (empty hostname key).
 	rIdx, ok := r.routeIndexes[hostname]
+	if !ok {
+		rIdx, ok = r.routeIndexes[""]
+	}
 	if !ok {
 		if recording {
 			span.AddEvent("route_not_found", trace.WithAttributes(

--- a/internal/agent/router/router_test.go
+++ b/internal/agent/router/router_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package router
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"testing"
 
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/novaedge/internal/agent/config"
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
@@ -164,6 +170,106 @@ func NewRegexMatcher(pattern string) (*RegexMatcher, error) {
 		return nil, err
 	}
 	return &RegexMatcher{Pattern: regex}, nil
+}
+
+func TestApplyConfigCatchAllRoute(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	r := NewRouter(logger)
+
+	// Create a snapshot with a route that has NO hostnames (catch-all)
+	snapshot := &config.Snapshot{
+		ConfigSnapshot: &pb.ConfigSnapshot{
+			Routes: []*pb.Route{
+				{
+					Name:      "catch-all",
+					Namespace: "default",
+					Hostnames: nil, // empty hostnames = catch-all
+					Rules: []*pb.RouteRule{
+						{
+							Matches: []*pb.RouteMatch{
+								{
+									Path: &pb.PathMatch{
+										Type:  pb.PathMatchType_PATH_PREFIX,
+										Value: "/",
+									},
+								},
+							},
+							BackendRefs: []*pb.BackendRef{
+								{Namespace: "default", Name: "backend1"},
+							},
+						},
+					},
+				},
+			},
+			Clusters:  []*pb.Cluster{},
+			Endpoints: map[string]*pb.EndpointList{},
+			Gateways:  []*pb.Gateway{},
+		},
+	}
+
+	err := r.ApplyConfig(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("ApplyConfig failed: %v", err)
+	}
+
+	// Verify that the catch-all route is stored under the empty string key
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if _, ok := r.routeIndexes[""]; !ok {
+		t.Fatal("Expected catch-all route index for empty hostname key")
+	}
+
+	if _, ok := r.routes[""]; !ok {
+		t.Fatal("Expected catch-all routes for empty hostname key")
+	}
+
+	if len(r.routes[""]) != 1 {
+		t.Fatalf("Expected 1 catch-all route, got %d", len(r.routes[""]))
+	}
+}
+
+func TestServeHTTPCatchAllFallback(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	r := NewRouter(logger)
+
+	// Set up a catch-all route under the empty hostname key
+	entry := &RouteEntry{
+		Route: &pb.Route{
+			Name:      "catch-all",
+			Namespace: "default",
+		},
+		Rule: &pb.RouteRule{
+			Matches: []*pb.RouteMatch{
+				{
+					Path: &pb.PathMatch{
+						Type:  pb.PathMatchType_PATH_PREFIX,
+						Value: "/",
+					},
+				},
+			},
+		},
+		PathMatcher: &PrefixMatcher{Prefix: "/"},
+	}
+
+	r.mu.Lock()
+	r.routes[""] = []*RouteEntry{entry}
+	r.routeIndexes[""] = newRouteIndex(r.routes[""])
+	r.mu.Unlock()
+
+	// Make a request with a specific hostname that has no route
+	req := httptest.NewRequest("GET", "http://unknown-host.example.com/api/test", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	// Should NOT get 404 "No route found" since catch-all exists.
+	// It may get 404 "No matching route rule" or other errors due to missing backends,
+	// but the key assertion is that the catch-all route was tried.
+	body := w.Body.String()
+	if w.Code == http.StatusNotFound && body == "No route found\n" {
+		t.Error("Expected catch-all route to handle request, but got 'No route found'")
+	}
 }
 
 func TestHashEndpointListIncludesLBPolicy(t *testing.T) {

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -44,8 +44,9 @@ const (
 // IngressReconciler reconciles Kubernetes Ingress objects
 type IngressReconciler struct {
 	client.Client
-	Scheme       *runtime.Scheme
-	IngressClass string // Configurable ingress class name to watch
+	Scheme        *runtime.Scheme
+	IngressClass  string // Configurable ingress class name to watch
+	DefaultVIPRef string // Configurable default VIP reference for Ingress resources without explicit annotation
 }
 
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;update;patch
@@ -93,8 +94,8 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	// Translate Ingress to CRDs with service port resolver
-	translator := NewIngressTranslatorWithResolver(ingress.Namespace, r.resolveServicePort)
+	// Translate Ingress to CRDs with service port resolver and configurable default VIP
+	translator := NewIngressTranslatorWithOptions(ingress.Namespace, r.resolveServicePort, r.DefaultVIPRef)
 	result, err := translator.Translate(ingress)
 	if err != nil {
 		logger.Error(err, "Failed to translate Ingress to CRDs")

--- a/internal/controller/ingress_translator.go
+++ b/internal/controller/ingress_translator.go
@@ -172,12 +172,14 @@ type ServicePortResolver func(namespace, serviceName, portName string) (int32, e
 type IngressTranslator struct {
 	namespace           string
 	servicePortResolver ServicePortResolver
+	defaultVIPRef       string
 }
 
 // NewIngressTranslator creates a new IngressTranslator
 func NewIngressTranslator(namespace string) *IngressTranslator {
 	return &IngressTranslator{
-		namespace: namespace,
+		namespace:     namespace,
+		defaultVIPRef: DefaultVIPRef,
 	}
 }
 
@@ -186,6 +188,20 @@ func NewIngressTranslatorWithResolver(namespace string, resolver ServicePortReso
 	return &IngressTranslator{
 		namespace:           namespace,
 		servicePortResolver: resolver,
+		defaultVIPRef:       DefaultVIPRef,
+	}
+}
+
+// NewIngressTranslatorWithOptions creates a new IngressTranslator with a service port resolver and configurable default VIP ref
+func NewIngressTranslatorWithOptions(namespace string, resolver ServicePortResolver, defaultVIPRef string) *IngressTranslator {
+	vipRef := defaultVIPRef
+	if vipRef == "" {
+		vipRef = DefaultVIPRef
+	}
+	return &IngressTranslator{
+		namespace:           namespace,
+		servicePortResolver: resolver,
+		defaultVIPRef:       vipRef,
 	}
 }
 
@@ -649,7 +665,7 @@ func (t *IngressTranslator) getVIPRef(ingress *networkingv1.Ingress) string {
 	if vipRef, exists := ingress.Annotations[AnnotationVIPRef]; exists {
 		return vipRef
 	}
-	return DefaultVIPRef
+	return t.defaultVIPRef
 }
 
 func (t *IngressTranslator) getIngressClassName(ingress *networkingv1.Ingress) string {

--- a/internal/controller/ingress_translator_extended_test.go
+++ b/internal/controller/ingress_translator_extended_test.go
@@ -64,6 +64,53 @@ func TestGetVIPRef(t *testing.T) {
 	}
 }
 
+func TestGetVIPRefConfigurable(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultVIPRef string
+		annotation    string
+		expectVIP     string
+	}{
+		{
+			name:          "custom default VIP used when no annotation",
+			defaultVIPRef: "production-vip",
+			annotation:    "",
+			expectVIP:     "production-vip",
+		},
+		{
+			name:          "annotation overrides custom default",
+			defaultVIPRef: "production-vip",
+			annotation:    "specific-vip",
+			expectVIP:     "specific-vip",
+		},
+		{
+			name:          "empty defaultVIPRef falls back to constant",
+			defaultVIPRef: "",
+			annotation:    "",
+			expectVIP:     DefaultVIPRef,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translator := NewIngressTranslatorWithOptions("default", nil, tt.defaultVIPRef)
+			ingress := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: "default",
+				},
+			}
+			if tt.annotation != "" {
+				ingress.Annotations = map[string]string{AnnotationVIPRef: tt.annotation}
+			}
+			result := translator.getVIPRef(ingress)
+			if result != tt.expectVIP {
+				t.Errorf("getVIPRef() = %v, want %v", result, tt.expectVIP)
+			}
+		})
+	}
+}
+
 func TestGetIngressClassName(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- **#265**: Routes without hostnames are no longer silently dropped. They are stored under an empty-string key and used as a catch-all fallback when no hostname-specific route matches in `ServeHTTP`.
- **#266**: The `config/rbac/role.yaml` already has correct verbs — this is a deployment sync issue. Re-apply manifests to the cluster (`kubectl apply -f config/rbac/role.yaml`).
- **#267**: The Ingress translator's hardcoded `"default-vip"` fallback is now configurable via `--default-vip-ref` flag on the controller and a new `NewIngressTranslatorWithOptions` constructor.

## Changes
- `internal/agent/router/router.go`: Catch-all routing for empty hostnames in `ApplyConfig` and `ServeHTTP`
- `internal/controller/ingress_translator.go`: `defaultVIPRef` field + `NewIngressTranslatorWithOptions` constructor
- `internal/controller/ingress_controller.go`: `DefaultVIPRef` field passed to translator
- `cmd/novaedge-controller/main.go`: `--default-vip-ref` flag (default: `"default-vip"`)
- Tests added for both fixes

## Test Plan
- [x] `go test ./internal/agent/router/...` — all pass
- [x] `go test ./internal/controller/...` — all pass
- [x] `make build-all` — all 5 binaries compile
- [x] No new lint issues introduced
- [ ] Deploy and verify: create a route without hostnames, confirm it matches all requests
- [ ] Deploy and verify: set `--default-vip-ref=my-vip`, confirm Ingress uses it when annotation absent

Resolves #265
Resolves #267