### PR TITLE
[Fix] Security hardening: constant-time auth, header sanitization, session validation

### DIFF
--- a/internal/agent/mesh/authz.go
+++ b/internal/agent/mesh/authz.go
@@ -111,8 +111,14 @@ func (a *Authorizer) Authorize(source SourceIdentity, destService, method, reque
 	servicePolicies, exists := a.policies[destService]
 	a.mu.RUnlock()
 
-	// No policies for this service — default allow
+	// No policies for this service — default allow.
+	// NOTE: Changing to default-deny would be a breaking change and should
+	// be a separate configurable option in a future release.
 	if !exists || len(servicePolicies) == 0 {
+		a.logger.Debug("mesh authorization default-allow: no policies defined for service",
+			zap.String("source", source.SpiffeID),
+			zap.String("dest", destService),
+		)
 		return true
 	}
 

--- a/internal/agent/policy/basicauth.go
+++ b/internal/agent/policy/basicauth.go
@@ -123,6 +123,9 @@ func (v *BasicAuthValidator) Validate(username, password string) bool {
 	v.mu.RUnlock()
 
 	if !exists {
+		// Constant-time: always perform a bcrypt comparison to prevent
+		// timing-based username enumeration attacks.
+		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$0000000000000000000000uVVuhVPJx6oeQxTAIoLqnGq7Ghfkhaq"), []byte(password))
 		return false
 	}
 

--- a/internal/agent/policy/oidc.go
+++ b/internal/agent/policy/oidc.go
@@ -21,7 +21,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -99,10 +98,12 @@ func NewOIDCHandler(ctx context.Context, config *pb.OIDCConfig, logger *zap.Logg
 	if len(sessionKey) == 0 {
 		return nil, fmt.Errorf("session secret is required (32 bytes)")
 	}
-	if len(sessionKey) != 32 {
-		// Hash to 32 bytes if not exact length
-		h := sha256.Sum256(sessionKey)
-		sessionKey = h[:]
+	if len(sessionKey) < 32 {
+		return nil, fmt.Errorf("session secret must be at least 32 bytes of random data, got %d", len(sessionKey))
+	}
+	if len(sessionKey) > 32 {
+		// Truncate to 32 bytes for AES-256
+		sessionKey = sessionKey[:32]
 	}
 
 	oauth2Config := oauth2.Config{

--- a/internal/agent/router/filter.go
+++ b/internal/agent/router/filter.go
@@ -18,6 +18,7 @@ package router
 
 import (
 	"net/http"
+	"strings"
 
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
@@ -25,6 +26,11 @@ import (
 // Filter represents a request/response filter
 type Filter interface {
 	Apply(w http.ResponseWriter, r *http.Request) (*http.Request, bool)
+}
+
+// sanitizeHeaderValue removes CR/LF characters to prevent header injection (CRLF injection).
+func sanitizeHeaderValue(value string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(value)
 }
 
 // HeaderModifierFilter modifies request headers
@@ -41,7 +47,7 @@ func NewHeaderModifierFilter(filter *pb.RouteFilter) *HeaderModifierFilter {
 func (f *HeaderModifierFilter) Apply(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
 	// Add headers
 	for _, header := range f.filter.AddHeaders {
-		r.Header.Add(header.Name, header.Value)
+		r.Header.Add(header.Name, sanitizeHeaderValue(header.Value))
 	}
 
 	// Remove headers


### PR DESCRIPTION
## Summary

- Add constant-time bcrypt comparison for non-existent usernames in basic auth to prevent timing-based username enumeration attacks
- Sanitize header values in route filters by stripping CR/LF characters to prevent CRLF header injection
- Require minimum 32-byte OIDC session secret instead of silently hashing shorter values, enforcing proper key material
- Add debug logging when mesh authorization defaults to allow due to no policies being defined

## Test plan

- [ ] Verify basic auth rejects invalid usernames with consistent timing regardless of username existence
- [ ] Verify header filter strips `\r` and `\n` from added header values
- [ ] Verify OIDC handler rejects session secrets shorter than 32 bytes with a clear error
- [ ] Verify OIDC handler truncates session secrets longer than 32 bytes
- [ ] Verify mesh authorizer logs debug message when no policies exist for a service
- [ ] Run `go build ./...` — passes
- [ ] Run `gofmt` — no formatting changes

Resolves #309