### PR TITLE
[Feature] Add mesh certificate request loop for agent mTLS (#281)

### DIFF
--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -34,6 +34,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/piwi3910/novaedge/internal/agent/config"
 	"github.com/piwi3910/novaedge/internal/agent/cpvip"
@@ -42,6 +44,7 @@ import (
 	"github.com/piwi3910/novaedge/internal/agent/server"
 	"github.com/piwi3910/novaedge/internal/agent/vip"
 	"github.com/piwi3910/novaedge/internal/observability"
+	"github.com/piwi3910/novaedge/internal/pkg/tlsutil"
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
@@ -308,6 +311,14 @@ func main() {
 		if err := meshManager.Start(ctx); err != nil {
 			logger.Fatal("Failed to start mesh manager", zap.Error(err))
 		}
+
+		// Start mesh certificate requester in background.
+		// Creates a separate gRPC connection to the controller for cert requests.
+		meshConn, meshConnErr := createGRPCConnection(controllerAddr, grpcTLSCert, grpcTLSKey, grpcTLSCA)
+		if meshConnErr != nil {
+			logger.Fatal("Failed to create gRPC connection for mesh cert requester", zap.Error(meshConnErr))
+		}
+		meshManager.StartCertRequester(ctx, nodeName, meshConn)
 	}
 
 	// Start config watcher
@@ -687,4 +698,26 @@ func initLogger(level string) (*zap.Logger, zap.AtomicLevel) {
 	}
 
 	return logger, atomicLevel
+}
+
+// createGRPCConnection creates a gRPC client connection to the controller.
+// If TLS cert/key/CA are provided, it uses mTLS; otherwise insecure.
+func createGRPCConnection(addr, certFile, keyFile, caFile string) (*grpc.ClientConn, error) {
+	var opts []grpc.DialOption
+
+	if certFile != "" && keyFile != "" && caFile != "" {
+		creds, err := tlsutil.LoadClientTLSCredentials(certFile, keyFile, caFile, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to load TLS credentials: %w", err)
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	conn, err := grpc.NewClient(addr, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	return conn, nil
 }

--- a/internal/agent/mesh/cert.go
+++ b/internal/agent/mesh/cert.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mesh
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	pb "github.com/piwi3910/novaedge/internal/proto/gen"
+)
+
+const (
+	// renewalThreshold is the fraction of cert lifetime at which renewal starts.
+	renewalThreshold = 0.8
+
+	// minRenewalInterval prevents tight renewal loops on very short-lived certs.
+	minRenewalInterval = 30 * time.Second
+
+	// certRequestTimeout is the timeout for a single cert request RPC.
+	certRequestTimeout = 30 * time.Second
+
+	// certRetryDelay is the delay between retries on cert request failure.
+	certRetryDelay = 5 * time.Second
+)
+
+// CertRequester handles requesting and renewing mesh workload certificates
+// from the controller's RequestMeshCertificate RPC.
+type CertRequester struct {
+	logger      *zap.Logger
+	nodeName    string
+	trustDomain string
+	onUpdate    func(certPEM, keyPEM, caCertPEM []byte, spiffeID string) error
+}
+
+// NewCertRequester creates a new certificate requester.
+// The onUpdate callback is called whenever a new certificate is obtained.
+func NewCertRequester(logger *zap.Logger, nodeName, trustDomain string,
+	onUpdate func(certPEM, keyPEM, caCertPEM []byte, spiffeID string) error,
+) *CertRequester {
+	return &CertRequester{
+		logger:      logger.Named("cert-requester"),
+		nodeName:    nodeName,
+		trustDomain: trustDomain,
+		onUpdate:    onUpdate,
+	}
+}
+
+// Run starts the certificate request and renewal loop. It blocks until the
+// context is cancelled. On first call it immediately requests a certificate,
+// then renews at 80% of the certificate's lifetime.
+func (cr *CertRequester) Run(ctx context.Context, conn *grpc.ClientConn) {
+	client := pb.NewConfigServiceClient(conn)
+
+	for {
+		expiry, err := cr.requestAndApply(ctx, client)
+		if err != nil {
+			cr.logger.Error("Failed to request mesh certificate, retrying",
+				zap.Error(err),
+				zap.Duration("retry_delay", certRetryDelay))
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(certRetryDelay):
+				continue
+			}
+		}
+
+		// Schedule renewal at 80% of lifetime
+		lifetime := time.Until(expiry)
+		renewIn := time.Duration(float64(lifetime) * renewalThreshold)
+		if renewIn < minRenewalInterval {
+			renewIn = minRenewalInterval
+		}
+
+		cr.logger.Info("Mesh certificate obtained, scheduling renewal",
+			zap.Time("expiry", expiry),
+			zap.Duration("lifetime", lifetime),
+			zap.Duration("renew_in", renewIn))
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(renewIn):
+			cr.logger.Info("Mesh certificate renewal triggered")
+		}
+	}
+}
+
+// requestAndApply generates a CSR, calls the controller RPC, and applies
+// the returned certificate material. Returns the certificate expiry time.
+func (cr *CertRequester) requestAndApply(ctx context.Context, client pb.ConfigServiceClient) (time.Time, error) {
+	// Generate ECDSA P-256 private key
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to generate key: %w", err)
+	}
+
+	// Build CSR with SPIFFE URI SAN
+	spiffeURI, parseErr := url.Parse(fmt.Sprintf("spiffe://%s/agent/%s", cr.trustDomain, cr.nodeName))
+	if parseErr != nil {
+		return time.Time{}, fmt.Errorf("failed to parse SPIFFE URI: %w", parseErr)
+	}
+
+	csrTemplate := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   cr.nodeName,
+			Organization: []string{"novaedge"},
+		},
+		URIs: []*url.URL{spiffeURI},
+	}
+
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, key)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to create CSR: %w", err)
+	}
+
+	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+	// Call controller RPC
+	reqCtx, cancel := context.WithTimeout(ctx, certRequestTimeout)
+	defer cancel()
+
+	resp, err := client.RequestMeshCertificate(reqCtx, &pb.MeshCertificateRequest{
+		Csr:      csrPEM,
+		NodeName: cr.nodeName,
+	})
+	if err != nil {
+		return time.Time{}, fmt.Errorf("RequestMeshCertificate RPC failed: %w", err)
+	}
+
+	// Encode private key to PEM
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	// Apply the certificate
+	if err := cr.onUpdate(resp.Certificate, keyPEM, resp.CaCertificate, resp.SpiffeId); err != nil {
+		return time.Time{}, fmt.Errorf("failed to apply certificate: %w", err)
+	}
+
+	expiry := time.Unix(resp.ExpiryUnix, 0)
+
+	cr.logger.Info("Mesh certificate applied",
+		zap.String("spiffe_id", resp.SpiffeId),
+		zap.Time("expiry", expiry))
+
+	return expiry, nil
+}

--- a/internal/agent/mesh/cert_test.go
+++ b/internal/agent/mesh/cert_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mesh
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	pb "github.com/piwi3910/novaedge/internal/proto/gen"
+)
+
+// fakeCertServer implements the RequestMeshCertificate RPC for testing.
+type fakeCertServer struct {
+	pb.UnimplementedConfigServiceServer
+	caKey  *ecdsa.PrivateKey
+	caCert *x509.Certificate
+	caPEM  []byte
+}
+
+func newFakeCertServer(t *testing.T) *fakeCertServer {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	return &fakeCertServer{
+		caKey:  caKey,
+		caCert: caCert,
+		caPEM:  caPEM,
+	}
+}
+
+func (s *fakeCertServer) RequestMeshCertificate(_ context.Context, req *pb.MeshCertificateRequest) (*pb.MeshCertificateResponse, error) {
+	// Parse the CSR
+	block, _ := pem.Decode(req.Csr)
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sign the certificate
+	expiry := time.Now().Add(24 * time.Hour)
+	certTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      csr.Subject,
+		URIs:         csr.URIs,
+		NotBefore:    time.Now(),
+		NotAfter:     expiry,
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, certTemplate, s.caCert, csr.PublicKey, s.caKey)
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	spiffeID := ""
+	if len(csr.URIs) > 0 {
+		spiffeID = csr.URIs[0].String()
+	}
+
+	return &pb.MeshCertificateResponse{
+		Certificate:   certPEM,
+		CaCertificate: s.caPEM,
+		SpiffeId:      spiffeID,
+		ExpiryUnix:    expiry.Unix(),
+	}, nil
+}
+
+func TestCertRequester_RequestAndApply(t *testing.T) {
+	// Start a fake gRPC server
+	server := grpc.NewServer()
+	fakeSrv := newFakeCertServer(t)
+	pb.RegisterConfigServiceServer(server, fakeSrv)
+
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = server.Serve(lis) }()
+	defer server.Stop()
+
+	// Connect to the fake server
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	logger := zaptest.NewLogger(t)
+
+	// Track cert updates
+	var mu sync.Mutex
+	var gotCert, gotKey, gotCA []byte
+	var gotSPIFFE string
+
+	cr := NewCertRequester(logger, "test-node", "cluster.local",
+		func(certPEM, keyPEM, caCertPEM []byte, spiffeID string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			gotCert = certPEM
+			gotKey = keyPEM
+			gotCA = caCertPEM
+			gotSPIFFE = spiffeID
+			return nil
+		})
+
+	// Run with a short-lived context so it does one request then stops
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go cr.Run(ctx, conn)
+
+	// Wait for the certificate to be applied
+	deadline := time.After(5 * time.Second)
+	for {
+		mu.Lock()
+		hasCert := gotCert != nil
+		mu.Unlock()
+		if hasCert {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for cert to be applied")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Verify certificate
+	if len(gotCert) == 0 {
+		t.Fatal("expected certificate, got empty")
+	}
+	if len(gotKey) == 0 {
+		t.Fatal("expected key, got empty")
+	}
+	if len(gotCA) == 0 {
+		t.Fatal("expected CA cert, got empty")
+	}
+
+	expectedSPIFFE := "spiffe://cluster.local/agent/test-node"
+	if gotSPIFFE != expectedSPIFFE {
+		t.Errorf("expected SPIFFE ID %q, got %q", expectedSPIFFE, gotSPIFFE)
+	}
+
+	// Verify the cert can be parsed and used as a TLS certificate
+	block, _ := pem.Decode(gotCert)
+	if block == nil {
+		t.Fatal("failed to decode cert PEM")
+	}
+	cert, parseErr := x509.ParseCertificate(block.Bytes)
+	if parseErr != nil {
+		t.Fatalf("failed to parse certificate: %v", parseErr)
+	}
+
+	// Verify SPIFFE URI SAN
+	if len(cert.URIs) == 0 {
+		t.Fatal("certificate has no URI SANs")
+	}
+	if cert.URIs[0].String() != expectedSPIFFE {
+		t.Errorf("cert URI SAN = %q, want %q", cert.URIs[0].String(), expectedSPIFFE)
+	}
+
+	// Verify the private key matches the cert
+	keyBlock, _ := pem.Decode(gotKey)
+	if keyBlock == nil {
+		t.Fatal("failed to decode key PEM")
+	}
+	privKey, keyErr := x509.ParseECPrivateKey(keyBlock.Bytes)
+	if keyErr != nil {
+		t.Fatalf("failed to parse private key: %v", keyErr)
+	}
+
+	// Verify key matches cert's public key
+	certPubKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("cert public key is not ECDSA")
+	}
+	if certPubKey.X.Cmp(privKey.X) != 0 || certPubKey.Y.Cmp(privKey.Y) != 0 {
+		t.Fatal("private key does not match certificate public key")
+	}
+}
+
+func TestCertRequester_RenewalLoop(t *testing.T) {
+	// Start a fake gRPC server that issues short-lived certs
+	server := grpc.NewServer()
+	fakeSrv := newFakeCertServer(t)
+	pb.RegisterConfigServiceServer(server, fakeSrv)
+
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = server.Serve(lis) }()
+	defer server.Stop()
+
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	logger := zaptest.NewLogger(t)
+
+	var mu sync.Mutex
+	var requestCount int
+
+	cr := NewCertRequester(logger, "test-node", "cluster.local",
+		func(_, _, _ []byte, _ string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			requestCount++
+			return nil
+		})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	go cr.Run(ctx, conn)
+
+	// Wait for at least one request
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		count := requestCount
+		mu.Unlock()
+		if count >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for cert request")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	mu.Lock()
+	count := requestCount
+	mu.Unlock()
+
+	if count < 1 {
+		t.Fatalf("expected at least 1 cert request, got %d", count)
+	}
+}

--- a/internal/agent/mesh/manager.go
+++ b/internal/agent/mesh/manager.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
@@ -238,6 +239,13 @@ func (m *Manager) ApplyConfig(services []*pb.InternalService, authzPolicies []*p
 		zap.Int("authz_policies", len(authzPolicies)))
 
 	return nil
+}
+
+// StartCertRequester launches a background goroutine that requests a mesh
+// workload certificate from the controller and renews it before expiry.
+func (m *Manager) StartCertRequester(ctx context.Context, nodeName string, conn *grpc.ClientConn) {
+	cr := NewCertRequester(m.logger, nodeName, m.trustDomain, m.UpdateTLSCertificate)
+	go cr.Run(ctx, conn)
 }
 
 // UpdateTLSCertificate updates the mesh mTLS certificate material.


### PR DESCRIPTION
## Summary

- Adds `CertRequester` to the mesh package that generates ECDSA P-256 CSR with SPIFFE URI SAN, calls `RequestMeshCertificate` RPC on the controller, and applies the returned cert/key/CA to the TLS provider
- Renewal loop triggers at 80% of cert lifetime with a 30s minimum interval
- Wires the cert requester into the agent main via a separate gRPC connection to the controller
- Adds `StartCertRequester` method to `mesh.Manager`

## Files Changed
- `internal/agent/mesh/cert.go` — New `CertRequester` with request and renewal loop
- `internal/agent/mesh/cert_test.go` — Tests with fake gRPC server verifying cert request, SPIFFE ID, and key matching
- `internal/agent/mesh/manager.go` — Added `StartCertRequester` method
- `cmd/novaedge-agent/main.go` — Creates gRPC connection and starts cert requester when mesh is enabled

## Test Plan
- [x] `go test ./internal/agent/mesh/ -run TestCertRequester` passes
- [x] `go test ./...` all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] All 5 binaries build

Resolves #281