### PR TITLE
Validate user-supplied regex patterns for length limits

### DIFF
--- a/internal/agent/router/matcher.go
+++ b/internal/agent/router/matcher.go
@@ -17,6 +17,7 @@ limitations under the License.
 package router
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -58,6 +59,17 @@ func (m *RegexMatcher) Match(path string) bool {
 	return m.Pattern.MatchString(path)
 }
 
+// maxRegexLength is the maximum allowed length for user-supplied regex patterns.
+const maxRegexLength = 500
+
+// validateRegexPattern checks a regex pattern for dangerous constructs.
+func validateRegexPattern(pattern string) error {
+	if len(pattern) > maxRegexLength {
+		return fmt.Errorf("regex pattern exceeds maximum length of %d characters", maxRegexLength)
+	}
+	return nil
+}
+
 // createPathMatcher creates a path matcher from a route rule
 func createPathMatcher(rule *pb.RouteRule) PathMatcher {
 	if len(rule.Matches) == 0 {
@@ -76,6 +88,9 @@ func createPathMatcher(rule *pb.RouteRule) PathMatcher {
 	case pb.PathMatchType_PATH_PREFIX:
 		return &PrefixMatcher{Prefix: match.Path.Value}
 	case pb.PathMatchType_REGULAR_EXPRESSION:
+		if err := validateRegexPattern(match.Path.Value); err != nil {
+			return nil
+		}
 		if regex, err := regexp.Compile(match.Path.Value); err == nil {
 			return &RegexMatcher{Pattern: regex}
 		}

--- a/internal/agent/router/route_entry.go
+++ b/internal/agent/router/route_entry.go
@@ -57,6 +57,9 @@ func compileHeaderRegexes(rule *pb.RouteRule) map[int]*regexp.Regexp {
 	for matchIdx, match := range rule.Matches {
 		for headerIdx, header := range match.Headers {
 			if header.Type == pb.HeaderMatchType_HEADER_REGULAR_EXPRESSION {
+				if err := validateRegexPattern(header.Value); err != nil {
+					continue
+				}
 				if regex, err := regexp.Compile(header.Value); err == nil {
 					// Store with a unique key combining match and header index
 					key := matchIdx*1000 + headerIdx

--- a/internal/agent/router/router.go
+++ b/internal/agent/router/router.go
@@ -682,6 +682,10 @@ func (r *Router) matchHeader(match *pb.HeaderMatch, headerIdx, matchIdx int, val
 		// Fallback: compile on the fly (shouldn't happen if caching is working)
 		// Log this as it indicates a problem with caching
 		r.logger.Warn("Regex not cached, compiling on-the-fly", zap.String("pattern", match.Value))
+		if err := validateRegexPattern(match.Value); err != nil {
+			r.logger.Warn("Regex pattern validation failed", zap.String("pattern", match.Value), zap.Error(err))
+			return false
+		}
 		if regex, err := regexp.Compile(match.Value); err == nil {
 			return regex.MatchString(value)
 		}


### PR DESCRIPTION
## Summary
- Add `validateRegexPattern()` function that enforces a 500-character maximum length on user-supplied regex patterns
- Apply validation before every `regexp.Compile` call on user input in `matcher.go`, `route_entry.go`, and `router.go`
- Prevents excessive resource usage from overly complex patterns (defensive measure since Go's RE2 engine is immune to catastrophic backtracking)

## Test plan
- [x] Existing router package tests pass
- [x] Code compiles and formats cleanly with `gofmt -s`

Resolves #302