### PR TITLE
[Fix] Operator binary missing CLI flags, federation controller, and webhook registration

### DIFF
--- a/cmd/novaedge-operator/main.go
+++ b/cmd/novaedge-operator/main.go
@@ -21,18 +21,22 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 	"github.com/piwi3910/novaedge/internal/operator/controller"
+	"github.com/piwi3910/novaedge/internal/operator/webhook"
 )
 
 // Build-time variables set via ldflags.
@@ -53,9 +57,10 @@ func init() {
 }
 
 func main() {
+	// Core flags
 	var metricsAddr string
-	var enableLeaderElection bool
 	var probeAddr string
+	var enableLeaderElection bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -63,18 +68,68 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 
-	opts := zap.Options{
-		Development: true,
+	// Leader election tuning flags
+	var leaseDuration time.Duration
+	var renewDeadline time.Duration
+	var retryPeriod time.Duration
+
+	flag.DurationVar(&leaseDuration, "leader-elect-lease-duration", 15*time.Second,
+		"The duration that non-leader candidates will wait to force acquire leadership.")
+	flag.DurationVar(&renewDeadline, "leader-elect-renew-deadline", 10*time.Second,
+		"The duration that the acting controlplane will retry refreshing leadership before giving up.")
+	flag.DurationVar(&retryPeriod, "leader-elect-retry-period", 2*time.Second,
+		"The duration the LeaderElector clients should wait between tries of actions.")
+
+	// Logging flags
+	var logLevel string
+	var logFormat string
+
+	flag.StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error.")
+	flag.StringVar(&logFormat, "log-format", "json", "Log format: json, text.")
+
+	// Webhook flags
+	var webhookPort int
+
+	flag.IntVar(&webhookPort, "webhook-port", 0, "Port for the webhook server. 0 disables webhooks.")
+
+	// Managed image override flags
+	var controllerImage string
+	var agentImage string
+	var novactlImage string
+
+	flag.StringVar(&controllerImage, "controller-image", "", "Override image for managed controller deployments.")
+	flag.StringVar(&agentImage, "agent-image", "", "Override image for managed agent daemonsets.")
+	flag.StringVar(&novactlImage, "novactl-image", "", "Override image for managed novactl/webui deployments.")
+
+	opts := ctrlzap.Options{
+		Development: logFormat == "text",
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	// Configure zap logger based on log-level and log-format flags
+	var zapLevel zap.AtomicLevel
+	switch logLevel {
+	case "debug":
+		zapLevel = zap.NewAtomicLevelAt(zap.DebugLevel)
+	case "warn":
+		zapLevel = zap.NewAtomicLevelAt(zap.WarnLevel)
+	case "error":
+		zapLevel = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	default:
+		zapLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
+	}
+
+	ctrl.SetLogger(ctrlzap.New(
+		ctrlzap.UseFlagOptions(&opts),
+		ctrlzap.Level(&zapLevel),
+	))
 
 	setupLog.Info("Starting NovaEdge operator",
 		"version", version, "commit", commit, "date", date)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	// Build manager options
+	mgrOpts := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -82,16 +137,33 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "novaedge-operator-leader-election",
-	})
+		LeaseDuration:          &leaseDuration,
+		RenewDeadline:          &renewDeadline,
+		RetryPeriod:            &retryPeriod,
+	}
+
+	// Configure webhook server if enabled
+	if webhookPort > 0 {
+		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
+			Port: webhookPort,
+		})
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
 
-	if err = (&controller.NovaEdgeClusterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	// Set up NovaEdgeCluster controller
+	clusterReconciler := &controller.NovaEdgeClusterReconciler{
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		ControllerImage: controllerImage,
+		AgentImage:      agentImage,
+		NovactlImage:    novactlImage,
+	}
+	if err = clusterReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NovaEdgeCluster")
 		os.Exit(1)
 	}
@@ -106,6 +178,39 @@ func main() {
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NovaEdgeRemoteCluster")
 		os.Exit(1)
+	}
+
+	// Set up NovaEdgeFederation controller
+	zapLogger, zapErr := zap.NewProduction()
+	if logFormat == "text" {
+		zapLogger, zapErr = zap.NewDevelopment()
+	}
+	if zapErr != nil {
+		setupLog.Error(zapErr, "unable to create zap logger")
+		os.Exit(1)
+	}
+
+	if err = (&controller.NovaEdgeFederationReconciler{
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		Logger:         zapLogger.Named("federation"),
+		ControllerName: "novaedge-operator",
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "NovaEdgeFederation")
+		os.Exit(1)
+	}
+
+	// Set up webhooks if enabled
+	if webhookPort > 0 {
+		if err = (&webhook.FederationValidator{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "FederationValidator")
+			os.Exit(1)
+		}
+		if err = (&webhook.FederationDefaulter{}).SetupDefaulterWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "FederationDefaulter")
+			os.Exit(1)
+		}
+		setupLog.Info("Webhook server enabled", "port", webhookPort)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/internal/operator/controller/novaedgecluster_controller.go
+++ b/internal/operator/controller/novaedgecluster_controller.go
@@ -60,6 +60,12 @@ const (
 type NovaEdgeClusterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// Managed image overrides (set via CLI flags).
+	// When non-empty, these take precedence over the CRD spec for image resolution.
+	ControllerImage string
+	AgentImage      string
+	NovactlImage    string
 }
 
 // +kubebuilder:rbac:groups=novaedge.io,resources=novaedgeclusters,verbs=get;list;watch;create;update;patch;delete
@@ -1045,6 +1051,23 @@ func (r *NovaEdgeClusterReconciler) getSelectorLabels(cluster *novaedgev1alpha1.
 }
 
 func (r *NovaEdgeClusterReconciler) getImage(cluster *novaedgev1alpha1.NovaEdgeCluster, component string) string {
+	// Check for CLI-level image overrides first
+	switch component {
+	case "novaedge-controller":
+		if r.ControllerImage != "" {
+			return r.ControllerImage
+		}
+	case "novaedge-agent":
+		if r.AgentImage != "" {
+			return r.AgentImage
+		}
+	case "novactl":
+		if r.NovactlImage != "" {
+			return r.NovactlImage
+		}
+	}
+
+	// Fall back to CRD spec
 	repo := "ghcr.io/piwi3910/novaedge"
 	if cluster.Spec.ImageRepository != "" {
 		repo = cluster.Spec.ImageRepository


### PR DESCRIPTION
## Summary

- Add 9 missing CLI flags to the operator binary that the Helm chart deployment template references: `--log-level`, `--log-format`, `--webhook-port`, `--controller-image`, `--agent-image`, `--novactl-image`, `--leader-elect-lease-duration`, `--leader-elect-renew-deadline`, `--leader-elect-retry-period`
- Register `NovaEdgeFederationReconciler` which existed in code but was never wired up in `main.go`
- Register `FederationValidator` and `FederationDefaulter` webhooks when `--webhook-port` is specified
- Add managed image override fields to `NovaEdgeClusterReconciler` so `--controller-image`/`--agent-image`/`--novactl-image` flags propagate to reconciled resources

## Test plan

- [x] All 5 binaries build successfully
- [x] `go vet` passes on all modified packages
- [x] `gofmt -s` passes on all modified files
- [x] `helm template` renders correct args matching binary flags
- [x] Verified with webhooks enabled + managed image overrides set

Resolves #345