### PR TITLE
[Fix] JWT: require explicit allowed algorithms and reject "none"

### DIFF
--- a/internal/agent/policy/jwt.go
+++ b/internal/agent/policy/jwt.go
@@ -93,6 +93,11 @@ func NewJWTValidator(ctx context.Context, config *pb.JWTConfig) (*JWTValidator, 
 		blacklist: NewTokenBlacklist(),
 	}
 
+	// Require explicit algorithm configuration to prevent algorithm confusion attacks
+	if len(config.GetAllowedAlgorithms()) == 0 {
+		return nil, fmt.Errorf("AllowedAlgorithms must be explicitly configured; refusing to allow all algorithms by default")
+	}
+
 	// Build allowed algorithms set
 	v.allowedAlgorithms = buildAllowedAlgorithms(config.GetAllowedAlgorithms())
 
@@ -109,18 +114,9 @@ func NewJWTValidator(ctx context.Context, config *pb.JWTConfig) (*JWTValidator, 
 	return v, nil
 }
 
-// buildAllowedAlgorithms constructs a set of allowed algorithm names.
-// If the input slice is empty, all supported algorithms are allowed.
+// buildAllowedAlgorithms constructs a set of allowed algorithm names from the
+// provided list. Only algorithms present in supportedAlgorithms are included.
 func buildAllowedAlgorithms(algorithms []string) map[string]bool {
-	if len(algorithms) == 0 {
-		// Allow all supported algorithms
-		result := make(map[string]bool, len(supportedAlgorithms))
-		for alg := range supportedAlgorithms {
-			result[alg] = true
-		}
-		return result
-	}
-
 	result := make(map[string]bool, len(algorithms))
 	for _, alg := range algorithms {
 		if supportedAlgorithms[alg] {
@@ -214,6 +210,11 @@ func isSupportedSigningMethod(method jwt.SigningMethod) bool {
 func (v *JWTValidator) Validate(tokenString string) (*jwt.Token, error) {
 	// Parse token
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		// Explicitly reject the "none" algorithm to prevent algorithm confusion attacks
+		if algHeader, ok := token.Header["alg"].(string); ok && strings.EqualFold(algHeader, "none") {
+			return nil, fmt.Errorf("algorithm \"none\" is not allowed")
+		}
+
 		// Verify the signing method is a supported type
 		if !isSupportedSigningMethod(token.Method) {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])

--- a/internal/agent/policy/jwt_blacklist_test.go
+++ b/internal/agent/policy/jwt_blacklist_test.go
@@ -153,8 +153,9 @@ func TestTokenBlacklistStartCleanupContextCancel(t *testing.T) {
 
 func TestJWTValidatorRevoke(t *testing.T) {
 	config := &pb.JWTConfig{
-		Issuer:   "test-issuer",
-		Audience: []string{"test-audience"},
+		AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+		Issuer:            "test-issuer",
+		Audience:          []string{"test-audience"},
 	}
 
 	validator, err := NewJWTValidator(context.Background(), config)
@@ -177,7 +178,8 @@ func TestJWTValidatorRevoke(t *testing.T) {
 
 func TestJWTValidatorBlacklistInitialized(t *testing.T) {
 	config := &pb.JWTConfig{
-		Issuer: "test-issuer",
+		AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+		Issuer:            "test-issuer",
 	}
 
 	validator, err := NewJWTValidator(context.Background(), config)
@@ -238,9 +240,10 @@ func TestValidateBlacklistedToken(t *testing.T) {
 
 	t.Run("blacklisted token is rejected", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -278,9 +281,10 @@ func TestValidateBlacklistedToken(t *testing.T) {
 
 	t.Run("token without jti is not affected by blacklist", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -309,9 +313,10 @@ func TestValidateBlacklistedToken(t *testing.T) {
 
 	t.Run("token with expired blacklist entry is allowed", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -340,9 +345,10 @@ func TestValidateBlacklistedToken(t *testing.T) {
 
 	t.Run("different jti not affected", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -392,9 +398,10 @@ func TestHandleJWTWithBlacklist(t *testing.T) {
 	defer server.Close()
 
 	config := &pb.JWTConfig{
-		Issuer:   "test-issuer",
-		Audience: []string{"test-audience"},
-		JwksUri:  server.URL,
+		AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+		Issuer:            "test-issuer",
+		Audience:          []string{"test-audience"},
+		JwksUri:           server.URL,
 	}
 
 	validator, err := NewJWTValidator(context.Background(), config)

--- a/internal/agent/policy/jwt_test.go
+++ b/internal/agent/policy/jwt_test.go
@@ -30,6 +30,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -545,12 +546,10 @@ func TestParseJWKPublicKey(t *testing.T) {
 }
 
 func TestBuildAllowedAlgorithms(t *testing.T) {
-	t.Run("empty list allows all", func(t *testing.T) {
+	t.Run("empty list returns empty set", func(t *testing.T) {
 		result := buildAllowedAlgorithms(nil)
-		for alg := range supportedAlgorithms {
-			if !result[alg] {
-				t.Errorf("Expected algorithm %s to be allowed", alg)
-			}
+		if len(result) != 0 {
+			t.Errorf("Expected empty set for nil input, got %d entries", len(result))
 		}
 	})
 
@@ -587,8 +586,9 @@ func TestBuildAllowedAlgorithms(t *testing.T) {
 func TestNewJWTValidator(t *testing.T) {
 	t.Run("without JWKS URI", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -627,9 +627,10 @@ func TestNewJWTValidator(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -653,9 +654,10 @@ func TestNewJWTValidator(t *testing.T) {
 
 	t.Run("with invalid JWKS URI", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  "http://invalid-host-that-does-not-exist.local/jwks",
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           "http://invalid-host-that-does-not-exist.local/jwks",
 		}
 
 		_, err := NewJWTValidator(context.Background(), config)
@@ -685,6 +687,23 @@ func TestNewJWTValidator(t *testing.T) {
 			t.Error("Expected ES384 to NOT be allowed")
 		}
 	})
+
+	t.Run("empty allowed algorithms returns error", func(t *testing.T) {
+		config := &pb.JWTConfig{
+			Issuer:   "test-issuer",
+			Audience: []string{"test-audience"},
+		}
+
+		_, err := NewJWTValidator(context.Background(), config)
+		if err == nil {
+			t.Fatal("Expected error when AllowedAlgorithms is empty")
+		}
+
+		expectedMsg := "AllowedAlgorithms must be explicitly configured"
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Errorf("Expected error containing %q, got: %v", expectedMsg, err)
+		}
+	})
 }
 
 func TestValidate(t *testing.T) {
@@ -710,9 +729,10 @@ func TestValidate(t *testing.T) {
 
 	t.Run("valid token", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -737,9 +757,10 @@ func TestValidate(t *testing.T) {
 
 	t.Run("expired token", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -760,9 +781,10 @@ func TestValidate(t *testing.T) {
 
 	t.Run("invalid issuer", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "expected-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "expected-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -783,9 +805,10 @@ func TestValidate(t *testing.T) {
 
 	t.Run("invalid audience", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"expected-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"expected-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -806,9 +829,10 @@ func TestValidate(t *testing.T) {
 
 	t.Run("unknown key ID", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -829,9 +853,10 @@ func TestValidate(t *testing.T) {
 
 	t.Run("malformed token", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -874,9 +899,10 @@ func TestValidateECDSA(t *testing.T) {
 			defer server.Close()
 
 			config := &pb.JWTConfig{
-				Issuer:   "test-issuer",
-				Audience: []string{"test-audience"},
-				JwksUri:  server.URL,
+				AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+				Issuer:            "test-issuer",
+				Audience:          []string{"test-audience"},
+				JwksUri:           server.URL,
 			}
 
 			validator, err := NewJWTValidator(context.Background(), config)
@@ -915,9 +941,10 @@ func TestValidateECDSA(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -953,9 +980,10 @@ func TestValidateEdDSA(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -993,9 +1021,10 @@ func TestValidateEdDSA(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -1196,9 +1225,10 @@ func TestValidateWithAllowedAlgorithms(t *testing.T) {
 
 	t.Run("no algorithms configured allows all", func(t *testing.T) {
 		config := &pb.JWTConfig{
-			Issuer:   "test-issuer",
-			Audience: []string{"test-audience"},
-			JwksUri:  server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			Issuer:            "test-issuer",
+			Audience:          []string{"test-audience"},
+			JwksUri:           server.URL,
 		}
 
 		validator, err := NewJWTValidator(context.Background(), config)
@@ -1263,9 +1293,10 @@ func TestValidateMixedKeyTypes(t *testing.T) {
 	defer server.Close()
 
 	config := &pb.JWTConfig{
-		Issuer:   "test-issuer",
-		Audience: []string{"test-audience"},
-		JwksUri:  server.URL,
+		AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+		Issuer:            "test-issuer",
+		Audience:          []string{"test-audience"},
+		JwksUri:           server.URL,
 	}
 
 	validator, err := NewJWTValidator(context.Background(), config)
@@ -1341,9 +1372,10 @@ func TestHandleJWT(t *testing.T) {
 	defer server.Close()
 
 	config := &pb.JWTConfig{
-		Issuer:   "test-issuer",
-		Audience: []string{"test-audience"},
-		JwksUri:  server.URL,
+		AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+		Issuer:            "test-issuer",
+		Audience:          []string{"test-audience"},
+		JwksUri:           server.URL,
 	}
 
 	validator, err := NewJWTValidator(context.Background(), config)
@@ -1473,9 +1505,10 @@ func TestHandleJWTWithECDSA(t *testing.T) {
 	defer server.Close()
 
 	config := &pb.JWTConfig{
-		Issuer:   "test-issuer",
-		Audience: []string{"test-audience"},
-		JwksUri:  server.URL,
+		AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+		Issuer:            "test-issuer",
+		Audience:          []string{"test-audience"},
+		JwksUri:           server.URL,
 	}
 
 	validator, err := NewJWTValidator(context.Background(), config)
@@ -1536,13 +1569,14 @@ func TestFetchJWKS(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			JwksUri: server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			JwksUri:           server.URL,
 		}
 
 		validator := &JWTValidator{
 			config:            config,
 			keys:              make(map[string]interface{}),
-			allowedAlgorithms: buildAllowedAlgorithms(nil),
+			allowedAlgorithms: buildAllowedAlgorithms([]string{"RS256", "ES256", "EdDSA"}),
 		}
 
 		err = validator.fetchJWKS(context.Background())
@@ -1574,13 +1608,14 @@ func TestFetchJWKS(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			JwksUri: server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			JwksUri:           server.URL,
 		}
 
 		validator := &JWTValidator{
 			config:            config,
 			keys:              make(map[string]interface{}),
-			allowedAlgorithms: buildAllowedAlgorithms(nil),
+			allowedAlgorithms: buildAllowedAlgorithms([]string{"RS256", "ES256", "EdDSA"}),
 		}
 
 		err = validator.fetchJWKS(context.Background())
@@ -1612,13 +1647,14 @@ func TestFetchJWKS(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			JwksUri: server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			JwksUri:           server.URL,
 		}
 
 		validator := &JWTValidator{
 			config:            config,
 			keys:              make(map[string]interface{}),
-			allowedAlgorithms: buildAllowedAlgorithms(nil),
+			allowedAlgorithms: buildAllowedAlgorithms([]string{"RS256", "ES256", "EdDSA"}),
 		}
 
 		err = validator.fetchJWKS(context.Background())
@@ -1642,13 +1678,14 @@ func TestFetchJWKS(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			JwksUri: server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			JwksUri:           server.URL,
 		}
 
 		validator := &JWTValidator{
 			config:            config,
 			keys:              make(map[string]interface{}),
-			allowedAlgorithms: buildAllowedAlgorithms(nil),
+			allowedAlgorithms: buildAllowedAlgorithms([]string{"RS256", "ES256", "EdDSA"}),
 		}
 
 		err := validator.fetchJWKS(context.Background())
@@ -1665,13 +1702,14 @@ func TestFetchJWKS(t *testing.T) {
 		defer server.Close()
 
 		config := &pb.JWTConfig{
-			JwksUri: server.URL,
+			AllowedAlgorithms: []string{"RS256", "ES256", "EdDSA"},
+			JwksUri:           server.URL,
 		}
 
 		validator := &JWTValidator{
 			config:            config,
 			keys:              make(map[string]interface{}),
-			allowedAlgorithms: buildAllowedAlgorithms(nil),
+			allowedAlgorithms: buildAllowedAlgorithms([]string{"RS256", "ES256", "EdDSA"}),
 		}
 
 		err := validator.fetchJWKS(context.Background())


### PR DESCRIPTION
## Summary

- Enforce that `AllowedAlgorithms` must be explicitly configured when creating a `JWTValidator`; an empty list now returns an error instead of silently allowing all supported algorithms
- Explicitly reject `alg: "none"` in the `Validate` keyfunc callback using a case-insensitive check, before any other algorithm validation, to prevent algorithm confusion attacks
- Updated `buildAllowedAlgorithms` to remove the fallback that allowed all algorithms when the input was empty
- Updated all tests to provide explicit `AllowedAlgorithms` and added a new test case verifying the empty-config error

## Test plan

- [x] All existing JWT tests pass with updated configs
- [x] New test `TestNewJWTValidator/empty_allowed_algorithms_returns_error` verifies the guard
- [x] `TestBuildAllowedAlgorithms/empty_list_returns_empty_set` confirms no fallback

Resolves #300