### PR TITLE
Replace silent no-op federation TODOs with explicit warnings

### DIFF
--- a/internal/controller/federation/antientropy.go
+++ b/internal/controller/federation/antientropy.go
@@ -481,27 +481,24 @@ func (m *AntiEntropyManager) compareWithPeer(peerName string) {
 	switch cmp {
 	case 0:
 		// Concurrent - potential conflicts, need detailed comparison
-		m.logger.Debug("Concurrent state with peer, detailed comparison needed",
+		m.logger.Warn("Concurrent state with peer requires full sync or merkle tree comparison (not yet implemented)",
 			zap.String("peer", peerName),
 		)
-		// TODO: Request full sync or merkle tree comparison
 
 	case 1:
 		// We're ahead - peer might need updates
 		if m.config.RepairMode == "push" || m.config.RepairMode == "bidirectional" {
-			m.logger.Debug("We're ahead of peer, may need to push updates",
+			m.logger.Warn("Push updates to peer not yet implemented",
 				zap.String("peer", peerName),
 			)
-			// TODO: Push updates to peer
 		}
 
 	case -1:
 		// Peer is ahead - we might need updates
 		if m.config.RepairMode == "pull" || m.config.RepairMode == "bidirectional" {
-			m.logger.Debug("Peer is ahead, may need to pull updates",
+			m.logger.Warn("Pull updates from peer not yet implemented",
 				zap.String("peer", peerName),
 			)
-			// TODO: Request full sync from peer
 		}
 	}
 }

--- a/internal/controller/federation/server.go
+++ b/internal/controller/federation/server.go
@@ -1013,27 +1013,15 @@ func (s *Server) maintainPeerConnection(ctx context.Context, peer *PeerInfo) {
 	}
 }
 
-// connectToPeer establishes a connection to a federation peer
-//
-//nolint:unparam // error return kept for future peer connection implementation (see TODOs)
+// connectToPeer establishes a connection to a federation peer.
+// Not yet implemented - returns an error indicating the feature is pending.
 func (s *Server) connectToPeer(_ context.Context, peer *PeerInfo) error {
-	// This would establish a gRPC client connection to the peer
-	// and start the SyncStream
-	// For now, this is a placeholder - the actual implementation
-	// would use grpc.Dial and the client stubs
-
-	s.logger.Debug("Would connect to peer",
+	s.logger.Warn("Federation peer connection is not yet implemented",
 		zap.String("peer", peer.Name),
 		zap.String("endpoint", peer.Endpoint),
 	)
 
-	// TODO: Implement actual peer connection
-	// conn, err := grpc.Dial(peer.Endpoint, opts...)
-	// client := pb.NewFederationServiceClient(conn)
-	// stream, err := client.SyncStream(ctx)
-	// ...
-
-	return nil
+	return fmt.Errorf("federation peer connection not yet implemented for peer %q at %s", peer.Name, peer.Endpoint)
 }
 
 // cleanupTombstones removes old tombstones

--- a/internal/operator/controller/novaedgefederation_controller.go
+++ b/internal/operator/controller/novaedgefederation_controller.go
@@ -149,7 +149,9 @@ func (r *NovaEdgeFederationReconciler) ensureManager(ctx context.Context, fed *n
 
 	// Check if manager already exists
 	if existing, ok := r.managers[key]; ok {
-		// TODO: Check if config changed and restart if needed
+		log.Warn("Federation manager already exists; config change detection not yet implemented",
+			zap.String("key", key),
+		)
 		_ = existing
 		return nil
 	}
@@ -183,11 +185,10 @@ func (r *NovaEdgeFederationReconciler) ensureManager(ctx context.Context, fed *n
 
 	// Set up callbacks
 	manager.OnResourceChange(func(key federation.ResourceKey, changeType federation.ChangeType, data []byte) {
-		log.Debug("Resource changed from federation",
+		log.Warn("Resource changed from federation but applying changes to local Kubernetes resources is not yet implemented",
 			zap.String("resource", fmt.Sprintf("%s/%s/%s", key.Kind, key.Namespace, key.Name)),
 			zap.String("change_type", string(changeType)),
 		)
-		// TODO: Apply changes to local Kubernetes resources
 	})
 
 	// Start the manager

--- a/internal/operator/controller/novaedgeremotecluster_controller.go
+++ b/internal/operator/controller/novaedgeremotecluster_controller.go
@@ -358,9 +358,10 @@ func (r *NovaEdgeRemoteClusterReconciler) updateOverallStatus(ctx context.Contex
 	return r.Status().Update(ctx, rc)
 }
 
-// cleanupRemoteCluster handles cleanup when a remote cluster is deleted
+// cleanupRemoteCluster handles cleanup when a remote cluster is deleted.
+// The error return is kept for future cleanup operations that may fail.
 //
-//nolint:unparam // error return kept for future cleanup operations (see TODOs)
+//nolint:unparam // error return reserved for future cleanup operations
 func (r *NovaEdgeRemoteClusterReconciler) cleanupRemoteCluster(ctx context.Context, rc *novaedgev1alpha1.NovaEdgeRemoteCluster) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Cleaning up remote cluster", "clusterName", rc.Spec.ClusterName)
@@ -368,8 +369,9 @@ func (r *NovaEdgeRemoteClusterReconciler) cleanupRemoteCluster(ctx context.Conte
 	// Unregister from registry
 	r.Registry.Unregister(rc.Spec.ClusterName)
 
-	// TODO: Notify controller to stop accepting connections from this cluster
-	// TODO: Clean up any cluster-specific resources (secrets, configmaps, etc.)
+	logger.Info("Remote cluster unregistered; notifying controller and cleaning up cluster-specific resources is not yet implemented",
+		"clusterName", rc.Spec.ClusterName,
+	)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Replace `connectToPeer` no-op with explicit error return
- Change silent Debug logs to Warn level for unimplemented antientropy operations
- Add warning logs for unimplemented operator controller callbacks
- Log acknowledgment for unimplemented remote cluster cleanup

## Test plan
- [ ] CI passes all checks
- [ ] No behavioral regression (functions already were no-ops)

Resolves #385