### PR TITLE
[Fix] Use RemoteAddr for observability rate limiting, ignore X-Forwarded-For

### DIFF
--- a/internal/agent/server/ratelimit.go
+++ b/internal/agent/server/ratelimit.go
@@ -123,20 +123,10 @@ func RateLimitMiddleware(limiter *IPRateLimiter) func(http.Handler) http.Handler
 				ip = r.RemoteAddr
 			}
 
-			// Check X-Forwarded-For header for proxied requests
-			if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
-				// Use the first IP in the X-Forwarded-For chain
-				ip = forwardedFor
-				if commaIdx := len(ip); commaIdx > 0 {
-					for i, c := range ip {
-						if c == ',' {
-							commaIdx = i
-							break
-						}
-					}
-					ip = ip[:commaIdx]
-				}
-			}
+			// Security: Do NOT trust X-Forwarded-For for rate limiting.
+			// XFF can be freely set by clients, allowing attackers to bypass
+			// rate limits by randomizing fake IPs. Observability endpoints
+			// should always use the direct connection IP (RemoteAddr).
 
 			// Get rate limiter for this IP
 			rl := limiter.getLimiter(ip)


### PR DESCRIPTION
## Summary

- Remove X-Forwarded-For trust from the observability endpoint rate limiter
- Use `RemoteAddr` (direct connection IP) exclusively for rate limiting keys
- Prevents attackers from bypassing rate limits by injecting randomized IPs in the XFF header

## Details

The `RateLimitMiddleware` in `internal/agent/server/ratelimit.go` blindly trusted the first IP in the `X-Forwarded-For` header without validating trusted proxies. Since observability endpoints (`/healthz`, `/ready`, `/metrics`) are internal infrastructure endpoints, they should always rate-limit based on the direct connection IP.

## Test plan

- [ ] Verify rate limiting works correctly using `RemoteAddr`
- [ ] Confirm requests with spoofed `X-Forwarded-For` headers are rate-limited by their real IP
- [ ] Existing unit tests pass

Resolves #303