### PR TITLE
Propagate caller context instead of context.Background()

### DIFF
--- a/internal/agent/cpvip/manager.go
+++ b/internal/agent/cpvip/manager.go
@@ -313,7 +313,7 @@ func (m *Manager) Stop() error {
 
 	if m.vipActive {
 		m.logger.Info("Releasing control-plane VIP on shutdown")
-		if err := m.releaseVIPLocked(); err != nil {
+		if err := m.releaseVIPLocked(context.Background()); err != nil {
 			return fmt.Errorf("failed to release VIP on stop: %w", err)
 		}
 	}
@@ -339,7 +339,7 @@ func (m *Manager) healthCheckTick(ctx context.Context) {
 		m.failCount = 0
 		if !m.vipActive {
 			m.logger.Info("API server is healthy, binding VIP")
-			if err := m.bindVIPLocked(); err != nil {
+			if err := m.bindVIPLocked(ctx); err != nil {
 				m.logger.Error("Failed to bind VIP", zap.Error(err))
 			}
 		}
@@ -353,7 +353,7 @@ func (m *Manager) healthCheckTick(ctx context.Context) {
 			m.logger.Warn("Fail threshold reached, releasing VIP",
 				zap.Int("fail_count", m.failCount),
 			)
-			if err := m.releaseVIPLocked(); err != nil {
+			if err := m.releaseVIPLocked(ctx); err != nil {
 				m.logger.Error("Failed to release VIP", zap.Error(err))
 			}
 		}
@@ -493,10 +493,10 @@ func (m *Manager) buildVIPAssignment() *pb.VIPAssignment {
 }
 
 // bindVIPLocked binds the VIP using the handler. Must be called with m.mu held.
-func (m *Manager) bindVIPLocked() error {
+func (m *Manager) bindVIPLocked(ctx context.Context) error {
 	assignment := m.buildVIPAssignment()
 
-	if err := m.handler.AddVIP(context.Background(), assignment); err != nil {
+	if err := m.handler.AddVIP(ctx, assignment); err != nil {
 		return fmt.Errorf("failed to add VIP: %w", err)
 	}
 
@@ -510,10 +510,10 @@ func (m *Manager) bindVIPLocked() error {
 }
 
 // releaseVIPLocked releases the VIP using the handler. Must be called with m.mu held.
-func (m *Manager) releaseVIPLocked() error {
+func (m *Manager) releaseVIPLocked(ctx context.Context) error {
 	assignment := m.buildVIPAssignment()
 
-	if err := m.handler.RemoveVIP(context.Background(), assignment); err != nil {
+	if err := m.handler.RemoveVIP(ctx, assignment); err != nil {
 		return fmt.Errorf("failed to remove VIP: %w", err)
 	}
 

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -98,7 +98,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Translate Ingress to CRDs with service port resolver, configurable default VIP, and VIP mode resolver
 	translator := NewIngressTranslatorWithOptions(ingress.Namespace, r.resolveServicePort, r.DefaultVIPRef, r.resolveVIPMode)
-	result, err := translator.Translate(ingress)
+	result, err := translator.Translate(ctx, ingress)
 	if err != nil {
 		logger.Error(err, "Failed to translate Ingress to CRDs")
 		return ctrl.Result{}, err
@@ -301,8 +301,7 @@ func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // resolveServicePort resolves a service port name to its port number
-func (r *IngressReconciler) resolveServicePort(namespace, serviceName, portName string) (int32, error) {
-	ctx := context.Background()
+func (r *IngressReconciler) resolveServicePort(ctx context.Context, namespace, serviceName, portName string) (int32, error) {
 	svc := &corev1.Service{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: serviceName}, svc); err != nil {
 		return 0, fmt.Errorf("failed to get service %s/%s: %w", namespace, serviceName, err)
@@ -320,9 +319,9 @@ func (r *IngressReconciler) resolveServicePort(namespace, serviceName, portName 
 
 // resolveVIPMode fetches a ProxyVIP by name and returns its mode (e.g. "BGP", "OSPF", "L2ARP").
 // Returns an empty string if the VIP cannot be found.
-func (r *IngressReconciler) resolveVIPMode(vipRef string) string {
+func (r *IngressReconciler) resolveVIPMode(ctx context.Context, vipRef string) string {
 	vip := &novaedgev1alpha1.ProxyVIP{}
-	if err := r.Get(context.Background(), types.NamespacedName{Name: vipRef}, vip); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: vipRef}, vip); err != nil {
 		return ""
 	}
 	return string(vip.Spec.Mode)

--- a/internal/controller/ingress_translator.go
+++ b/internal/controller/ingress_translator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -166,10 +167,10 @@ const (
 )
 
 // ServicePortResolver resolves service port names to port numbers
-type ServicePortResolver func(namespace, serviceName, portName string) (int32, error)
+type ServicePortResolver func(ctx context.Context, namespace, serviceName, portName string) (int32, error)
 
 // VIPModeResolver resolves a VIP reference name to its mode (e.g. "BGP", "OSPF", "L2ARP")
-type VIPModeResolver func(vipRef string) string
+type VIPModeResolver func(ctx context.Context, vipRef string) string
 
 // IngressTranslator translates Kubernetes Ingress resources to NovaEdge CRDs
 type IngressTranslator struct {
@@ -218,7 +219,7 @@ type TranslationResult struct {
 }
 
 // Translate converts an Ingress resource to NovaEdge CRDs
-func (t *IngressTranslator) Translate(ingress *networkingv1.Ingress) (*TranslationResult, error) {
+func (t *IngressTranslator) Translate(ctx context.Context, ingress *networkingv1.Ingress) (*TranslationResult, error) {
 	result := &TranslationResult{
 		Routes:   make([]*novaedgev1alpha1.ProxyRoute, 0),
 		Backends: make([]*novaedgev1alpha1.ProxyBackend, 0),
@@ -244,7 +245,7 @@ func (t *IngressTranslator) Translate(ingress *networkingv1.Ingress) (*Translati
 		for pathIdx, path := range rule.HTTP.Paths {
 			backendName := t.generateBackendName(ingress, ruleIdx, pathIdx)
 			if _, exists := backendMap[backendName]; !exists {
-				backend := t.translateBackend(ingress, path.Backend, backendName)
+				backend := t.translateBackend(ctx, ingress, path.Backend, backendName)
 				backendMap[backendName] = backend
 			}
 		}
@@ -259,7 +260,7 @@ func (t *IngressTranslator) Translate(ingress *networkingv1.Ingress) (*Translati
 	if ingress.Spec.DefaultBackend != nil {
 		defaultBackendName := t.generateDefaultBackendName(ingress)
 		if _, exists := backendMap[defaultBackendName]; !exists {
-			backend := t.translateBackend(ingress, *ingress.Spec.DefaultBackend, defaultBackendName)
+			backend := t.translateBackend(ctx, ingress, *ingress.Spec.DefaultBackend, defaultBackendName)
 			result.Backends = append(result.Backends, backend)
 		}
 	}
@@ -574,7 +575,7 @@ func (t *IngressTranslator) convertPathMatchWithIngress(ingress *networkingv1.In
 }
 
 // translateBackend creates a ProxyBackend from an Ingress backend
-func (t *IngressTranslator) translateBackend(ingress *networkingv1.Ingress, backend networkingv1.IngressBackend, backendName string) *novaedgev1alpha1.ProxyBackend {
+func (t *IngressTranslator) translateBackend(ctx context.Context, ingress *networkingv1.Ingress, backend networkingv1.IngressBackend, backendName string) *novaedgev1alpha1.ProxyBackend {
 	proxyBackend := &novaedgev1alpha1.ProxyBackend{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      backendName,
@@ -585,7 +586,7 @@ func (t *IngressTranslator) translateBackend(ingress *networkingv1.Ingress, back
 			},
 		},
 		Spec: novaedgev1alpha1.ProxyBackendSpec{
-			LBPolicy: t.getLBPolicy(ingress),
+			LBPolicy: t.getLBPolicy(ctx, ingress),
 		},
 	}
 
@@ -595,7 +596,7 @@ func (t *IngressTranslator) translateBackend(ingress *networkingv1.Ingress, back
 		proxyBackend.Spec.ServiceRef = &novaedgev1alpha1.ServiceReference{
 			Name:      backend.Service.Name,
 			Namespace: &namespace,
-			Port:      t.getServicePort(ingress, backend.Service),
+			Port:      t.getServicePort(ctx, ingress, backend.Service),
 		}
 	}
 
@@ -630,13 +631,13 @@ func (t *IngressTranslator) translateBackend(ingress *networkingv1.Ingress, back
 }
 
 // getServicePort extracts the port number from IngressServiceBackend
-func (t *IngressTranslator) getServicePort(ingress *networkingv1.Ingress, service *networkingv1.IngressServiceBackend) int32 {
+func (t *IngressTranslator) getServicePort(ctx context.Context, ingress *networkingv1.Ingress, service *networkingv1.IngressServiceBackend) int32 {
 	if service.Port.Number != 0 {
 		return service.Port.Number
 	}
 	// If port is specified by name, try to resolve it
 	if service.Port.Name != "" && t.servicePortResolver != nil {
-		port, err := t.servicePortResolver(ingress.Namespace, service.Name, service.Port.Name)
+		port, err := t.servicePortResolver(ctx, ingress.Namespace, service.Name, service.Port.Name)
 		if err == nil {
 			return port
 		}
@@ -684,7 +685,7 @@ func (t *IngressTranslator) getIngressClassName(ingress *networkingv1.Ingress) s
 	return ""
 }
 
-func (t *IngressTranslator) getLBPolicy(ingress *networkingv1.Ingress) novaedgev1alpha1.LoadBalancingPolicy {
+func (t *IngressTranslator) getLBPolicy(ctx context.Context, ingress *networkingv1.Ingress) novaedgev1alpha1.LoadBalancingPolicy {
 	// Explicit annotation always wins
 	if lbPolicy, exists := ingress.Annotations[AnnotationLoadBalancing]; exists {
 		switch strings.ToLower(lbPolicy) {
@@ -703,7 +704,7 @@ func (t *IngressTranslator) getLBPolicy(ingress *networkingv1.Ingress) novaedgev
 	// Auto-detect from VIP mode: BGP/OSPF require hash-based LB for ECMP
 	if t.vipModeResolver != nil {
 		vipRef := t.getVIPRef(ingress)
-		mode := t.vipModeResolver(vipRef)
+		mode := t.vipModeResolver(ctx, vipRef)
 		if mode == string(novaedgev1alpha1.VIPModeBGP) || mode == string(novaedgev1alpha1.VIPModeOSPF) {
 			return novaedgev1alpha1.LBPolicyMaglev
 		}

--- a/internal/controller/ingress_translator_extended_test.go
+++ b/internal/controller/ingress_translator_extended_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
 	networkingv1 "k8s.io/api/networking/v1"
@@ -264,7 +265,7 @@ func TestGetLBPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			translator := NewIngressTranslator("default")
-			result := translator.getLBPolicy(tt.ingress)
+			result := translator.getLBPolicy(context.Background(), tt.ingress)
 			if string(result) != tt.expectedName {
 				t.Errorf("getLBPolicy() = %v, want %v", result, tt.expectedName)
 			}
@@ -1308,7 +1309,7 @@ func TestGetLBPolicyVIPModeAware(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var resolver VIPModeResolver
 			if tt.name != "nil resolver defaults to RoundRobin" {
-				resolver = func(_ string) string { return tt.vipModeResult }
+				resolver = func(_ context.Context, _ string) string { return tt.vipModeResult }
 			}
 
 			translator := NewIngressTranslatorWithOptions("default", nil, "default-vip", resolver)
@@ -1324,7 +1325,7 @@ func TestGetLBPolicyVIPModeAware(t *testing.T) {
 				},
 			}
 
-			result := translator.getLBPolicy(ingress)
+			result := translator.getLBPolicy(context.Background(), ingress)
 			if result != tt.expectedPolicy {
 				t.Errorf("getLBPolicy() = %v, want %v", result, tt.expectedPolicy)
 			}


### PR DESCRIPTION
## Summary
- Four functions in ingress controller and CP VIP manager now accept and propagate caller context
- Enables proper cancellation and tracing through the call chain
- Updated tests to pass context

## Test plan
- [ ] Verify CI passes (gofmt, golangci-lint, go vet, tests, build)

Resolves #381