### PR TITLE
LB: atomic endpoint snapshots to eliminate Select() lock contention

### DIFF
--- a/internal/agent/lb/ewma.go
+++ b/internal/agent/lb/ewma.go
@@ -25,19 +25,23 @@ import (
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
+// ewmaSnapshot holds an immutable point-in-time view of the data that
+// Select() needs. It is stored in an atomic.Value so that Select() can read
+// it without acquiring any lock.
+type ewmaSnapshot struct {
+	healthy        []*pb.Endpoint
+	endpointKeys   map[*pb.Endpoint]string
+	scores         map[string]*int64
+	activeRequests map[string]*int64
+}
+
 // EWMA implements Exponentially Weighted Moving Average load balancing
 // Selects endpoints based on weighted average response times
 type EWMA struct {
-	mu               sync.RWMutex
-	endpoints        []*pb.Endpoint
-	healthyEndpoints []*pb.Endpoint          // cached healthy list
-	endpointKeys     map[*pb.Endpoint]string // cached keys
-
-	// EWMA scores per endpoint (lower is better)
-	scores map[string]*int64 // Stored as nanoseconds * 1000 for precision
-
-	// Active requests per endpoint
-	activeRequests map[string]*int64
+	mu        sync.Mutex // protects writes in UpdateEndpoints only
+	endpoints []*pb.Endpoint
+	// snap holds a *ewmaSnapshot; read lock-free via atomic.Value.
+	snap atomic.Value
 
 	// Decay factor for EWMA (0.0 to 1.0, typically 0.9)
 	// Higher values give more weight to historical data
@@ -69,28 +73,54 @@ func NewEWMA(endpoints []*pb.Endpoint) *EWMA {
 	}
 
 	e := &EWMA{
-		endpoints:      endpoints,
-		scores:         scores,
-		activeRequests: activeRequests,
-		decay:          0.9, // 90% weight to historical data
+		endpoints: endpoints,
+		decay:     0.9, // 90% weight to historical data
 	}
-	e.buildKeyCache()
-	e.rebuildHealthy()
+	e.storeSnapshot(endpoints, scores, activeRequests)
 	return e
 }
 
-// Select chooses an endpoint with the lowest EWMA score
-func (e *EWMA) Select() *pb.Endpoint {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
+// storeSnapshot builds and atomically publishes a new snapshot.
+func (e *EWMA) storeSnapshot(endpoints []*pb.Endpoint, scores map[string]*int64, activeRequests map[string]*int64) {
+	healthy := make([]*pb.Endpoint, 0, len(endpoints))
+	keys := make(map[*pb.Endpoint]string, len(endpoints))
+	for _, ep := range endpoints {
+		keys[ep] = endpointKey(ep)
+		if ep.Ready {
+			healthy = append(healthy, ep)
+		}
+	}
+	e.snap.Store(&ewmaSnapshot{
+		healthy:        healthy,
+		endpointKeys:   keys,
+		scores:         scores,
+		activeRequests: activeRequests,
+	})
+}
 
-	healthy := e.getHealthyEndpoints()
-	if len(healthy) == 0 {
+// loadSnapshot returns the current snapshot, or nil if none has been stored.
+func (e *EWMA) loadSnapshot() *ewmaSnapshot {
+	v := e.snap.Load()
+	if v == nil {
+		return nil
+	}
+	s, ok := v.(*ewmaSnapshot)
+	if !ok {
+		return nil
+	}
+	return s
+}
+
+// Select chooses an endpoint with the lowest EWMA score.
+// It reads from an atomic snapshot and never acquires a lock.
+func (e *EWMA) Select() *pb.Endpoint {
+	s := e.loadSnapshot()
+	if s == nil || len(s.healthy) == 0 {
 		return nil
 	}
 
-	if len(healthy) == 1 {
-		return healthy[0]
+	if len(s.healthy) == 1 {
+		return s.healthy[0]
 	}
 
 	// Select endpoint with lowest weighted score
@@ -98,10 +128,18 @@ func (e *EWMA) Select() *pb.Endpoint {
 	var bestEndpoint *pb.Endpoint
 	bestScore := int64(math.MaxInt64)
 
-	for _, ep := range healthy {
-		key := e.cachedKey(ep)
-		ewmaScore := atomic.LoadInt64(e.scores[key])
-		activeCount := atomic.LoadInt64(e.activeRequests[key])
+	for _, ep := range s.healthy {
+		key := cachedKeyFromSnapshot(s.endpointKeys, ep)
+		scorePtr, ok := s.scores[key]
+		if !ok {
+			continue
+		}
+		ewmaScore := atomic.LoadInt64(scorePtr)
+		reqPtr, ok := s.activeRequests[key]
+		if !ok {
+			continue
+		}
+		activeCount := atomic.LoadInt64(reqPtr)
 
 		// Penalize endpoints with many active requests
 		weightedScore := ewmaScore * (1 + activeCount)
@@ -120,6 +158,14 @@ func (e *EWMA) UpdateEndpoints(endpoints []*pb.Endpoint) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	oldSnap := e.loadSnapshot()
+	var oldScores map[string]*int64
+	var oldActiveRequests map[string]*int64
+	if oldSnap != nil {
+		oldScores = oldSnap.scores
+		oldActiveRequests = oldSnap.activeRequests
+	}
+
 	e.endpoints = endpoints
 
 	// Update maps for new endpoints
@@ -130,16 +176,27 @@ func (e *EWMA) UpdateEndpoints(endpoints []*pb.Endpoint) {
 		if ep.Ready {
 			key := endpointKey(ep)
 
-			// Preserve existing scores and counters
-			if existingScore, ok := e.scores[key]; ok {
-				newScores[key] = existingScore
+			// Preserve existing scores
+			if oldScores != nil {
+				if existingScore, ok := oldScores[key]; ok {
+					newScores[key] = existingScore
+				} else {
+					score := int64(initialScore * scorePrecision)
+					newScores[key] = &score
+				}
 			} else {
 				score := int64(initialScore * scorePrecision)
 				newScores[key] = &score
 			}
 
-			if existingCount, ok := e.activeRequests[key]; ok {
-				newActiveRequests[key] = existingCount
+			// Preserve existing counters
+			if oldActiveRequests != nil {
+				if existingCount, ok := oldActiveRequests[key]; ok {
+					newActiveRequests[key] = existingCount
+				} else {
+					var count int64
+					newActiveRequests[key] = &count
+				}
 			} else {
 				var count int64
 				newActiveRequests[key] = &count
@@ -147,10 +204,7 @@ func (e *EWMA) UpdateEndpoints(endpoints []*pb.Endpoint) {
 		}
 	}
 
-	e.scores = newScores
-	e.activeRequests = newActiveRequests
-	e.buildKeyCache()
-	e.rebuildHealthy()
+	e.storeSnapshot(endpoints, newScores, newActiveRequests)
 }
 
 // RecordLatency updates the EWMA score for an endpoint based on observed latency
@@ -159,12 +213,13 @@ func (e *EWMA) RecordLatency(endpoint *pb.Endpoint, latency time.Duration) {
 		return
 	}
 
-	e.mu.RLock()
-	key := e.cachedKey(endpoint)
-	scorePtr := e.scores[key]
-	e.mu.RUnlock()
-
-	if scorePtr == nil {
+	s := e.loadSnapshot()
+	if s == nil {
+		return
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	scorePtr, ok := s.scores[key]
+	if !ok {
 		return
 	}
 
@@ -187,11 +242,12 @@ func (e *EWMA) IncrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	e.mu.RLock()
-	key := e.cachedKey(endpoint)
-	counter := e.activeRequests[key]
-	e.mu.RUnlock()
-	if counter != nil {
+	s := e.loadSnapshot()
+	if s == nil {
+		return
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if counter, ok := s.activeRequests[key]; ok {
 		atomic.AddInt64(counter, 1)
 	}
 }
@@ -201,11 +257,12 @@ func (e *EWMA) DecrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	e.mu.RLock()
-	key := e.cachedKey(endpoint)
-	counter := e.activeRequests[key]
-	e.mu.RUnlock()
-	if counter != nil {
+	s := e.loadSnapshot()
+	if s == nil {
+		return
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if counter, ok := s.activeRequests[key]; ok {
 		atomic.AddInt64(counter, -1)
 	}
 }
@@ -215,47 +272,14 @@ func (e *EWMA) GetScore(endpoint *pb.Endpoint) float64 {
 	if endpoint == nil {
 		return 0
 	}
-	e.mu.RLock()
-	key := e.cachedKey(endpoint)
-	scorePtr := e.scores[key]
-	e.mu.RUnlock()
-	if scorePtr != nil {
+	s := e.loadSnapshot()
+	if s == nil {
+		return 0
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if scorePtr, ok := s.scores[key]; ok {
 		score := atomic.LoadInt64(scorePtr)
 		return float64(score) / scorePrecision / 1000000 // Convert to milliseconds
 	}
 	return 0
-}
-
-// rebuildHealthy filters and caches the list of healthy endpoints.
-// Must be called with e.mu held (write lock).
-func (e *EWMA) rebuildHealthy() {
-	healthy := make([]*pb.Endpoint, 0, len(e.endpoints))
-	for _, ep := range e.endpoints {
-		if ep.Ready {
-			healthy = append(healthy, ep)
-		}
-	}
-	e.healthyEndpoints = healthy
-}
-
-func (e *EWMA) getHealthyEndpoints() []*pb.Endpoint {
-	return e.healthyEndpoints
-}
-
-// buildKeyCache pre-computes endpoint keys for all endpoints.
-// Must be called with e.mu held (write lock).
-func (e *EWMA) buildKeyCache() {
-	e.endpointKeys = make(map[*pb.Endpoint]string, len(e.endpoints))
-	for _, ep := range e.endpoints {
-		e.endpointKeys[ep] = endpointKey(ep)
-	}
-}
-
-// cachedKey returns the cached key for an endpoint, falling back to computing it
-// if the pointer is not in the cache.
-func (e *EWMA) cachedKey(ep *pb.Endpoint) string {
-	if key, ok := e.endpointKeys[ep]; ok {
-		return key
-	}
-	return endpointKey(ep)
 }

--- a/internal/agent/lb/ewma_test.go
+++ b/internal/agent/lb/ewma_test.go
@@ -46,12 +46,12 @@ func TestNewEWMA(t *testing.T) {
 		t.Errorf("Expected 2 endpoints, got %d", len(ewma.endpoints))
 	}
 
-	if len(ewma.scores) != 2 {
-		t.Errorf("Expected 2 scores, got %d", len(ewma.scores))
+	if len(ewma.loadSnapshot().scores) != 2 {
+		t.Errorf("Expected 2 scores, got %d", len(ewma.loadSnapshot().scores))
 	}
 
-	if len(ewma.activeRequests) != 2 {
-		t.Errorf("Expected 2 active request counters, got %d", len(ewma.activeRequests))
+	if len(ewma.loadSnapshot().activeRequests) != 2 {
+		t.Errorf("Expected 2 active request counters, got %d", len(ewma.loadSnapshot().activeRequests))
 	}
 }
 
@@ -520,10 +520,8 @@ func TestEWMAAtomicOperations(t *testing.T) {
 		wg.Wait()
 
 		// Check that final count is correct
-		key := endpointKey(endpoints[0])
-		ewma.mu.RLock()
-		counter := atomic.LoadInt64(ewma.activeRequests[key])
-		ewma.mu.RUnlock()
+		s := ewma.loadSnapshot()
+		counter := atomic.LoadInt64(s.activeRequests[endpointKey(endpoints[0])])
 
 		if counter != int64(numGoroutines) {
 			t.Errorf("Expected active count %d, got %d", numGoroutines, counter)

--- a/internal/agent/lb/leastconn.go
+++ b/internal/agent/lb/leastconn.go
@@ -26,17 +26,24 @@ import (
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
+// leastConnSnapshot holds an immutable point-in-time view of the data that
+// Select() needs. It is stored in an atomic.Value so that Select() can read
+// it without acquiring any lock.
+type leastConnSnapshot struct {
+	healthy      []*pb.Endpoint
+	endpointKeys map[*pb.Endpoint]string
+	activeConns  map[string]*int64
+}
+
 // LeastConn implements least-connections load balancing.
 // It tracks the number of active connections per endpoint and selects the
 // endpoint with the fewest active connections. When multiple endpoints have
 // the same number of connections, one is chosen at random to avoid bias.
 type LeastConn struct {
-	mu               sync.RWMutex
-	endpoints        []*pb.Endpoint
-	healthyEndpoints []*pb.Endpoint          // cached healthy list
-	endpointKeys     map[*pb.Endpoint]string // cached keys
-	// activeConns tracks active connection count per endpoint key ("address:port")
-	activeConns map[string]*int64
+	mu        sync.Mutex // protects writes in UpdateEndpoints only
+	endpoints []*pb.Endpoint
+	// snap holds a *leastConnSnapshot; read lock-free via atomic.Value.
+	snap atomic.Value
 }
 
 // NewLeastConn creates a new least-connections load balancer.
@@ -51,63 +58,84 @@ func NewLeastConn(endpoints []*pb.Endpoint) *LeastConn {
 	}
 
 	lc := &LeastConn{
-		endpoints:   endpoints,
-		activeConns: activeConns,
+		endpoints: endpoints,
 	}
-	lc.buildKeyCache()
-	lc.rebuildHealthy()
+	lc.storeSnapshot(endpoints, activeConns)
 	return lc
 }
 
-// Select chooses the endpoint with the fewest active connections.
-// If multiple endpoints are tied, one is chosen randomly among those with the
-// minimum connection count.
-func (lc *LeastConn) Select() *pb.Endpoint {
-	lc.mu.RLock()
-	defer lc.mu.RUnlock()
+// storeSnapshot builds and atomically publishes a new snapshot.
+func (lc *LeastConn) storeSnapshot(endpoints []*pb.Endpoint, activeConns map[string]*int64) {
+	healthy := make([]*pb.Endpoint, 0, len(endpoints))
+	keys := make(map[*pb.Endpoint]string, len(endpoints))
+	for _, ep := range endpoints {
+		keys[ep] = endpointKey(ep)
+		if ep.Ready {
+			healthy = append(healthy, ep)
+		}
+	}
+	lc.snap.Store(&leastConnSnapshot{
+		healthy:      healthy,
+		endpointKeys: keys,
+		activeConns:  activeConns,
+	})
+}
 
-	healthy := lc.getHealthyEndpoints()
-	if len(healthy) == 0 {
+// loadSnapshot returns the current snapshot, or nil if none has been stored.
+func (lc *LeastConn) loadSnapshot() *leastConnSnapshot {
+	v := lc.snap.Load()
+	if v == nil {
+		return nil
+	}
+	s, ok := v.(*leastConnSnapshot)
+	if !ok {
+		return nil
+	}
+	return s
+}
+
+// Select chooses the endpoint with the fewest active connections.
+// It reads from an atomic snapshot and never acquires a lock.
+func (lc *LeastConn) Select() *pb.Endpoint {
+	s := lc.loadSnapshot()
+	if s == nil || len(s.healthy) == 0 {
 		return nil
 	}
 
-	if len(healthy) == 1 {
-		return healthy[0]
+	if len(s.healthy) == 1 {
+		return s.healthy[0]
 	}
 
-	// Find the minimum active connection count
+	// Single-pass: find the endpoint with the minimum active connection count.
+	// On ties, use reservoir sampling (random replacement) to avoid bias.
+	var best *pb.Endpoint
 	minConns := int64(math.MaxInt64)
-	for _, ep := range healthy {
-		key := lc.cachedKey(ep)
-		if counter, ok := lc.activeConns[key]; ok {
-			count := atomic.LoadInt64(counter)
-			if count < minConns {
-				minConns = count
+	tieCount := 0
+
+	for _, ep := range s.healthy {
+		key := cachedKeyFromSnapshot(s.endpointKeys, ep)
+		counter, ok := s.activeConns[key]
+		if !ok {
+			continue
+		}
+		count := atomic.LoadInt64(counter)
+		if count < minConns {
+			minConns = count
+			best = ep
+			tieCount = 1
+		} else if count == minConns {
+			tieCount++
+			// Reservoir sampling: replace with probability 1/tieCount
+			if cryptoRandIntn(tieCount) == 0 {
+				best = ep
 			}
 		}
 	}
 
-	// Collect all endpoints with the minimum count
-	candidates := make([]*pb.Endpoint, 0, len(healthy))
-	for _, ep := range healthy {
-		key := lc.cachedKey(ep)
-		if counter, ok := lc.activeConns[key]; ok {
-			if atomic.LoadInt64(counter) == minConns {
-				candidates = append(candidates, ep)
-			}
-		}
+	if best != nil {
+		return best
 	}
-
-	// Fallback if atomic counters changed between two passes (concurrent access)
-	if len(candidates) == 0 {
-		return healthy[cryptoRandIntn(len(healthy))]
-	}
-
-	// Random selection among tied candidates to prevent bias
-	if len(candidates) == 1 {
-		return candidates[0]
-	}
-	return candidates[cryptoRandIntn(len(candidates))]
+	return s.healthy[cryptoRandIntn(len(s.healthy))]
 }
 
 // UpdateEndpoints updates the endpoint list, preserving active connection
@@ -116,23 +144,29 @@ func (lc *LeastConn) UpdateEndpoints(endpoints []*pb.Endpoint) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 
+	oldSnap := lc.loadSnapshot()
+	var oldActiveConns map[string]*int64
+	if oldSnap != nil {
+		oldActiveConns = oldSnap.activeConns
+	}
+
 	lc.endpoints = endpoints
 
 	newActiveConns := make(map[string]*int64)
 	for _, ep := range endpoints {
 		if ep.Ready {
 			key := endpointKey(ep)
-			if existing, ok := lc.activeConns[key]; ok {
-				newActiveConns[key] = existing
-			} else {
-				var count int64
-				newActiveConns[key] = &count
+			if oldActiveConns != nil {
+				if existing, ok := oldActiveConns[key]; ok {
+					newActiveConns[key] = existing
+					continue
+				}
 			}
+			var count int64
+			newActiveConns[key] = &count
 		}
 	}
-	lc.activeConns = newActiveConns
-	lc.buildKeyCache()
-	lc.rebuildHealthy()
+	lc.storeSnapshot(endpoints, newActiveConns)
 }
 
 // IncrementActive increments the active connection count for an endpoint.
@@ -141,11 +175,12 @@ func (lc *LeastConn) IncrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	lc.mu.RLock()
-	key := lc.cachedKey(endpoint)
-	counter := lc.activeConns[key]
-	lc.mu.RUnlock()
-	if counter != nil {
+	s := lc.loadSnapshot()
+	if s == nil {
+		return
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if counter, ok := s.activeConns[key]; ok {
 		atomic.AddInt64(counter, 1)
 	}
 }
@@ -156,11 +191,12 @@ func (lc *LeastConn) DecrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	lc.mu.RLock()
-	key := lc.cachedKey(endpoint)
-	counter := lc.activeConns[key]
-	lc.mu.RUnlock()
-	if counter != nil {
+	s := lc.loadSnapshot()
+	if s == nil {
+		return
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if counter, ok := s.activeConns[key]; ok {
 		atomic.AddInt64(counter, -1)
 	}
 }
@@ -170,45 +206,21 @@ func (lc *LeastConn) GetActiveCount(endpoint *pb.Endpoint) int64 {
 	if endpoint == nil {
 		return 0
 	}
-	lc.mu.RLock()
-	key := lc.cachedKey(endpoint)
-	counter := lc.activeConns[key]
-	lc.mu.RUnlock()
-	if counter != nil {
+	s := lc.loadSnapshot()
+	if s == nil {
+		return 0
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if counter, ok := s.activeConns[key]; ok {
 		return atomic.LoadInt64(counter)
 	}
 	return 0
 }
 
-// rebuildHealthy filters and caches the list of healthy endpoints.
-// Must be called with lc.mu held (write lock).
-func (lc *LeastConn) rebuildHealthy() {
-	healthy := make([]*pb.Endpoint, 0, len(lc.endpoints))
-	for _, ep := range lc.endpoints {
-		if ep.Ready {
-			healthy = append(healthy, ep)
-		}
-	}
-	lc.healthyEndpoints = healthy
-}
-
-func (lc *LeastConn) getHealthyEndpoints() []*pb.Endpoint {
-	return lc.healthyEndpoints
-}
-
-// buildKeyCache pre-computes endpoint keys for all endpoints.
-// Must be called with lc.mu held (write lock).
-func (lc *LeastConn) buildKeyCache() {
-	lc.endpointKeys = make(map[*pb.Endpoint]string, len(lc.endpoints))
-	for _, ep := range lc.endpoints {
-		lc.endpointKeys[ep] = endpointKey(ep)
-	}
-}
-
-// cachedKey returns the cached key for an endpoint, falling back to computing it
-// if the pointer is not in the cache.
-func (lc *LeastConn) cachedKey(ep *pb.Endpoint) string {
-	if key, ok := lc.endpointKeys[ep]; ok {
+// cachedKeyFromSnapshot returns the cached key for an endpoint from the given
+// key map, falling back to computing it if the pointer is not in the cache.
+func cachedKeyFromSnapshot(keys map[*pb.Endpoint]string, ep *pb.Endpoint) string {
+	if key, ok := keys[ep]; ok {
 		return key
 	}
 	return endpointKey(ep)

--- a/internal/agent/lb/p2c.go
+++ b/internal/agent/lb/p2c.go
@@ -25,14 +25,22 @@ import (
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
+// p2cSnapshot holds an immutable point-in-time view of the data that
+// Select() needs. It is stored in an atomic.Value so that Select() can read
+// it without acquiring any lock.
+type p2cSnapshot struct {
+	healthy        []*pb.Endpoint
+	endpointKeys   map[*pb.Endpoint]string
+	activeRequests map[string]*int64
+}
+
 // P2C implements Power of Two Choices load balancing
 // Selects the best of two randomly chosen endpoints based on active requests
 type P2C struct {
-	mu               sync.RWMutex
-	endpoints        []*pb.Endpoint
-	healthyEndpoints []*pb.Endpoint // cached healthy list
-	activeRequests   map[string]*int64
-	endpointKeys     map[*pb.Endpoint]string // cached keys
+	mu        sync.Mutex // protects writes in UpdateEndpoints only
+	endpoints []*pb.Endpoint
+	// snap holds a *p2cSnapshot; read lock-free via atomic.Value.
+	snap atomic.Value
 }
 
 // NewP2C creates a new P2C load balancer
@@ -47,43 +55,71 @@ func NewP2C(endpoints []*pb.Endpoint) *P2C {
 	}
 
 	p := &P2C{
-		endpoints:      endpoints,
-		activeRequests: activeRequests,
+		endpoints: endpoints,
 	}
-	p.buildKeyCache()
-	p.rebuildHealthy()
+	p.storeSnapshot(endpoints, activeRequests)
 	return p
 }
 
-// Select chooses an endpoint using Power of Two Choices
-func (p *P2C) Select() *pb.Endpoint {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+// storeSnapshot builds and atomically publishes a new snapshot.
+func (p *P2C) storeSnapshot(endpoints []*pb.Endpoint, activeRequests map[string]*int64) {
+	healthy := make([]*pb.Endpoint, 0, len(endpoints))
+	keys := make(map[*pb.Endpoint]string, len(endpoints))
+	for _, ep := range endpoints {
+		keys[ep] = endpointKey(ep)
+		if ep.Ready {
+			healthy = append(healthy, ep)
+		}
+	}
+	p.snap.Store(&p2cSnapshot{
+		healthy:        healthy,
+		endpointKeys:   keys,
+		activeRequests: activeRequests,
+	})
+}
 
-	healthy := p.getHealthyEndpoints()
-	if len(healthy) == 0 {
+// loadSnapshot returns the current snapshot, or nil if none has been stored.
+func (p *P2C) loadSnapshot() *p2cSnapshot {
+	v := p.snap.Load()
+	if v == nil {
+		return nil
+	}
+	s, ok := v.(*p2cSnapshot)
+	if !ok {
+		return nil
+	}
+	return s
+}
+
+// Select chooses an endpoint using Power of Two Choices.
+// It reads from an atomic snapshot and never acquires a lock.
+func (p *P2C) Select() *pb.Endpoint {
+	s := p.loadSnapshot()
+	if s == nil || len(s.healthy) == 0 {
 		return nil
 	}
 
-	if len(healthy) == 1 {
-		return healthy[0]
+	if len(s.healthy) == 1 {
+		return s.healthy[0]
 	}
 
 	// Pick two random endpoints
 	// Global rand functions in Go 1.22+ are auto-seeded with crypto/rand and goroutine-safe.
 	// math/rand/v2 is intentional here: cryptographic randomness is not needed for load balancing.
-	idx1 := rand.IntN(len(healthy)) //nolint:gosec // G404: math/rand is acceptable for load balancer selection
-	idx2 := rand.IntN(len(healthy)) //nolint:gosec // G404: math/rand is acceptable for load balancer selection
-	for idx1 == idx2 && len(healthy) > 1 {
-		idx2 = rand.IntN(len(healthy)) //nolint:gosec // G404: math/rand is acceptable for load balancer selection
+	idx1 := rand.IntN(len(s.healthy)) //nolint:gosec // G404: math/rand is acceptable for load balancer selection
+	idx2 := rand.IntN(len(s.healthy)) //nolint:gosec // G404: math/rand is acceptable for load balancer selection
+	for idx1 == idx2 && len(s.healthy) > 1 {
+		idx2 = rand.IntN(len(s.healthy)) //nolint:gosec // G404: math/rand is acceptable for load balancer selection
 	}
 
-	ep1 := healthy[idx1]
-	ep2 := healthy[idx2]
+	ep1 := s.healthy[idx1]
+	ep2 := s.healthy[idx2]
 
 	// Choose the one with fewer active requests
-	count1 := atomic.LoadInt64(p.activeRequests[p.cachedKey(ep1)])
-	count2 := atomic.LoadInt64(p.activeRequests[p.cachedKey(ep2)])
+	key1 := cachedKeyFromSnapshot(s.endpointKeys, ep1)
+	key2 := cachedKeyFromSnapshot(s.endpointKeys, ep2)
+	count1 := atomic.LoadInt64(s.activeRequests[key1])
+	count2 := atomic.LoadInt64(s.activeRequests[key2])
 
 	if count1 <= count2 {
 		return ep1
@@ -96,6 +132,12 @@ func (p *P2C) UpdateEndpoints(endpoints []*pb.Endpoint) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	oldSnap := p.loadSnapshot()
+	var oldActiveRequests map[string]*int64
+	if oldSnap != nil {
+		oldActiveRequests = oldSnap.activeRequests
+	}
+
 	p.endpoints = endpoints
 
 	// Update active requests map
@@ -104,17 +146,17 @@ func (p *P2C) UpdateEndpoints(endpoints []*pb.Endpoint) {
 		if ep.Ready {
 			key := endpointKey(ep)
 			// Preserve existing counters
-			if existing, ok := p.activeRequests[key]; ok {
-				newActiveRequests[key] = existing
-			} else {
-				var count int64
-				newActiveRequests[key] = &count
+			if oldActiveRequests != nil {
+				if existing, ok := oldActiveRequests[key]; ok {
+					newActiveRequests[key] = existing
+					continue
+				}
 			}
+			var count int64
+			newActiveRequests[key] = &count
 		}
 	}
-	p.activeRequests = newActiveRequests
-	p.buildKeyCache()
-	p.rebuildHealthy()
+	p.storeSnapshot(endpoints, newActiveRequests)
 }
 
 // IncrementActive increments the active request count for an endpoint
@@ -122,11 +164,12 @@ func (p *P2C) IncrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	p.mu.RLock()
-	key := p.cachedKey(endpoint)
-	counter := p.activeRequests[key]
-	p.mu.RUnlock()
-	if counter != nil {
+	s := p.loadSnapshot()
+	if s == nil {
+		return
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if counter, ok := s.activeRequests[key]; ok {
 		atomic.AddInt64(counter, 1)
 	}
 }
@@ -136,11 +179,12 @@ func (p *P2C) DecrementActive(endpoint *pb.Endpoint) {
 	if endpoint == nil {
 		return
 	}
-	p.mu.RLock()
-	key := p.cachedKey(endpoint)
-	counter := p.activeRequests[key]
-	p.mu.RUnlock()
-	if counter != nil {
+	s := p.loadSnapshot()
+	if s == nil {
+		return
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if counter, ok := s.activeRequests[key]; ok {
 		atomic.AddInt64(counter, -1)
 	}
 }
@@ -150,48 +194,15 @@ func (p *P2C) GetActiveCount(endpoint *pb.Endpoint) int64 {
 	if endpoint == nil {
 		return 0
 	}
-	p.mu.RLock()
-	key := p.cachedKey(endpoint)
-	counter := p.activeRequests[key]
-	p.mu.RUnlock()
-	if counter != nil {
+	s := p.loadSnapshot()
+	if s == nil {
+		return 0
+	}
+	key := cachedKeyFromSnapshot(s.endpointKeys, endpoint)
+	if counter, ok := s.activeRequests[key]; ok {
 		return atomic.LoadInt64(counter)
 	}
 	return 0
-}
-
-// rebuildHealthy filters and caches the list of healthy endpoints.
-// Must be called with p.mu held (write lock).
-func (p *P2C) rebuildHealthy() {
-	healthy := make([]*pb.Endpoint, 0, len(p.endpoints))
-	for _, ep := range p.endpoints {
-		if ep.Ready {
-			healthy = append(healthy, ep)
-		}
-	}
-	p.healthyEndpoints = healthy
-}
-
-func (p *P2C) getHealthyEndpoints() []*pb.Endpoint {
-	return p.healthyEndpoints
-}
-
-// buildKeyCache pre-computes endpoint keys for all endpoints.
-// Must be called with p.mu held (write lock).
-func (p *P2C) buildKeyCache() {
-	p.endpointKeys = make(map[*pb.Endpoint]string, len(p.endpoints))
-	for _, ep := range p.endpoints {
-		p.endpointKeys[ep] = endpointKey(ep)
-	}
-}
-
-// cachedKey returns the cached key for an endpoint, falling back to computing it
-// if the pointer is not in the cache.
-func (p *P2C) cachedKey(ep *pb.Endpoint) string {
-	if key, ok := p.endpointKeys[ep]; ok {
-		return key
-	}
-	return endpointKey(ep)
 }
 
 func endpointKey(ep *pb.Endpoint) string {

--- a/internal/agent/lb/p2c_test.go
+++ b/internal/agent/lb/p2c_test.go
@@ -18,7 +18,6 @@ package lb
 
 import (
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
@@ -40,8 +39,8 @@ func TestNewP2C(t *testing.T) {
 		t.Errorf("Expected 2 endpoints, got %d", len(p2c.endpoints))
 	}
 
-	if len(p2c.activeRequests) != 2 {
-		t.Errorf("Expected 2 active request counters, got %d", len(p2c.activeRequests))
+	if len(p2c.loadSnapshot().activeRequests) != 2 {
+		t.Errorf("Expected 2 active request counters, got %d", len(p2c.loadSnapshot().activeRequests))
 	}
 
 }
@@ -418,10 +417,7 @@ func TestP2CAtomicCounters(t *testing.T) {
 		wg.Wait()
 
 		// Check that final count is correct
-		key := endpointKey(endpoints[0])
-		p2c.mu.RLock()
-		counter := atomic.LoadInt64(p2c.activeRequests[key])
-		p2c.mu.RUnlock()
+		counter := p2c.GetActiveCount(endpoints[0])
 
 		if counter != int64(numGoroutines) {
 			t.Errorf("Expected active count %d, got %d", numGoroutines, counter)


### PR DESCRIPTION
## Summary
- Replace `sync.RWMutex` lock in `Select()` hot path with `atomic.Value` snapshots for `LeastConn`, `EWMA`, and `P2C` load balancers
- Bundle healthy endpoints, key caches, and counter maps into immutable snapshot structs published atomically by `UpdateEndpoints()`
- Eliminate `candidates` slice allocation in `LeastConn.Select()` using single-pass reservoir sampling

## Test plan
- [x] All existing unit tests pass (`go test ./internal/agent/lb/`)
- [x] Package builds cleanly (`go build ./internal/agent/lb/`)
- [x] `gofmt -s` applied to all modified files
- [ ] Verify concurrent access correctness under load (existing concurrent tests pass)

Resolves #311