### PR TITLE
Add test coverage for SSRF, WAF cache, and WAF rate limiter

### DIFF
--- a/internal/agent/policy/ssrf_test.go
+++ b/internal/agent/policy/ssrf_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		private bool
+	}{
+		// RFC 1918 – 10.0.0.0/8
+		{"10.0.0.0 start of range", "10.0.0.0", true},
+		{"10.0.0.1", "10.0.0.1", true},
+		{"10.255.255.255 end of range", "10.255.255.255", true},
+
+		// RFC 1918 – 172.16.0.0/12
+		{"172.16.0.1", "172.16.0.1", true},
+		{"172.31.255.255 end of range", "172.31.255.255", true},
+		{"172.15.255.255 just below range", "172.15.255.255", false},
+		{"172.32.0.0 just above range", "172.32.0.0", false},
+
+		// RFC 1918 – 192.168.0.0/16
+		{"192.168.0.1", "192.168.0.1", true},
+		{"192.168.255.255 end of range", "192.168.255.255", true},
+		{"192.167.0.1 outside range", "192.167.0.1", false},
+
+		// Loopback – 127.0.0.0/8
+		{"127.0.0.1 loopback", "127.0.0.1", true},
+		{"127.255.255.255 end of loopback", "127.255.255.255", true},
+
+		// Link-local – 169.254.0.0/16
+		{"169.254.0.1 link-local", "169.254.0.1", true},
+		{"169.254.169.254 metadata endpoint", "169.254.169.254", true},
+
+		// IPv6 loopback
+		{"::1 IPv6 loopback", "::1", true},
+
+		// IPv6 unique local (fc00::/7)
+		{"fd00::1 unique local", "fd00::1", true},
+		{"fc00::1 unique local", "fc00::1", true},
+
+		// IPv6 link-local (fe80::/10)
+		{"fe80::1 IPv6 link-local", "fe80::1", true},
+
+		// Public IPs – should NOT be private
+		{"8.8.8.8 Google DNS", "8.8.8.8", false},
+		{"1.1.1.1 Cloudflare DNS", "1.1.1.1", false},
+		{"93.184.216.34 example.com", "93.184.216.34", false},
+		{"203.0.113.1 TEST-NET-3", "203.0.113.1", false},
+		{"2001:4860:4860::8888 Google IPv6", "2001:4860:4860::8888", false},
+
+		// Edge cases
+		{"0.0.0.0 unspecified", "0.0.0.0", false},
+		{"255.255.255.255 broadcast", "255.255.255.255", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse IP %q", tt.ip)
+			}
+			got := isPrivateIP(ip)
+			if got != tt.private {
+				t.Errorf("isPrivateIP(%s) = %v, want %v", tt.ip, got, tt.private)
+			}
+		})
+	}
+}
+
+func TestPrivateNetworksInitialized(t *testing.T) {
+	// Verify that the init() function populated the private networks list
+	if len(privateNetworks) == 0 {
+		t.Fatal("privateNetworks slice is empty; init() may not have run")
+	}
+
+	// We expect exactly 8 CIDR blocks based on the source
+	expected := 8
+	if len(privateNetworks) != expected {
+		t.Errorf("expected %d private network blocks, got %d", expected, len(privateNetworks))
+	}
+}
+
+func TestNewSSRFProtectedClient(t *testing.T) {
+	timeout := 5 * time.Second
+	client := NewSSRFProtectedClient(timeout)
+
+	if client == nil {
+		t.Fatal("NewSSRFProtectedClient returned nil")
+	}
+	if client.Timeout != timeout {
+		t.Errorf("client timeout = %v, want %v", client.Timeout, timeout)
+	}
+	if client.Transport == nil {
+		t.Error("client transport is nil")
+	}
+}
+
+func TestNewSSRFProtectedTransport(t *testing.T) {
+	transport := NewSSRFProtectedTransport()
+
+	if transport == nil {
+		t.Fatal("NewSSRFProtectedTransport returned nil")
+	}
+	if transport.TLSHandshakeTimeout != 10*time.Second {
+		t.Errorf("TLSHandshakeTimeout = %v, want 10s", transport.TLSHandshakeTimeout)
+	}
+	if transport.DialContext == nil {
+		t.Error("DialContext function is nil")
+	}
+}

--- a/internal/agent/policy/waf_cache_test.go
+++ b/internal/agent/policy/waf_cache_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	pb "github.com/piwi3910/novaedge/internal/proto/gen"
+)
+
+func newTestLogger(t *testing.T) *zap.Logger {
+	t.Helper()
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("failed to create test logger: %v", err)
+	}
+	return logger
+}
+
+func TestNewWAFEngineCache(t *testing.T) {
+	logger := newTestLogger(t)
+	cache := NewWAFEngineCache(logger)
+
+	if cache == nil {
+		t.Fatal("NewWAFEngineCache returned nil")
+	}
+	if cache.Size() != 0 {
+		t.Errorf("new cache size = %d, want 0", cache.Size())
+	}
+}
+
+func TestWAFEngineCacheGetOrCreate(t *testing.T) {
+	logger := newTestLogger(t)
+	cache := NewWAFEngineCache(logger)
+
+	config := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "detection",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+	}
+
+	// First call should create a new engine (cache miss)
+	engine1, err := cache.GetOrCreate(config)
+	if err != nil {
+		t.Fatalf("GetOrCreate (first call) failed: %v", err)
+	}
+	if engine1 == nil {
+		t.Fatal("GetOrCreate returned nil engine")
+	}
+	if cache.Size() != 1 {
+		t.Errorf("cache size after first insert = %d, want 1", cache.Size())
+	}
+
+	// Second call with same config should return cached engine (cache hit)
+	engine2, err := cache.GetOrCreate(config)
+	if err != nil {
+		t.Fatalf("GetOrCreate (second call) failed: %v", err)
+	}
+	if engine1 != engine2 {
+		t.Error("expected same engine instance on cache hit, got different pointers")
+	}
+	if cache.Size() != 1 {
+		t.Errorf("cache size after cache hit = %d, want 1", cache.Size())
+	}
+}
+
+func TestWAFEngineCacheDifferentConfigs(t *testing.T) {
+	logger := newTestLogger(t)
+	cache := NewWAFEngineCache(logger)
+
+	config1 := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "detection",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+	}
+	config2 := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "prevention",
+		ParanoiaLevel:    2,
+		AnomalyThreshold: 10,
+	}
+
+	engine1, err := cache.GetOrCreate(config1)
+	if err != nil {
+		t.Fatalf("GetOrCreate config1 failed: %v", err)
+	}
+
+	engine2, err := cache.GetOrCreate(config2)
+	if err != nil {
+		t.Fatalf("GetOrCreate config2 failed: %v", err)
+	}
+
+	if engine1 == engine2 {
+		t.Error("different configs should produce different engine instances")
+	}
+	if cache.Size() != 2 {
+		t.Errorf("cache size = %d, want 2", cache.Size())
+	}
+}
+
+func TestWAFEngineCachePurge(t *testing.T) {
+	logger := newTestLogger(t)
+	cache := NewWAFEngineCache(logger)
+
+	config := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "detection",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+	}
+
+	_, err := cache.GetOrCreate(config)
+	if err != nil {
+		t.Fatalf("GetOrCreate failed: %v", err)
+	}
+
+	if cache.Size() != 1 {
+		t.Fatalf("cache size before purge = %d, want 1", cache.Size())
+	}
+
+	cache.Purge()
+
+	if cache.Size() != 0 {
+		t.Errorf("cache size after purge = %d, want 0", cache.Size())
+	}
+
+	// After purge, same config should create a new engine
+	_, err = cache.GetOrCreate(config)
+	if err != nil {
+		t.Fatalf("GetOrCreate after purge failed: %v", err)
+	}
+	if cache.Size() != 1 {
+		t.Errorf("cache size after re-insert = %d, want 1", cache.Size())
+	}
+}
+
+func TestConfigHash(t *testing.T) {
+	config1 := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "detection",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+	}
+	config2 := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "detection",
+		ParanoiaLevel:    1,
+		AnomalyThreshold: 5,
+	}
+	config3 := &pb.WAFConfig{
+		Enabled:          true,
+		Mode:             "prevention",
+		ParanoiaLevel:    2,
+		AnomalyThreshold: 10,
+	}
+
+	hash1, err := configHash(config1)
+	if err != nil {
+		t.Fatalf("configHash(config1) failed: %v", err)
+	}
+	hash2, err := configHash(config2)
+	if err != nil {
+		t.Fatalf("configHash(config2) failed: %v", err)
+	}
+	hash3, err := configHash(config3)
+	if err != nil {
+		t.Fatalf("configHash(config3) failed: %v", err)
+	}
+
+	// Identical configs must produce the same hash
+	if hash1 != hash2 {
+		t.Errorf("identical configs produced different hashes: %s vs %s", hash1, hash2)
+	}
+
+	// Different configs must produce different hashes
+	if hash1 == hash3 {
+		t.Error("different configs produced the same hash")
+	}
+
+	// Hash should be a valid hex string of SHA-256 length (64 chars)
+	if len(hash1) != 64 {
+		t.Errorf("hash length = %d, want 64 (SHA-256 hex)", len(hash1))
+	}
+}
+
+func TestConfigHashNilConfig(t *testing.T) {
+	// nil protobuf message should still produce a valid hash (empty message)
+	hash, err := configHash(nil)
+	if err != nil {
+		t.Fatalf("configHash(nil) failed: %v", err)
+	}
+	if len(hash) != 64 {
+		t.Errorf("hash length = %d, want 64", len(hash))
+	}
+}

--- a/internal/agent/policy/waf_ratelimit_test.go
+++ b/internal/agent/policy/waf_ratelimit_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewWAFMatchCounter(t *testing.T) {
+	counter := NewWAFMatchCounter(5 * time.Minute)
+	if counter == nil {
+		t.Fatal("NewWAFMatchCounter returned nil")
+	}
+	if counter.ttl != 5*time.Minute {
+		t.Errorf("TTL = %v, want 5m", counter.ttl)
+	}
+}
+
+func TestWAFMatchCounterIncrement(t *testing.T) {
+	counter := NewWAFMatchCounter(5 * time.Minute)
+
+	// Initial count should be zero
+	if got := counter.Get("192.0.2.1"); got != 0 {
+		t.Errorf("initial count = %d, want 0", got)
+	}
+
+	// Increment and verify
+	counter.Increment("192.0.2.1")
+	if got := counter.Get("192.0.2.1"); got != 1 {
+		t.Errorf("count after 1 increment = %d, want 1", got)
+	}
+
+	counter.Increment("192.0.2.1")
+	counter.Increment("192.0.2.1")
+	if got := counter.Get("192.0.2.1"); got != 3 {
+		t.Errorf("count after 3 increments = %d, want 3", got)
+	}
+}
+
+func TestWAFMatchCounterMultipleIPs(t *testing.T) {
+	counter := NewWAFMatchCounter(5 * time.Minute)
+
+	counter.Increment("192.0.2.1")
+	counter.Increment("192.0.2.1")
+	counter.Increment("198.51.100.1")
+
+	if got := counter.Get("192.0.2.1"); got != 2 {
+		t.Errorf("count for 192.0.2.1 = %d, want 2", got)
+	}
+	if got := counter.Get("198.51.100.1"); got != 1 {
+		t.Errorf("count for 198.51.100.1 = %d, want 1", got)
+	}
+	if got := counter.Get("203.0.113.1"); got != 0 {
+		t.Errorf("count for unknown IP = %d, want 0", got)
+	}
+}
+
+func TestWAFMatchCounterExpiry(t *testing.T) {
+	ttl := 10 * time.Minute
+	counter := NewWAFMatchCounter(ttl)
+
+	// Use a controllable time function
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	counter.nowFunc = func() time.Time { return now }
+
+	counter.Increment("192.0.2.1")
+	counter.Increment("192.0.2.1")
+	counter.Increment("192.0.2.1")
+
+	if got := counter.Get("192.0.2.1"); got != 3 {
+		t.Fatalf("count before expiry = %d, want 3", got)
+	}
+
+	// Advance time past TTL
+	now = now.Add(ttl + 1*time.Second)
+
+	// Get should return 0 for expired entry
+	if got := counter.Get("192.0.2.1"); got != 0 {
+		t.Errorf("count after expiry = %d, want 0", got)
+	}
+}
+
+func TestWAFMatchCounterExpiryResetsCount(t *testing.T) {
+	ttl := 5 * time.Minute
+	counter := NewWAFMatchCounter(ttl)
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	counter.nowFunc = func() time.Time { return now }
+
+	counter.Increment("192.0.2.1")
+	counter.Increment("192.0.2.1")
+	counter.Increment("192.0.2.1")
+
+	if got := counter.Get("192.0.2.1"); got != 3 {
+		t.Fatalf("count before expiry = %d, want 3", got)
+	}
+
+	// Advance past TTL
+	now = now.Add(ttl + 1*time.Second)
+
+	// Increment after expiry should reset count to 1
+	counter.Increment("192.0.2.1")
+	if got := counter.Get("192.0.2.1"); got != 1 {
+		t.Errorf("count after expiry + increment = %d, want 1 (should have reset)", got)
+	}
+}
+
+func TestWAFMatchCounterCleanup(t *testing.T) {
+	ttl := 5 * time.Minute
+	counter := NewWAFMatchCounter(ttl)
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	counter.nowFunc = func() time.Time { return now }
+
+	counter.Increment("192.0.2.1")
+	counter.Increment("198.51.100.1")
+	counter.Increment("203.0.113.1")
+
+	// All three should be present
+	if got := len(counter.counts); got != 3 {
+		t.Fatalf("entries before cleanup = %d, want 3", got)
+	}
+
+	// Advance time to expire all entries
+	now = now.Add(ttl + 1*time.Second)
+
+	counter.Cleanup()
+
+	if got := len(counter.counts); got != 0 {
+		t.Errorf("entries after cleanup = %d, want 0", got)
+	}
+}
+
+func TestWAFMatchCounterCleanupPartial(t *testing.T) {
+	ttl := 5 * time.Minute
+	counter := NewWAFMatchCounter(ttl)
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	counter.nowFunc = func() time.Time { return now }
+
+	counter.Increment("192.0.2.1") // old entry
+
+	// Advance 3 minutes
+	now = now.Add(3 * time.Minute)
+	counter.Increment("198.51.100.1") // newer entry
+
+	// Advance another 3 minutes (total 6 from start, 3 from second)
+	now = now.Add(3 * time.Minute)
+
+	// First entry is now 6min old (expired), second is 3min old (still valid)
+	counter.Cleanup()
+
+	if got := len(counter.counts); got != 1 {
+		t.Errorf("entries after partial cleanup = %d, want 1", got)
+	}
+	if got := counter.Get("192.0.2.1"); got != 0 {
+		t.Errorf("expired entry count = %d, want 0", got)
+	}
+	if got := counter.Get("198.51.100.1"); got != 1 {
+		t.Errorf("valid entry count = %d, want 1", got)
+	}
+}
+
+func TestWAFMatchCounterGetNonExistent(t *testing.T) {
+	counter := NewWAFMatchCounter(5 * time.Minute)
+
+	if got := counter.Get("nonexistent"); got != 0 {
+		t.Errorf("count for non-existent key = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add 26 table-driven tests for SSRF private IP detection in `ssrf_test.go`
- Add 6 tests for WAF engine cache behavior in `waf_cache_test.go`
- Add 8 tests for WAF match counter/rate limiting in `waf_ratelimit_test.go`
- 27 new tests total, all passing

## Test plan
- [x] `go test -v ./internal/agent/policy/...` passes (27 new tests)
- [x] All 5 binaries build successfully
- [ ] CI passes all checks

Resolves #384