### PR TITLE
Fix WebSocket security: reject upgrades with no allowed origins, add message size limit

### DIFF
--- a/internal/agent/router/constants.go
+++ b/internal/agent/router/constants.go
@@ -35,4 +35,9 @@ const (
 	// This prevents memory exhaustion attacks from extremely large request bodies.
 	// Can be overridden per-gateway via policy configuration in the future.
 	DefaultMaxRequestBodySize = 10 * 1024 * 1024 // 10MB
+
+	// MaxWebSocketMessageSize is the maximum allowed size for a single WebSocket message (10MB)
+	// This prevents memory exhaustion from oversized messages sent by clients or backends.
+	// Messages exceeding this limit will cause the connection to be closed with an error.
+	MaxWebSocketMessageSize = 10 * 1024 * 1024 // 10MB
 )

--- a/internal/agent/router/websocket.go
+++ b/internal/agent/router/websocket.go
@@ -41,7 +41,7 @@ func NewWebSocketProxy(logger *zap.Logger) *WebSocketProxy {
 }
 
 // NewWebSocketProxyWithOrigins creates a new WebSocket proxy with allowed origins
-// If allowedOrigins is nil or empty, all origins are allowed (insecure - for development only)
+// If allowedOrigins is nil or empty, all origins are rejected (fail secure)
 // Supports wildcard patterns like "*.example.com"
 func NewWebSocketProxyWithOrigins(logger *zap.Logger, allowedOrigins []string) *WebSocketProxy {
 	proxy := &WebSocketProxy{
@@ -62,12 +62,12 @@ func NewWebSocketProxyWithOrigins(logger *zap.Logger, allowedOrigins []string) *
 func (p *WebSocketProxy) checkOrigin(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 
-	// If no allowed origins configured, allow all (insecure - log warning)
+	// If no allowed origins configured, reject all (fail secure)
 	if len(p.allowedOrigins) == 0 {
-		p.logger.Warn("WebSocket origin validation disabled - allowing all origins",
+		p.logger.Warn("WebSocket upgrade rejected - no allowed origins configured, configure allowedOrigins to permit upgrades",
 			zap.String("origin", origin),
 			zap.String("remote_addr", r.RemoteAddr))
-		return true
+		return false
 	}
 
 	// If no Origin header, reject (WebSocket spec requires Origin)
@@ -159,6 +159,10 @@ func (p *WebSocketProxy) ProxyWebSocket(w http.ResponseWriter, r *http.Request, 
 		return fmt.Errorf("failed to connect to backend: %w", err)
 	}
 	defer func() { _ = backendConn.Close() }()
+
+	// Set read limits to prevent memory exhaustion from oversized messages
+	clientConn.SetReadLimit(MaxWebSocketMessageSize)
+	backendConn.SetReadLimit(MaxWebSocketMessageSize)
 
 	p.logger.Info("WebSocket connection established",
 		zap.String("client", r.RemoteAddr),


### PR DESCRIPTION
## Summary
- Default to rejecting WebSocket upgrades when no allowed origins are configured (fail secure instead of fail open)
- Add 10MB `SetReadLimit` on both client and backend WebSocket connections to prevent memory exhaustion from oversized messages
- Add `MaxWebSocketMessageSize` constant in `constants.go`

## Test plan
- [ ] Verify WebSocket upgrades are rejected when `allowedOrigins` is empty (log warning confirms rejection)
- [ ] Verify WebSocket upgrades succeed when valid origins are configured
- [ ] Verify connections are closed when a message exceeds 10MB
- [ ] Run `make test` to confirm no regressions

Resolves #305