### PR TITLE
Fix release artifact download filter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,19 +109,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download all artifacts
+      - name: Download binary artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: '*-linux-*'
 
       - name: Prepare release assets
         run: |
           mkdir -p release
           for dir in artifacts/*/; do
-            # Skip non-binary artifacts (like webui-dist)
-            if [[ "$(basename "$dir")" == "webui-dist" ]]; then
-              continue
-            fi
             cp "${dir}"* release/
           done
           chmod +x release/*


### PR DESCRIPTION
## Summary

Fix the release job failing to download artifacts due to Docker buildx cache artifacts being included.

## Problem

The `download-artifact@v4` action without a `pattern` filter downloads ALL artifacts including Docker buildx internal cache artifacts (e.g. `piwi3910~novaedge~SCV1PQ.dockerbuild`), which caused the release job to fail with:

```
Unable to download and extract artifact: Artifact download failed after 5 retries.
```

This was introduced in #361 where Docker images now run in parallel with the release job.

## Fix

Add `pattern: '*-linux-*'` to the download step to only fetch binary artifacts (e.g. `novaedge-controller-linux-amd64`). This also removes the now-unnecessary webui-dist skip logic since the pattern naturally excludes it.

## Test plan
- [ ] Tag a release and confirm the Create Release job succeeds
- [ ] Verify all 10 binaries appear in the GitHub release

Resolves #360