### PR TITLE
[Performance] Health check: worker pool and connection reuse

### DIFF
--- a/internal/agent/health/checker.go
+++ b/internal/agent/health/checker.go
@@ -131,6 +131,9 @@ func NewChecker(cluster *pb.Cluster, endpoints []*pb.Endpoint, logger *zap.Logge
 					Timeout:   DefaultHealthCheckDialTimeout,
 					KeepAlive: 30 * time.Second,
 				}).DialContext,
+				MaxIdleConns:        50,
+				MaxIdleConnsPerHost: 2,
+				IdleConnTimeout:     90 * time.Second,
 			},
 		},
 		httpsClient: &http.Client{
@@ -140,6 +143,9 @@ func NewChecker(cluster *pb.Cluster, endpoints []*pb.Endpoint, logger *zap.Logge
 					Timeout:   DefaultHealthCheckDialTimeout,
 					KeepAlive: 30 * time.Second,
 				}).DialContext,
+				MaxIdleConns:        50,
+				MaxIdleConnsPerHost: 2,
+				IdleConnTimeout:     90 * time.Second,
 				TLSClientConfig: &tls.Config{
 					MinVersion:         tls.VersionTLS12,
 					InsecureSkipVerify: true, //nolint:gosec // Health checks use skip-verify for backend probing
@@ -361,25 +367,37 @@ func (hc *Checker) healthCheckLoop(ctx context.Context) {
 	}
 }
 
-// performHealthChecks performs health checks on all endpoints
+// healthCheckWorkers is the maximum number of concurrent goroutines used
+// to perform health checks. This bounds resource usage regardless of
+// how many endpoints are configured.
+const healthCheckWorkers = 10
+
+// performHealthChecks performs health checks on all endpoints using a
+// bounded worker pool to avoid spawning unbounded goroutines.
 func (hc *Checker) performHealthChecks(ctx context.Context) {
 	hc.mu.RLock()
 	endpoints := make([]*pb.Endpoint, len(hc.endpoints))
 	copy(endpoints, hc.endpoints)
 	hc.mu.RUnlock()
 
-	// Use WaitGroup to ensure all health checks complete before returning
-	var wg sync.WaitGroup
+	// Create a job channel and enqueue all endpoints
+	jobs := make(chan *pb.Endpoint, len(endpoints))
 	for _, ep := range endpoints {
-		wg.Add(1)
-		// Perform check in goroutine for concurrency
-		go func(endpoint *pb.Endpoint) {
-			defer wg.Done()
-			hc.checkEndpoint(ctx, endpoint)
-		}(ep)
+		jobs <- ep
 	}
+	close(jobs)
 
-	// Wait for all health checks to complete
+	// Spawn a bounded number of workers
+	var wg sync.WaitGroup
+	for i := 0; i < healthCheckWorkers && i < len(endpoints); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ep := range jobs {
+				hc.checkEndpoint(ctx, ep)
+			}
+		}()
+	}
 	wg.Wait()
 }
 


### PR DESCRIPTION
## Summary
- Replace per-endpoint goroutine spawning with a bounded worker pool (10 workers) in `performHealthChecks()` to cap resource usage regardless of endpoint count
- Add connection pooling settings (`MaxIdleConns`, `MaxIdleConnsPerHost`, `IdleConnTimeout`) to both HTTP and HTTPS health check transports for connection reuse across check intervals

## Test plan
- [x] `go build ./internal/agent/health/` passes
- [x] `go test ./internal/agent/health/` passes
- [ ] Verify health checks still detect unhealthy endpoints in a live cluster
- [ ] Confirm goroutine count stays bounded under high endpoint counts

Resolves #315