### PR TITLE
Controller: add generation-based event filtering to reduce reconciliation

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -26,9 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
@@ -452,7 +454,7 @@ func (r *GatewayReconciler) countAttachedRoutes(ctx context.Context, gatewayName
 // SetupWithManager sets up the controller with the Manager
 func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1.Gateway{}).
+		For(&gatewayv1.Gateway{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyGateway{}).
 		Complete(r)
 }

--- a/internal/controller/gatewayclass_controller.go
+++ b/internal/controller/gatewayclass_controller.go
@@ -24,8 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -102,6 +104,6 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // SetupWithManager sets up the controller with the Manager
 func (r *GatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1.GatewayClass{}).
+		For(&gatewayv1.GatewayClass{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -27,9 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
@@ -351,7 +353,7 @@ func (r *GRPCRouteReconciler) updateGRPCRouteStatus(ctx context.Context, grpcRou
 // SetupWithManager sets up the controller with the Manager
 func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1.GRPCRoute{}).
+		For(&gatewayv1.GRPCRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
 		Owns(&novaedgev1alpha1.ProxyBackend{}).
 		Complete(r)

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -27,9 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
@@ -423,7 +425,7 @@ func (r *HTTPRouteReconciler) handleDeletion(ctx context.Context, httpRoute *gat
 // SetupWithManager sets up the controller with the Manager
 func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1.HTTPRoute{}).
+		For(&gatewayv1.HTTPRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
 		Owns(&novaedgev1alpha1.ProxyBackend{}).
 		Complete(r)

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -27,9 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 )
@@ -291,7 +293,7 @@ func (r *IngressReconciler) reconcileBackend(ctx context.Context, desired *novae
 // SetupWithManager sets up the controller with the Manager
 func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&networkingv1.Ingress{}).
+		For(&networkingv1.Ingress{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyGateway{}).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
 		Owns(&novaedgev1alpha1.ProxyBackend{}).

--- a/internal/controller/proxybackend_controller.go
+++ b/internal/controller/proxybackend_controller.go
@@ -27,8 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 )
@@ -198,6 +200,6 @@ func (r *ProxyBackendReconciler) validateAndUpdateStatus(ctx context.Context, ba
 // SetupWithManager sets up the controller with the Manager
 func (r *ProxyBackendReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&novaedgev1alpha1.ProxyBackend{}).
+		For(&novaedgev1alpha1.ProxyBackend{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/proxygateway_controller.go
+++ b/internal/controller/proxygateway_controller.go
@@ -28,8 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 	"github.com/piwi3910/novaedge/internal/controller/certmanager"
@@ -317,6 +319,6 @@ func (r *ProxyGatewayReconciler) shouldReconcileGateway(gateway *novaedgev1alpha
 // SetupWithManager sets up the controller with the Manager
 func (r *ProxyGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&novaedgev1alpha1.ProxyGateway{}).
+		For(&novaedgev1alpha1.ProxyGateway{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/proxyippool_controller.go
+++ b/internal/controller/proxyippool_controller.go
@@ -24,8 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 	"github.com/piwi3910/novaedge/internal/controller/ipam"
@@ -138,6 +140,6 @@ func (r *ProxyIPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // SetupWithManager sets up the controller with the Manager
 func (r *ProxyIPPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&novaedgev1alpha1.ProxyIPPool{}).
+		For(&novaedgev1alpha1.ProxyIPPool{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/proxypolicy_controller.go
+++ b/internal/controller/proxypolicy_controller.go
@@ -27,8 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 )
@@ -209,6 +211,6 @@ func (r *ProxyPolicyReconciler) validateAndUpdateStatus(ctx context.Context, pol
 // SetupWithManager sets up the controller with the Manager
 func (r *ProxyPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&novaedgev1alpha1.ProxyPolicy{}).
+		For(&novaedgev1alpha1.ProxyPolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/proxyroute_controller.go
+++ b/internal/controller/proxyroute_controller.go
@@ -26,8 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 )
@@ -159,6 +161,6 @@ func (r *ProxyRouteReconciler) validateAndUpdateStatus(ctx context.Context, rout
 // SetupWithManager sets up the controller with the Manager
 func (r *ProxyRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&novaedgev1alpha1.ProxyRoute{}).
+		For(&novaedgev1alpha1.ProxyRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/proxyvip_controller.go
+++ b/internal/controller/proxyvip_controller.go
@@ -27,8 +27,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 	"github.com/piwi3910/novaedge/internal/controller/ipam"
@@ -345,6 +347,6 @@ func removeCondition(conditions *[]metav1.Condition, conditionType string) {
 // SetupWithManager sets up the controller with the Manager
 func (r *ProxyVIPReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&novaedgev1alpha1.ProxyVIP{}).
+		For(&novaedgev1alpha1.ProxyVIP{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/service_controller.go
+++ b/internal/controller/service_controller.go
@@ -28,8 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 	"github.com/piwi3910/novaedge/internal/controller/ipam"
@@ -348,7 +350,7 @@ func (r *ServiceReconciler) recordEvent(obj runtime.Object, eventType, reason, m
 // SetupWithManager sets up the controller with the Manager
 func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Service{}).
+		For(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyVIP{}).
 		Complete(r)
 }

--- a/internal/controller/tcproute_controller.go
+++ b/internal/controller/tcproute_controller.go
@@ -26,8 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
@@ -149,7 +151,7 @@ func (r *TCPRouteReconciler) updateRouteStatus(ctx context.Context, tcpRoute *ga
 // SetupWithManager sets up the controller with the Manager
 func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1alpha2.TCPRoute{}).
+		For(&gatewayv1alpha2.TCPRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
 		Complete(r)
 }

--- a/internal/controller/tlsroute_controller.go
+++ b/internal/controller/tlsroute_controller.go
@@ -26,8 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
@@ -148,7 +150,7 @@ func (r *TLSRouteReconciler) updateRouteStatus(ctx context.Context, tlsRoute *ga
 // SetupWithManager sets up the controller with the Manager
 func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1alpha2.TLSRoute{}).
+		For(&gatewayv1alpha2.TLSRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
 		Complete(r)
 }


### PR DESCRIPTION
## Summary
- Add `GenerationChangedPredicate` to the `For()` watch in all 14 controllers so reconciliation only triggers on spec (generation) changes, not status-only updates
- Predicate is only applied to the primary resource watch (`For()`), not to `Owns()` watches which may legitimately need status update triggers
- Reduces unnecessary reconciliation cycles and API server load

## Test plan
- [ ] Verify all 14 controllers build successfully (`go build ./internal/controller/...`)
- [ ] Confirm controllers still reconcile on spec changes (create/update ProxyGateway, ProxyRoute, etc.)
- [ ] Confirm controllers do NOT reconcile on status-only updates
- [ ] Run existing unit tests (`go test ./internal/controller/...`)

Resolves #319