### PR TITLE
Replace time.Sleep with context-aware select in retry loops

### DIFF
--- a/internal/agent/config/failover.go
+++ b/internal/agent/config/failover.go
@@ -265,7 +265,12 @@ func (w *FailoverWatcher) Start(applyFunc ApplyFunc) error {
 
 		if err := w.runStateMachine(); err != nil {
 			w.logger.Error("State machine error", zap.Error(err))
-			time.Sleep(time.Second)
+			select {
+			case <-w.ctx.Done():
+				w.cleanup()
+				return w.ctx.Err()
+			case <-time.After(time.Second):
+			}
 		}
 	}
 }
@@ -402,7 +407,11 @@ func (w *FailoverWatcher) handleFailingOver() error {
 		w.transitionTo(StateAutonomous, nil)
 	} else {
 		// Wait and retry
-		time.Sleep(5 * time.Second)
+		select {
+		case <-w.ctx.Done():
+			return w.ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
 	}
 
 	return nil

--- a/internal/agent/config/watcher.go
+++ b/internal/agent/config/watcher.go
@@ -164,7 +164,11 @@ func (w *Watcher) Start(applyFunc ApplyFunc) error {
 					zap.Error(err),
 					zap.Duration("retry_delay", 5*time.Second),
 				)
-				time.Sleep(5 * time.Second)
+				select {
+				case <-w.ctx.Done():
+					return w.ctx.Err()
+				case <-time.After(5 * time.Second):
+				}
 				continue
 			}
 		}
@@ -216,7 +220,11 @@ func (w *Watcher) connectWithRetry() (*grpc.ClientConn, error) {
 				zap.Error(err),
 				zap.Duration("retry_in", backoff),
 			)
-			time.Sleep(backoff)
+			select {
+			case <-w.ctx.Done():
+				return nil, w.ctx.Err()
+			case <-time.After(backoff):
+			}
 			backoff *= 2
 			if backoff > maxBackoff {
 				backoff = maxBackoff

--- a/internal/agent/vip/l2.go
+++ b/internal/agent/vip/l2.go
@@ -352,7 +352,7 @@ func (h *L2Handler) announcementLoop(ctx context.Context) {
 			return
 
 		case <-ticker.C:
-			h.announceActiveVIPs()
+			h.announceActiveVIPs(ctx)
 		}
 	}
 }
@@ -364,7 +364,7 @@ const maxGARPPerSecond = 10
 // announceActiveVIPs sends GARP/NDP for all active VIPs with rate limiting.
 // VIP state is snapshot under a short read lock, then announcements are sent
 // outside the lock to avoid blocking concurrent operations.
-func (h *L2Handler) announceActiveVIPs() {
+func (h *L2Handler) announceActiveVIPs(ctx context.Context) {
 	// Snapshot active VIPs under read lock
 	h.mu.RLock()
 	if len(h.activeVIPs) == 0 {
@@ -391,7 +391,11 @@ func (h *L2Handler) announceActiveVIPs() {
 
 	for i, vip := range vips {
 		if i > 0 {
-			time.Sleep(garpInterval)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(garpInterval):
+			}
 		}
 
 		if vip.isIPv6 {

--- a/internal/agent/vip/l2_test.go
+++ b/internal/agent/vip/l2_test.go
@@ -342,7 +342,7 @@ func TestL2Handler_AnnounceActiveVIPs(t *testing.T) {
 	}
 
 	t.Run("no VIPs to announce", func(t *testing.T) {
-		handler.announceActiveVIPs()
+		handler.announceActiveVIPs(context.Background())
 	})
 
 	t.Run("with active VIPs including IPv6", func(t *testing.T) {
@@ -362,7 +362,7 @@ func TestL2Handler_AnnounceActiveVIPs(t *testing.T) {
 		handler.mu.Unlock()
 
 		// Should not panic
-		handler.announceActiveVIPs()
+		handler.announceActiveVIPs(context.Background())
 	})
 }
 


### PR DESCRIPTION
## Summary
- Replace `time.Sleep` with context-aware `select` in failover, watcher, and GARP loops
- All backoff delays now respect context cancellation for faster graceful shutdown

## Test plan
- [ ] Verify CI passes (gofmt, golangci-lint, go vet, tests, build)

Resolves #380