### PR TITLE
[Fix] Sync documentation and RBAC with codebase (#283)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ NovaEdge is a distributed Kubernetes-native load balancer, reverse proxy, and VI
 - Ingress Controller (compatible with Kubernetes Ingress and Gateway API)
 - Distributed VIP management (L2 ARP, BGP, OSPF modes with BFD and IPv6)
 - Certificate management (ACME, cert-manager, HashiCorp Vault)
+- Service mesh with transparent mTLS (TPROXY + SPIFFE)
 - WASM plugin system for extensibility
 - Multi-cluster federation with hub-spoke topology
 - Kubernetes-native control plane using 10 CRDs
@@ -43,10 +44,11 @@ novaedge/
 │   │   ├── vault/                    # HashiCorp Vault integration
 │   │   ├── federation/               # Multi-cluster federation
 │   │   ├── ipam/                     # IP address management
+│   │   ├── meshca/                   # Mesh certificate authority
 │   │   └── snapshot/                 # Config snapshot builder
 │   ├── agent/                        # Agent implementation
 │   │   ├── vip/                      # VIP management (L2/BGP/OSPF/BFD)
-│   │   ├── lb/                       # Load balancing algorithms (6 + sticky)
+│   │   ├── lb/                       # Load balancing algorithms (12 types)
 │   │   ├── router/                   # Request routing, middleware, caching, compression
 │   │   ├── policy/                   # Policy enforcement (rate-limit, auth, CORS, JWT, WAF, mTLS)
 │   │   ├── server/                   # HTTP/HTTPS/HTTP3 servers, mTLS, OCSP, PROXY protocol
@@ -57,7 +59,11 @@ novaedge/
 │   │   ├── config/                   # Config snapshot handling
 │   │   ├── metrics/                  # Prometheus metrics
 │   │   ├── grpc/                     # gRPC handler
-│   │   └── protocol/                 # Protocol detection
+│   │   ├── protocol/                 # Protocol detection
+│   │   ├── mesh/                     # Service mesh (mTLS, TPROXY, tunnel, authz, certs)
+│   │   ├── cpvip/                    # Control-plane VIP management
+│   │   ├── filters/                  # Request/response filter chains
+│   │   └── websocket/               # WebSocket upgrade handling
 │   ├── acme/                         # ACME client (Let's Encrypt)
 │   │   └── dns/                      # DNS-01 providers (Cloudflare, Route53, Google)
 │   ├── standalone/                   # Standalone mode config
@@ -70,7 +76,7 @@ novaedge/
 │   └── novaedge-operator/            # Operator chart
 ├── config/                           # Kubernetes manifests
 │   ├── crd/                          # CRD definitions (10 CRDs)
-│   ├── samples/                      # Example resources (52 samples)
+│   ├── samples/                      # Example resources (51 samples)
 │   ├── rbac/                         # RBAC manifests
 │   ├── controller/                   # Controller deployment
 │   ├── agent/                        # Agent DaemonSet
@@ -112,8 +118,8 @@ make test
 # Run unit tests only
 go test ./internal/...
 
-# Run integration tests
-make test-integration
+# Run conformance tests (requires running cluster)
+make test-conformance
 
 # Run tests with coverage
 make test-coverage
@@ -213,6 +219,11 @@ When implementing LB algorithms in `internal/agent/lb/`:
 - **EWMA**: Latency-aware using exponentially weighted moving average
 - **Ring Hash / Maglev**: Consistent hashing for session affinity
 - **Sticky**: Cookie-based session affinity
+- **Locality-aware**: Prefer endpoints in the same zone/region
+- **Priority failover**: Route to highest-priority endpoint group
+- **Panic mode**: Bypass health checks when too many endpoints are unhealthy
+- **Slow-start**: Gradually ramp traffic to newly added endpoints
+- **Resource-adaptive**: Weight endpoints by CPU/memory usage
 - All algorithms must handle endpoint addition/removal without disruption
 
 ## VIP Management
@@ -238,6 +249,24 @@ When implementing LB algorithms in `internal/agent/lb/`:
 ### IPv6 Dual-Stack
 - Full IPv6 support for VIP addresses
 - IP address pools via ProxyIPPool CRD with IPAM allocation
+
+## Service Mesh
+
+The service mesh provides transparent mTLS between Kubernetes services:
+
+- **`internal/agent/mesh/`**: TPROXY-based traffic interception, HTTP/2 mTLS tunnel, TLS provider, authorization engine, certificate requester
+- **`internal/controller/meshca/`**: Embedded certificate authority issuing SPIFFE workload certificates (ECDSA P-256, 24h lifetime)
+- Services opt-in via `novaedge.io/mesh: "enabled"` annotation
+- SPIFFE identity format: `spiffe://cluster.local/agent/<node>`
+- Agent cert requester generates CSR, calls `RequestMeshCertificate` RPC, auto-renews at 80% lifetime
+- TPROXY iptables rules intercept ClusterIP traffic to port 15001, tunnel via mTLS on port 15002
+
+## Control-Plane VIP
+
+- **`internal/agent/cpvip/`**: Manages a dedicated VIP for controller high availability
+- Health checks controller via `/livez` endpoint with ServiceAccount token auth
+- Supports L2/BGP/BFD modes for CP VIP announcement
+- Separate from data-plane VIP management in `internal/agent/vip/`
 
 ## Policy & Middleware Architecture
 
@@ -267,6 +296,8 @@ The controller pushes versioned `ConfigSnapshot` to agents containing:
 - TLS certificates
 - L4 route configurations
 - Authentication configurations
+- Internal services (mesh-enabled) with endpoints
+- Mesh authorization policies
 
 Agents must atomically swap runtime config when receiving new snapshots.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ NovaEdge is a distributed Kubernetes-native load balancer, reverse proxy, and VI
 
 ### L7 Load Balancing & Reverse Proxy
 - **Protocol support**: HTTP/1.1, HTTP/2 (h2/h2c), HTTP/3 (QUIC), WebSockets, gRPC, Server-Sent Events
-- **6 load balancing algorithms**: RoundRobin, P2C, EWMA, RingHash, Maglev, LeastConn
-- **Cookie-based session affinity** (sticky sessions)
+- **12 load balancing algorithms**: RoundRobin, LeastConn, P2C, EWMA, RingHash, Maglev, Sticky (cookie-based), Locality-aware, Priority failover, Panic mode, Slow-start, Resource-adaptive
 - **Advanced routing**: hostname, path, header, method matching with boolean routing expressions
 - **Traffic management**: canary/weighted splitting, traffic mirroring, request retry with configurable policies
 - **Response processing**: HTTP caching, gzip/Brotli compression, buffering, custom error pages
@@ -65,6 +64,18 @@ NovaEdge is a distributed Kubernetes-native load balancer, reverse proxy, and VI
 - **Web UI dashboard** (via novactl)
 - **Per-route access logging**
 - **CLI tool** (novactl) with trace query, metrics query, and agent inspection
+
+### Service Mesh
+- **Transparent mTLS** between services via TPROXY interception
+- **Embedded mesh CA** with SPIFFE identity (ECDSA P-256 workload certificates)
+- **HTTP/2 mTLS tunnel** for encrypted service-to-service communication
+- **Mesh authorization engine** with service-level access policies
+- **Automatic certificate rotation** with configurable renewal threshold
+
+### Control-Plane VIP
+- **Dedicated VIP for controller** high availability
+- **Health-check based failover** using Kubernetes `/livez` endpoint
+- **BGP/BFD mode support** for CP VIP announcement
 
 ### Health & Resilience
 - **Active and passive health checking**
@@ -218,9 +229,8 @@ kubectl get proxyippools
 ## Testing & Quality
 
 ### Test Suite
-- **191+ test functions** across unit, integration, and controller tests
-- **46.5% integration coverage** with end-to-end request flow validation
-- **85%+ unit coverage** for critical components (router, health, VIP, load balancing)
+- **1500+ test functions** across unit, integration, and controller tests
+- **85%+ unit coverage** for critical components (router, health, VIP, load balancing, mesh, policies)
 
 ### Running Tests
 ```bash

--- a/charts/novaedge/templates/controller-rbac.yaml
+++ b/charts/novaedge/templates/controller-rbac.yaml
@@ -10,9 +10,22 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - configmaps
   - secrets
+  - serviceaccounts
   - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
   verbs:
   - get
   - list
@@ -24,6 +37,19 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - discovery.k8s.io
   resources:
@@ -88,8 +114,13 @@ rules:
 - apiGroups:
   - novaedge.io
   resources:
+  - novaedgeclusters
+  - novaedgefederations
+  - novaedgeremoteclusters
   - proxybackends
+  - proxycertificates
   - proxygateways
+  - proxyippools
   - proxypolicies
   - proxyroutes
   - proxyvips
@@ -104,8 +135,13 @@ rules:
 - apiGroups:
   - novaedge.io
   resources:
+  - novaedgeclusters/finalizers
+  - novaedgefederations/finalizers
+  - novaedgeremoteclusters/finalizers
   - proxybackends/finalizers
+  - proxycertificates/finalizers
   - proxygateways/finalizers
+  - proxyippools/finalizers
   - proxypolicies/finalizers
   - proxyroutes/finalizers
   - proxyvips/finalizers
@@ -114,8 +150,13 @@ rules:
 - apiGroups:
   - novaedge.io
   resources:
+  - novaedgeclusters/status
+  - novaedgefederations/status
+  - novaedgeremoteclusters/status
   - proxybackends/status
+  - proxycertificates/status
   - proxygateways/status
+  - proxyippools/status
   - proxypolicies/status
   - proxyroutes/status
   - proxyvips/status
@@ -123,6 +164,21 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -107,7 +107,9 @@ rules:
   - novaedgefederations
   - novaedgeremoteclusters
   - proxybackends
+  - proxycertificates
   - proxygateways
+  - proxyippools
   - proxypolicies
   - proxyroutes
   - proxyvips
@@ -126,7 +128,9 @@ rules:
   - novaedgefederations/finalizers
   - novaedgeremoteclusters/finalizers
   - proxybackends/finalizers
+  - proxycertificates/finalizers
   - proxygateways/finalizers
+  - proxyippools/finalizers
   - proxypolicies/finalizers
   - proxyroutes/finalizers
   - proxyvips/finalizers
@@ -139,7 +143,9 @@ rules:
   - novaedgefederations/status
   - novaedgeremoteclusters/status
   - proxybackends/status
+  - proxycertificates/status
   - proxygateways/status
+  - proxyippools/status
   - proxypolicies/status
   - proxyroutes/status
   - proxyvips/status


### PR DESCRIPTION
## Summary

- **RBAC**: Add missing `ProxyCertificate` and `ProxyIPPool` permissions to `config/rbac/role.yaml` (resources, finalizers, status)
- **Helm RBAC**: Sync `charts/novaedge/templates/controller-rbac.yaml` with role.yaml — adds core resources (configmaps, serviceaccounts), apps group (daemonsets, deployments), cluster management CRDs, rbac group, and the two missing CRDs
- **README**: Fix LB algorithm count (6 → 12), test count (191 → 1500+), add Service Mesh and Control-Plane VIP feature sections
- **CLAUDE.md**: Fix repo structure (add mesh, cpvip, meshca, filters, websocket packages), expand LB algorithms list, fix sample count (52 → 51), replace non-existent `make test-integration` with `make test-conformance`, add service mesh and CP VIP documentation sections

## Test Plan

- [ ] `go test ./...` passes (no Go changes, docs/yaml only)
- [ ] `helm template novaedge charts/novaedge` renders without errors
- [ ] Verify RBAC role.yaml lists all 10 CRD resource types
- [ ] Verify Helm RBAC matches config/rbac/role.yaml permissions
- [ ] Deploy updated RBAC to cluster: `kubectl apply -f config/rbac/role.yaml`

Resolves #283