### PR TITLE
[Performance] VIP: reduce lock contention and rate-limit GARPs

### DIFF
--- a/internal/agent/vip/l2.go
+++ b/internal/agent/vip/l2.go
@@ -342,7 +342,7 @@ func (h *L2Handler) sendUnsolicitedNA(ip net.IP) error {
 
 // announcementLoop periodically sends GARP/NDP for active VIPs
 func (h *L2Handler) announcementLoop(ctx context.Context) {
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
 
 	for {
@@ -357,29 +357,54 @@ func (h *L2Handler) announcementLoop(ctx context.Context) {
 	}
 }
 
-// announceActiveVIPs sends GARP/NDP for all active VIPs
-func (h *L2Handler) announceActiveVIPs() {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+// maxGARPPerSecond is the maximum number of GARP/NDP announcements sent per second
+// to avoid flooding the network during periodic announcements.
+const maxGARPPerSecond = 10
 
+// announceActiveVIPs sends GARP/NDP for all active VIPs with rate limiting.
+// VIP state is snapshot under a short read lock, then announcements are sent
+// outside the lock to avoid blocking concurrent operations.
+func (h *L2Handler) announceActiveVIPs() {
+	// Snapshot active VIPs under read lock
+	h.mu.RLock()
 	if len(h.activeVIPs) == 0 {
+		h.mu.RUnlock()
 		return
 	}
 
-	h.logger.Debug("Announcing active VIPs", zap.Int("count", len(h.activeVIPs)))
+	type vipSnapshot struct {
+		name   string
+		ip     net.IP
+		isIPv6 bool
+	}
 
-	for vipName, state := range h.activeVIPs {
-		if state.IsIPv6 {
-			if err := h.sendUnsolicitedNA(state.IP); err != nil {
+	vips := make([]vipSnapshot, 0, len(h.activeVIPs))
+	for name, state := range h.activeVIPs {
+		vips = append(vips, vipSnapshot{name: name, ip: state.IP, isIPv6: state.IsIPv6})
+	}
+	h.mu.RUnlock()
+
+	h.logger.Debug("Announcing active VIPs", zap.Int("count", len(vips)))
+
+	// Rate-limit GARP/NDP sends to avoid network flooding
+	garpInterval := time.Second / time.Duration(maxGARPPerSecond)
+
+	for i, vip := range vips {
+		if i > 0 {
+			time.Sleep(garpInterval)
+		}
+
+		if vip.isIPv6 {
+			if err := h.sendUnsolicitedNA(vip.ip); err != nil {
 				h.logger.Warn("Failed to send unsolicited NA",
-					zap.String("vip", vipName),
+					zap.String("vip", vip.name),
 					zap.Error(err),
 				)
 			}
 		} else {
-			if err := h.sendGARP(state.IP); err != nil {
+			if err := h.sendGARP(vip.ip); err != nil {
 				h.logger.Warn("Failed to send GARP",
-					zap.String("vip", vipName),
+					zap.String("vip", vip.name),
 					zap.Error(err),
 				)
 			}

--- a/internal/agent/vip/manager.go
+++ b/internal/agent/vip/manager.go
@@ -103,11 +103,16 @@ func (m *DefaultManager) Start(ctx context.Context) error {
 	return nil
 }
 
-// ApplyVIPs applies new VIP assignments
-func (m *DefaultManager) ApplyVIPs(ctx context.Context, assignments []*pb.VIPAssignment) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// vipAction describes a VIP operation to perform outside the lock.
+type vipAction struct {
+	release    bool // true = release, false = apply
+	assignment *pb.VIPAssignment
+}
 
+// ApplyVIPs applies new VIP assignments using a read-copy-update pattern:
+// compute the diff under lock, perform network operations without the lock,
+// then update state under a short write lock.
+func (m *DefaultManager) ApplyVIPs(ctx context.Context, assignments []*pb.VIPAssignment) error {
 	m.logger.Info("Applying VIP assignments", zap.Int("count", len(assignments)))
 
 	// Build map of new assignments
@@ -116,24 +121,23 @@ func (m *DefaultManager) ApplyVIPs(ctx context.Context, assignments []*pb.VIPAss
 		newAssignments[assignment.VipName] = assignment
 	}
 
-	// Release VIPs that are no longer assigned
+	// Phase 1: Compute diff under read lock
+	m.mu.RLock()
+	var actions []vipAction
+
+	// Find VIPs to release (no longer assigned)
 	for vipName, oldAssignment := range m.assignments {
 		if _, exists := newAssignments[vipName]; !exists {
 			m.logger.Info("Releasing VIP", zap.String("vip", vipName))
-			if err := m.releaseVIP(ctx, oldAssignment); err != nil {
-				m.logger.Error("Failed to release VIP",
-					zap.String("vip", vipName),
-					zap.Error(err),
-				)
-			}
+			actions = append(actions, vipAction{release: true, assignment: oldAssignment})
 		}
 	}
 
-	// Apply new VIP assignments
+	// Find VIPs to add or update
 	for vipName, assignment := range newAssignments {
 		oldAssignment, exists := m.assignments[vipName]
 
-		// Check if assignment changed
+		// Skip unchanged assignments
 		if exists && assignmentsEqual(oldAssignment, assignment) {
 			continue
 		}
@@ -146,44 +150,50 @@ func (m *DefaultManager) ApplyVIPs(ctx context.Context, assignments []*pb.VIPAss
 		)
 
 		if exists && !configOnlyChange(oldAssignment, assignment) {
-			// Address/mode/active changed — full release and re-apply
+			// Address/mode/active changed -- release old VIP first
 			m.logger.Info("VIP structural change detected, releasing old VIP first",
 				zap.String("vip", vipName),
 			)
-			if err := m.releaseVIP(ctx, oldAssignment); err != nil {
-				m.logger.Error("Failed to release old VIP during reconfiguration",
-					zap.String("vip", vipName),
-					zap.Error(err),
-				)
-			}
+			actions = append(actions, vipAction{release: true, assignment: oldAssignment})
 		}
+
 		// For config-only changes the handler's AddVIP detects the existing
 		// VIP and performs in-place reconfiguration.
+		actions = append(actions, vipAction{release: false, assignment: assignment})
 
-		if err := m.applyVIP(ctx, assignment); err != nil {
-			m.logger.Error("Failed to apply VIP",
-				zap.String("vip", vipName),
-				zap.Error(err),
-			)
-			continue
-		}
-
-		// For dual-stack: also apply the IPv6 address if present
+		// Dual-stack: also apply IPv6 address if present
 		if assignment.Ipv6Address != "" && assignment.IsActive {
 			ipv6Assignment := cloneAssignmentWithAddress(assignment, assignment.Ipv6Address)
 			ipv6Assignment.VipName = vipName + "-v6"
+			actions = append(actions, vipAction{release: false, assignment: ipv6Assignment})
+		}
+	}
+	m.mu.RUnlock()
 
-			if err := m.applyVIP(ctx, ipv6Assignment); err != nil {
-				m.logger.Error("Failed to apply IPv6 VIP",
-					zap.String("vip", vipName),
-					zap.String("ipv6_address", assignment.Ipv6Address),
+	// Phase 2: Execute network operations without holding the lock
+	for _, action := range actions {
+		if action.release {
+			if err := m.releaseVIP(ctx, action.assignment); err != nil {
+				m.logger.Error("Failed to release VIP",
+					zap.String("vip", action.assignment.VipName),
+					zap.Error(err),
+				)
+			}
+		} else {
+			if err := m.applyVIP(ctx, action.assignment); err != nil {
+				m.logger.Error("Failed to apply VIP",
+					zap.String("vip", action.assignment.VipName),
 					zap.Error(err),
 				)
 			}
 		}
 	}
 
+	// Phase 3: Update state under write lock
+	m.mu.Lock()
 	m.assignments = newAssignments
+	m.mu.Unlock()
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- **Read-Copy-Update for ApplyVIPs**: Network operations (addVIP/removeVIP) are now performed outside the write lock. The diff is computed under a short read lock, network I/O runs lock-free, and state is updated under a brief write lock. This prevents blocking concurrent `GetActiveVIPs()` reads during slow network operations.
- **GARP rate limiting**: Periodic GARP/NDP announcements are now rate-limited to 10/sec to avoid flooding the network when many VIPs are active.
- **Increased periodic GARP interval**: Changed from 30s to 60s for stable VIPs, reducing unnecessary network traffic while preserving fast initial failover announcements.

## Test plan

- [ ] Verify `go build ./internal/agent/vip/` compiles cleanly
- [ ] Verify `gofmt` produces no changes
- [ ] Confirm VIP failover still sends immediate GARPs on assignment
- [ ] Confirm periodic announcements occur at 60s intervals
- [ ] Load test with 50+ VIPs to confirm no GARP flood

Resolves #317