### PR TITLE
[Fix] Ingress translator auto-detects LB policy from VIP mode (#292)

### DIFF
--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -94,8 +94,8 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	// Translate Ingress to CRDs with service port resolver and configurable default VIP
-	translator := NewIngressTranslatorWithOptions(ingress.Namespace, r.resolveServicePort, r.DefaultVIPRef)
+	// Translate Ingress to CRDs with service port resolver, configurable default VIP, and VIP mode resolver
+	translator := NewIngressTranslatorWithOptions(ingress.Namespace, r.resolveServicePort, r.DefaultVIPRef, r.resolveVIPMode)
 	result, err := translator.Translate(ingress)
 	if err != nil {
 		logger.Error(err, "Failed to translate Ingress to CRDs")
@@ -314,6 +314,16 @@ func (r *IngressReconciler) resolveServicePort(namespace, serviceName, portName 
 	}
 
 	return 0, fmt.Errorf("port %s not found in service %s/%s", portName, namespace, serviceName)
+}
+
+// resolveVIPMode fetches a ProxyVIP by name and returns its mode (e.g. "BGP", "OSPF", "L2ARP").
+// Returns an empty string if the VIP cannot be found.
+func (r *IngressReconciler) resolveVIPMode(vipRef string) string {
+	vip := &novaedgev1alpha1.ProxyVIP{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: vipRef}, vip); err != nil {
+		return ""
+	}
+	return string(vip.Spec.Mode)
 }
 
 // updateIngressStatus updates the Ingress status with the LoadBalancer IP from the VIP

--- a/internal/controller/ingress_translator.go
+++ b/internal/controller/ingress_translator.go
@@ -168,11 +168,15 @@ const (
 // ServicePortResolver resolves service port names to port numbers
 type ServicePortResolver func(namespace, serviceName, portName string) (int32, error)
 
+// VIPModeResolver resolves a VIP reference name to its mode (e.g. "BGP", "OSPF", "L2ARP")
+type VIPModeResolver func(vipRef string) string
+
 // IngressTranslator translates Kubernetes Ingress resources to NovaEdge CRDs
 type IngressTranslator struct {
 	namespace           string
 	servicePortResolver ServicePortResolver
 	defaultVIPRef       string
+	vipModeResolver     VIPModeResolver
 }
 
 // NewIngressTranslator creates a new IngressTranslator
@@ -193,7 +197,7 @@ func NewIngressTranslatorWithResolver(namespace string, resolver ServicePortReso
 }
 
 // NewIngressTranslatorWithOptions creates a new IngressTranslator with a service port resolver and configurable default VIP ref
-func NewIngressTranslatorWithOptions(namespace string, resolver ServicePortResolver, defaultVIPRef string) *IngressTranslator {
+func NewIngressTranslatorWithOptions(namespace string, resolver ServicePortResolver, defaultVIPRef string, vipModeResolver VIPModeResolver) *IngressTranslator {
 	vipRef := defaultVIPRef
 	if vipRef == "" {
 		vipRef = DefaultVIPRef
@@ -202,6 +206,7 @@ func NewIngressTranslatorWithOptions(namespace string, resolver ServicePortResol
 		namespace:           namespace,
 		servicePortResolver: resolver,
 		defaultVIPRef:       vipRef,
+		vipModeResolver:     vipModeResolver,
 	}
 }
 
@@ -680,6 +685,7 @@ func (t *IngressTranslator) getIngressClassName(ingress *networkingv1.Ingress) s
 }
 
 func (t *IngressTranslator) getLBPolicy(ingress *networkingv1.Ingress) novaedgev1alpha1.LoadBalancingPolicy {
+	// Explicit annotation always wins
 	if lbPolicy, exists := ingress.Annotations[AnnotationLoadBalancing]; exists {
 		switch strings.ToLower(lbPolicy) {
 		case "roundrobin":
@@ -694,7 +700,14 @@ func (t *IngressTranslator) getLBPolicy(ingress *networkingv1.Ingress) novaedgev
 			return novaedgev1alpha1.LBPolicyMaglev
 		}
 	}
-	// Default to RoundRobin
+	// Auto-detect from VIP mode: BGP/OSPF require hash-based LB for ECMP
+	if t.vipModeResolver != nil {
+		vipRef := t.getVIPRef(ingress)
+		mode := t.vipModeResolver(vipRef)
+		if mode == string(novaedgev1alpha1.VIPModeBGP) || mode == string(novaedgev1alpha1.VIPModeOSPF) {
+			return novaedgev1alpha1.LBPolicyMaglev
+		}
+	}
 	return novaedgev1alpha1.LBPolicyRoundRobin
 }
 

--- a/internal/controller/ingress_translator_extended_test.go
+++ b/internal/controller/ingress_translator_extended_test.go
@@ -22,6 +22,8 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 )
 
 func TestGetVIPRef(t *testing.T) {
@@ -93,7 +95,7 @@ func TestGetVIPRefConfigurable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			translator := NewIngressTranslatorWithOptions("default", nil, tt.defaultVIPRef)
+			translator := NewIngressTranslatorWithOptions("default", nil, tt.defaultVIPRef, nil)
 			ingress := &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ingress",
@@ -1249,4 +1251,83 @@ func TestGenerateNames(t *testing.T) {
 			t.Errorf("generateDefaultBackendName() = %v, want %v", result, expected)
 		}
 	})
+}
+
+func TestGetLBPolicyVIPModeAware(t *testing.T) {
+	tests := []struct {
+		name           string
+		vipModeResult  string
+		annotation     string
+		expectedPolicy novaedgev1alpha1.LoadBalancingPolicy
+	}{
+		{
+			name:           "BGP VIP with no annotation defaults to Maglev",
+			vipModeResult:  "BGP",
+			annotation:     "",
+			expectedPolicy: novaedgev1alpha1.LBPolicyMaglev,
+		},
+		{
+			name:           "OSPF VIP with no annotation defaults to Maglev",
+			vipModeResult:  "OSPF",
+			annotation:     "",
+			expectedPolicy: novaedgev1alpha1.LBPolicyMaglev,
+		},
+		{
+			name:           "L2ARP VIP with no annotation defaults to RoundRobin",
+			vipModeResult:  "L2ARP",
+			annotation:     "",
+			expectedPolicy: novaedgev1alpha1.LBPolicyRoundRobin,
+		},
+		{
+			name:           "BGP VIP with explicit roundrobin annotation honored",
+			vipModeResult:  "BGP",
+			annotation:     "roundrobin",
+			expectedPolicy: novaedgev1alpha1.LBPolicyRoundRobin,
+		},
+		{
+			name:           "BGP VIP with explicit ringhash annotation honored",
+			vipModeResult:  "BGP",
+			annotation:     "ringhash",
+			expectedPolicy: novaedgev1alpha1.LBPolicyRingHash,
+		},
+		{
+			name:           "VIP not found (empty mode) defaults to RoundRobin",
+			vipModeResult:  "",
+			annotation:     "",
+			expectedPolicy: novaedgev1alpha1.LBPolicyRoundRobin,
+		},
+		{
+			name:           "nil resolver defaults to RoundRobin",
+			vipModeResult:  "", // won't be called
+			annotation:     "",
+			expectedPolicy: novaedgev1alpha1.LBPolicyRoundRobin,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resolver VIPModeResolver
+			if tt.name != "nil resolver defaults to RoundRobin" {
+				resolver = func(_ string) string { return tt.vipModeResult }
+			}
+
+			translator := NewIngressTranslatorWithOptions("default", nil, "default-vip", resolver)
+			annotations := map[string]string{}
+			if tt.annotation != "" {
+				annotations[AnnotationLoadBalancing] = tt.annotation
+			}
+			ingress := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-ingress",
+					Namespace:   "default",
+					Annotations: annotations,
+				},
+			}
+
+			result := translator.getLBPolicy(ingress)
+			if result != tt.expectedPolicy {
+				t.Errorf("getLBPolicy() = %v, want %v", result, tt.expectedPolicy)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Ingress translator hardcoded `RoundRobin` as default LB policy, breaking all Ingress resources with BGP/OSPF VIPs that require hash-based policies for ECMP routing
- Added `VIPModeResolver` callback to `IngressTranslator` (same pattern as existing `ServicePortResolver`) that auto-detects VIP mode and defaults to `Maglev` for BGP/OSPF
- Explicit `novaedge.io/load-balancing` annotations always override auto-detection

## Test plan

- [x] Unit tests: BGP VIP → Maglev, OSPF VIP → Maglev, L2ARP VIP → RoundRobin
- [x] Unit tests: explicit annotation overrides VIP mode auto-detection
- [x] Unit tests: nil resolver / VIP not found → RoundRobin fallback
- [x] `golangci-lint` on `./internal/controller/...` → 0 issues
- [x] All 5 binaries build successfully

Resolves #292