### PR TITLE
Minor code quality cleanup: prealloc, error handling, dead code

### DIFF
--- a/internal/agent/filters/doc.go
+++ b/internal/agent/filters/doc.go
@@ -1,3 +1,0 @@
-// Package filters is reserved for future filter implementations.
-// Current filter implementations are in the internal/agent/policy package.
-package filters

--- a/internal/agent/mesh/manager.go
+++ b/internal/agent/mesh/manager.go
@@ -328,10 +328,14 @@ func (m *Manager) proxyTCP(ctx context.Context, clientConn io.ReadWriteCloser, b
 	// Bidirectional copy
 	done := make(chan struct{})
 	go func() {
-		_, _ = io.Copy(backendConn, clientConn)
+		if _, err := io.Copy(backendConn, clientConn); err != nil {
+			m.logger.Debug("io.Copy client->backend finished with error", zap.Error(err))
+		}
 		done <- struct{}{}
 	}()
 
-	_, _ = io.Copy(clientConn, backendConn)
+	if _, err := io.Copy(clientConn, backendConn); err != nil {
+		m.logger.Debug("io.Copy backend->client finished with error", zap.Error(err))
+	}
 	<-done
 }

--- a/internal/agent/mesh/tunnel.go
+++ b/internal/agent/mesh/tunnel.go
@@ -189,11 +189,15 @@ func (ts *TunnelServer) handleConnect(w http.ResponseWriter, r *http.Request) {
 	done := make(chan struct{})
 	go func() {
 		defer func() { done <- struct{}{} }()
-		_, _ = io.Copy(backendConn, r.Body)
+		if _, err := io.Copy(backendConn, r.Body); err != nil {
+			ts.logger.Debug("io.Copy client->backend finished with error", zap.Error(err))
+		}
 	}()
 
 	fw := &flushWriter{w: w}
-	_, _ = io.Copy(fw, backendConn)
+	if _, err := io.Copy(fw, backendConn); err != nil {
+		ts.logger.Debug("io.Copy backend->client finished with error", zap.Error(err))
+	}
 	<-done
 }
 

--- a/internal/agent/policy/ipfilter.go
+++ b/internal/agent/policy/ipfilter.go
@@ -39,6 +39,24 @@ func isBogonIP(ip net.IP) bool {
 	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }
 
+// parseSingleIPAsCIDR converts a validated net.IP to a *net.IPNet by appending
+// the appropriate mask (/32 for IPv4, /128 for IPv6). It logs a warning if the
+// resulting CIDR string unexpectedly fails to parse.
+func parseSingleIPAsCIDR(ip net.IP, raw string) *net.IPNet {
+	mask := "/128"
+	if ip.To4() != nil {
+		mask = "/32"
+	}
+	_, ipNet, err := net.ParseCIDR(raw + mask)
+	if err != nil {
+		zap.L().Warn("failed to parse single IP as CIDR",
+			zap.String("input", raw+mask),
+			zap.Error(err),
+		)
+	}
+	return ipNet
+}
+
 // trustedProxyCIDRsPtr holds the global list of trusted proxy IP ranges.
 // It uses atomic.Pointer for lock-free concurrent reads during request
 // processing while allowing safe writes during config reload.
@@ -59,11 +77,7 @@ func SetGlobalTrustedProxies(cidrs []string) error {
 				return err
 			}
 			// Convert single IP to CIDR
-			if ip.To4() != nil {
-				_, ipNet, _ = net.ParseCIDR(cidr + "/32")
-			} else {
-				_, ipNet, _ = net.ParseCIDR(cidr + "/128")
-			}
+			ipNet = parseSingleIPAsCIDR(ip, cidr)
 		}
 		newCIDRs = append(newCIDRs, ipNet)
 	}
@@ -193,11 +207,7 @@ func NewIPAllowListFilter(cidrs []string) (*IPFilter, error) {
 				return nil, err
 			}
 			// Convert single IP to CIDR
-			if ip.To4() != nil {
-				_, ipNet, _ = net.ParseCIDR(cidr + "/32")
-			} else {
-				_, ipNet, _ = net.ParseCIDR(cidr + "/128")
-			}
+			ipNet = parseSingleIPAsCIDR(ip, cidr)
 		}
 		filter.allowList = append(filter.allowList, ipNet)
 	}
@@ -220,11 +230,7 @@ func NewIPDenyListFilter(cidrs []string) (*IPFilter, error) {
 				return nil, err
 			}
 			// Convert single IP to CIDR
-			if ip.To4() != nil {
-				_, ipNet, _ = net.ParseCIDR(cidr + "/32")
-			} else {
-				_, ipNet, _ = net.ParseCIDR(cidr + "/128")
-			}
+			ipNet = parseSingleIPAsCIDR(ip, cidr)
 		}
 		filter.denyList = append(filter.denyList, ipNet)
 	}
@@ -244,11 +250,7 @@ func (f *IPFilter) SetTrustedProxies(cidrs []string) error {
 				return err
 			}
 			// Convert single IP to CIDR
-			if ip.To4() != nil {
-				_, ipNet, _ = net.ParseCIDR(cidr + "/32")
-			} else {
-				_, ipNet, _ = net.ParseCIDR(cidr + "/128")
-			}
+			ipNet = parseSingleIPAsCIDR(ip, cidr)
 		}
 		f.trustedProxy = append(f.trustedProxy, ipNet)
 	}

--- a/internal/agent/policy/ssrf.go
+++ b/internal/agent/policy/ssrf.go
@@ -27,23 +27,27 @@ import (
 // privateNetworks contains CIDR ranges that should be blocked for outbound requests.
 var privateNetworks []*net.IPNet
 
-func init() {
-	cidrs := []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"127.0.0.0/8",
-		"169.254.0.0/16",
-		"::1/128",
-		"fc00::/7",
-		"fe80::/10",
+// mustParseCIDR parses a CIDR string and panics with a descriptive message on
+// failure. It is intended only for package-level initialization of constant
+// CIDR blocks that are guaranteed to be valid.
+func mustParseCIDR(s string) *net.IPNet {
+	_, block, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(fmt.Sprintf("ssrf: invalid constant CIDR %q: %v", s, err))
 	}
-	for _, cidr := range cidrs {
-		_, block, err := net.ParseCIDR(cidr)
-		if err != nil {
-			panic(fmt.Sprintf("failed to parse CIDR %s: %v", cidr, err))
-		}
-		privateNetworks = append(privateNetworks, block)
+	return block
+}
+
+func init() {
+	privateNetworks = []*net.IPNet{
+		mustParseCIDR("10.0.0.0/8"),
+		mustParseCIDR("172.16.0.0/12"),
+		mustParseCIDR("192.168.0.0/16"),
+		mustParseCIDR("127.0.0.0/8"),
+		mustParseCIDR("169.254.0.0/16"),
+		mustParseCIDR("::1/128"),
+		mustParseCIDR("fc00::/7"),
+		mustParseCIDR("fe80::/10"),
 	}
 }
 

--- a/internal/agent/router/retry.go
+++ b/internal/agent/router/retry.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -453,12 +452,4 @@ func selectEndpointExcluding(
 		return loadBalancer.Select()
 	}
 	return nil
-}
-
-// retryMetricsOnce ensures retry metrics are registered once
-var retryMetricsOnce atomic.Bool
-
-func init() {
-	// Metrics are registered in the metrics package
-	_ = retryMetricsOnce.Load()
 }

--- a/internal/agent/vip/manager.go
+++ b/internal/agent/vip/manager.go
@@ -123,7 +123,7 @@ func (m *DefaultManager) ApplyVIPs(ctx context.Context, assignments []*pb.VIPAss
 
 	// Phase 1: Compute diff under read lock
 	m.mu.RLock()
-	var actions []vipAction
+	actions := make([]vipAction, 0, len(m.assignments)+len(newAssignments))
 
 	// Find VIPs to release (no longer assigned)
 	for vipName, oldAssignment := range m.assignments {


### PR DESCRIPTION
## Summary

- Preallocate `actions` slice in vip/manager.go
- Remove no-op `init()` and unused variable in retry.go
- Remove empty filters/doc.go package (unreferenced)
- Log ParseCIDR errors in ipfilter.go (8 places) via helper function
- Log io.Copy errors at debug level in mesh tunnel and manager
- Replace raw panic in ssrf.go init() with `mustParseCIDR` helper

## Test plan
- [ ] CI passes all checks
- [ ] No behavioral regression

Resolves #386