### PR TITLE
[Performance] Skip unchanged config snapshot rebuilds

### DIFF
--- a/internal/controller/snapshot/builder.go
+++ b/internal/controller/snapshot/builder.go
@@ -1136,8 +1136,8 @@ func (b *Builder) generateVersion(snapshot *pb.ConfigSnapshot) string {
 	}
 	hash := hex.EncodeToString(h.Sum(nil))
 
-	// Return timestamp + hash prefix for readability
-	return fmt.Sprintf("%d-%s", snapshot.GenerationTime, hash[:16])
+	// Return content hash only for deterministic version comparison
+	return hash[:16]
 }
 
 // buildMeshAuthorizationPolicies converts ProxyPolicy resources of type

--- a/internal/controller/snapshot/builder_test.go
+++ b/internal/controller/snapshot/builder_test.go
@@ -152,14 +152,14 @@ func TestGenerateVersion(t *testing.T) {
 	v2 := builder.generateVersion(snapshot2)
 	v3 := builder.generateVersion(snapshot3)
 
-	// Same content, different timestamps should have different full versions
-	if v1 == v2 {
-		t.Error("Expected different versions for different timestamps")
+	// Same content, different timestamps should produce the same version (content-based)
+	if v1 != v2 {
+		t.Errorf("Expected same version for same content regardless of timestamp, got %q and %q", v1, v2)
 	}
 
-	// Different content should have different hash parts
-	if v1[len("1000-"):] == v3[len("1000-"):] {
-		t.Error("Expected different hash parts for different content")
+	// Different content should produce different versions
+	if v1 == v3 {
+		t.Error("Expected different versions for different content")
 	}
 }
 

--- a/internal/controller/snapshot/server.go
+++ b/internal/controller/snapshot/server.go
@@ -181,6 +181,9 @@ func (s *Server) StreamConfig(req *pb.StreamConfigRequest, stream pb.ConfigServi
 	RecordSnapshotUpdate(req.NodeName, "initial")
 	logger.Info("Sent initial config snapshot", "version", snapshot.Version)
 
+	// Track last sent version to skip unchanged snapshots
+	lastVersion := snapshot.Version
+
 	// Create update channel for this node
 	updateCh := make(chan string, 10)
 	s.cache.Subscribe(req.NodeName, updateCh)
@@ -205,17 +208,20 @@ func (s *Server) StreamConfig(req *pb.StreamConfigRequest, stream pb.ConfigServi
 				continue
 			}
 
-			// Only send if version changed
-			if newSnapshot.Version != snapshot.Version {
-				if err := stream.Send(newSnapshot); err != nil {
-					logger.Error(err, "Failed to send updated snapshot")
-					return status.Errorf(codes.Internal, "failed to send snapshot: %v", err)
-				}
-				snapshot = newSnapshot
-				s.cache.Set(req.NodeName, snapshot)
-				RecordSnapshotUpdate(req.NodeName, "periodic")
-				logger.Info("Sent updated config snapshot", "version", snapshot.Version)
+			// Skip if version hasn't changed since last push
+			if newSnapshot.Version == lastVersion {
+				continue
 			}
+
+			if err := stream.Send(newSnapshot); err != nil {
+				logger.Error(err, "Failed to send updated snapshot")
+				return status.Errorf(codes.Internal, "failed to send snapshot: %v", err)
+			}
+			lastVersion = newSnapshot.Version
+			snapshot = newSnapshot
+			s.cache.Set(req.NodeName, snapshot)
+			RecordSnapshotUpdate(req.NodeName, "periodic")
+			logger.Info("Sent updated config snapshot", "version", snapshot.Version)
 
 		case <-updateCh:
 			// Triggered update - rebuild and send
@@ -231,6 +237,7 @@ func (s *Server) StreamConfig(req *pb.StreamConfigRequest, stream pb.ConfigServi
 				return status.Errorf(codes.Internal, "failed to send snapshot: %v", err)
 			}
 
+			lastVersion = newSnapshot.Version
 			snapshot = newSnapshot
 			s.cache.Set(req.NodeName, snapshot)
 			RecordSnapshotUpdate(req.NodeName, "triggered")


### PR DESCRIPTION
## Summary

- Fixed `generateVersion()` to use content-hash-only versioning instead of including `GenerationTime` timestamp, so identical configs produce identical versions
- Added explicit `lastVersion` tracking in the gRPC stream handler to skip sending unchanged snapshots on periodic tick
- Updated triggered update path to also track `lastVersion` for consistency

## Root Cause

The periodic rebuild (every 30s) always produced a unique version because `GenerationTime` was embedded in the version string. This defeated the existing version comparison check, causing every tick to serialize and send the snapshot even when nothing changed.

## Test plan

- [x] Updated `TestGenerateVersion` to verify same content with different timestamps produces identical versions
- [x] All existing snapshot tests pass (`go test ./internal/controller/snapshot/...`)
- [x] Build verified (`go build ./internal/controller/...`)

Resolves #314