### PR TITLE
Fix fail-open security middleware for IP filter policies

### DIFF
--- a/internal/agent/router/middleware.go
+++ b/internal/agent/router/middleware.go
@@ -81,7 +81,16 @@ func (r *Router) createPolicyMiddleware(ctx context.Context, route *pb.Route, sn
 		case pb.PolicyType_IP_ALLOW_LIST:
 			if policyProto.IpList != nil {
 				filter, err := policy.NewIPAllowListFilter(policyProto.IpList.Cidrs)
-				if err == nil {
+				if err != nil {
+					r.logger.Error("Failed to create IP allow list filter, failing closed",
+						zap.String("policy", policyProto.Name),
+						zap.Error(err),
+					)
+					middlewares = append(middlewares, policyMiddleware{
+						name:    fmt.Sprintf("ip-allow-%s-fail-closed", policyProto.Name),
+						handler: failClosedMiddleware("IP allow list", policyProto.Name, r.logger),
+					})
+				} else {
 					middlewares = append(middlewares, policyMiddleware{
 						name:    fmt.Sprintf("ip-allow-%s", policyProto.Name),
 						handler: policy.HandleIPFilter(filter),
@@ -92,7 +101,16 @@ func (r *Router) createPolicyMiddleware(ctx context.Context, route *pb.Route, sn
 		case pb.PolicyType_IP_DENY_LIST:
 			if policyProto.IpList != nil {
 				filter, err := policy.NewIPDenyListFilter(policyProto.IpList.Cidrs)
-				if err == nil {
+				if err != nil {
+					r.logger.Error("Failed to create IP deny list filter, failing closed",
+						zap.String("policy", policyProto.Name),
+						zap.Error(err),
+					)
+					middlewares = append(middlewares, policyMiddleware{
+						name:    fmt.Sprintf("ip-deny-%s-fail-closed", policyProto.Name),
+						handler: failClosedMiddleware("IP deny list", policyProto.Name, r.logger),
+					})
+				} else {
 					middlewares = append(middlewares, policyMiddleware{
 						name:    fmt.Sprintf("ip-deny-%s", policyProto.Name),
 						handler: policy.HandleIPFilter(filter),


### PR DESCRIPTION
## Summary
- Make IP Allow List and IP Deny List middleware fail closed when CIDR parsing errors occur
- Previously, initialization errors silently skipped the middleware, allowing requests through without IP filtering
- Now installs a `failClosedMiddleware` returning 503 Service Unavailable, matching existing WAF and distributed rate-limit behavior

## Test plan
- [ ] Verify CI passes (gofmt, golangci-lint, go vet, tests, build)
- [ ] Verify fail-closed pattern matches existing WAF/distributed-ratelimit middleware

Resolves #376