### PR TITLE
[Fix] gRPC: add message size limits to agent and novactl clients

### DIFF
--- a/cmd/novactl/pkg/grpc/client.go
+++ b/cmd/novactl/pkg/grpc/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/piwi3910/novaedge/internal/pkg/grpclimits"
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -35,9 +36,9 @@ func NewAgentClient(ctx context.Context, clientset kubernetes.Interface, namespa
 	agentAddress := fmt.Sprintf("%s:9090", pod.Status.PodIP)
 
 	// Create gRPC connection using lazy connect (grpc.NewClient)
-	conn, err := grpc.NewClient(agentAddress,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	opts := grpclimits.ClientOptions()
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(agentAddress, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to agent at %s: %w", agentAddress, err)
 	}

--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/piwi3910/novaedge/internal/agent/server"
 	"github.com/piwi3910/novaedge/internal/agent/vip"
 	"github.com/piwi3910/novaedge/internal/observability"
+	"github.com/piwi3910/novaedge/internal/pkg/grpclimits"
 	"github.com/piwi3910/novaedge/internal/pkg/tlsutil"
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
@@ -703,7 +704,7 @@ func initLogger(level string) (*zap.Logger, zap.AtomicLevel) {
 // createGRPCConnection creates a gRPC client connection to the controller.
 // If TLS cert/key/CA are provided, it uses mTLS; otherwise insecure.
 func createGRPCConnection(addr, certFile, keyFile, caFile string) (*grpc.ClientConn, error) {
-	var opts []grpc.DialOption
+	opts := grpclimits.ClientOptions()
 
 	if certFile != "" && keyFile != "" && caFile != "" {
 		creds, err := tlsutil.LoadClientTLSCredentials(certFile, keyFile, caFile, "")


### PR DESCRIPTION
## Summary

- Add `grpclimits.ClientOptions()` to the agent's `createGRPCConnection()` function in `cmd/novaedge-agent/main.go`, applying 16 MiB message size limits and keepalive parameters to the agent-to-controller gRPC connection
- Add `grpclimits.ClientOptions()` to the novactl CLI client in `cmd/novactl/pkg/grpc/client.go`, applying the same limits to CLI-to-agent connections
- The controller server and internal agent clients (config watcher, failover, federation) already used `grpclimits` — these two clients were the remaining gaps

## Test plan

- [x] Both `cmd/novaedge-agent` and `cmd/novactl` compile successfully
- [x] `gofmt -s` passes on modified files
- [ ] Verify agent connects to controller and receives config snapshots normally
- [ ] Verify novactl CLI commands work against running agents

Resolves #308