### PR TITLE
Update Web UI for v1.2.x features: federation, load shedding, WASM plugins, dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,8 @@ const Traces = lazy(() => import('./pages/Traces'))
 const Logs = lazy(() => import('./pages/Logs'))
 const WAFEvents = lazy(() => import('./pages/WAFEvents'))
 const ConfigPage = lazy(() => import('./pages/Config'))
+const LoadShedding = lazy(() => import('./pages/LoadShedding'))
+const WASMPlugins = lazy(() => import('./pages/WASMPlugins'))
 
 function LoadingFallback() {
   return (
@@ -112,6 +114,8 @@ export default function App() {
             <Route path="/logs" element={<Logs />} />
             <Route path="/waf" element={<WAFEvents />} />
             <Route path="/config" element={<ConfigPage />} />
+            <Route path="/load-shedding" element={<LoadShedding />} />
+            <Route path="/wasm-plugins" element={<WASMPlugins />} />
           </Routes>
         </Suspense>
       </AppLayout>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -22,6 +22,12 @@ import type {
   MeshTopology,
   ConfigSnapshot,
   ConfigDiff,
+  Federation,
+  RemoteCluster,
+  OverloadConfig,
+  OverloadStatus,
+  WASMPluginConfig,
+  WASMPluginStatus,
 } from './types'
 import {
   normalizeGateways,
@@ -289,20 +295,20 @@ const clustersAPI = {
 
 // Federations CRUD
 const federationsAPI = {
-  list: async (namespace: string = 'all'): Promise<GenericResource[]> => {
-    return fetchJSON<GenericResource[]>(`${API_BASE}/federations?namespace=${namespace}`)
+  list: async (namespace: string = 'all'): Promise<Federation[]> => {
+    return fetchJSON<Federation[]>(`${API_BASE}/federations?namespace=${namespace}`)
   },
-  get: async (namespace: string, name: string): Promise<GenericResource> => {
-    return fetchJSON<GenericResource>(`${API_BASE}/federations/${namespace}/${name}`)
+  get: async (namespace: string, name: string): Promise<Federation> => {
+    return fetchJSON<Federation>(`${API_BASE}/federations/${namespace}/${name}`)
   },
-  create: async (resource: GenericResource): Promise<GenericResource> => {
-    return fetchJSON<GenericResource>(`${API_BASE}/federations`, {
+  create: async (resource: Federation): Promise<Federation> => {
+    return fetchJSON<Federation>(`${API_BASE}/federations`, {
       method: 'POST',
       body: JSON.stringify(resource),
     })
   },
-  update: async (namespace: string, name: string, resource: GenericResource): Promise<GenericResource> => {
-    return fetchJSON<GenericResource>(`${API_BASE}/federations/${namespace}/${name}`, {
+  update: async (namespace: string, name: string, resource: Federation): Promise<Federation> => {
+    return fetchJSON<Federation>(`${API_BASE}/federations/${namespace}/${name}`, {
       method: 'PUT',
       body: JSON.stringify(resource),
     })
@@ -314,26 +320,52 @@ const federationsAPI = {
 
 // Remote Clusters CRUD
 const remoteclustersAPI = {
-  list: async (namespace: string = 'all'): Promise<GenericResource[]> => {
-    return fetchJSON<GenericResource[]>(`${API_BASE}/remoteclusters?namespace=${namespace}`)
+  list: async (namespace: string = 'all'): Promise<RemoteCluster[]> => {
+    return fetchJSON<RemoteCluster[]>(`${API_BASE}/remoteclusters?namespace=${namespace}`)
   },
-  get: async (namespace: string, name: string): Promise<GenericResource> => {
-    return fetchJSON<GenericResource>(`${API_BASE}/remoteclusters/${namespace}/${name}`)
+  get: async (namespace: string, name: string): Promise<RemoteCluster> => {
+    return fetchJSON<RemoteCluster>(`${API_BASE}/remoteclusters/${namespace}/${name}`)
   },
-  create: async (resource: GenericResource): Promise<GenericResource> => {
-    return fetchJSON<GenericResource>(`${API_BASE}/remoteclusters`, {
+  create: async (resource: RemoteCluster): Promise<RemoteCluster> => {
+    return fetchJSON<RemoteCluster>(`${API_BASE}/remoteclusters`, {
       method: 'POST',
       body: JSON.stringify(resource),
     })
   },
-  update: async (namespace: string, name: string, resource: GenericResource): Promise<GenericResource> => {
-    return fetchJSON<GenericResource>(`${API_BASE}/remoteclusters/${namespace}/${name}`, {
+  update: async (namespace: string, name: string, resource: RemoteCluster): Promise<RemoteCluster> => {
+    return fetchJSON<RemoteCluster>(`${API_BASE}/remoteclusters/${namespace}/${name}`, {
       method: 'PUT',
       body: JSON.stringify(resource),
     })
   },
   delete: async (namespace: string, name: string): Promise<void> => {
     await fetchJSON<{ status: string }>(`${API_BASE}/remoteclusters/${namespace}/${name}`, { method: 'DELETE' })
+  },
+}
+
+// Overload/Load Shedding
+const overloadAPI = {
+  status: async (): Promise<OverloadStatus> => {
+    return fetchJSON<OverloadStatus>(`${API_BASE}/overload/status`)
+  },
+  config: async (): Promise<OverloadConfig> => {
+    return fetchJSON<OverloadConfig>(`${API_BASE}/overload/config`)
+  },
+  updateConfig: async (config: OverloadConfig): Promise<OverloadConfig> => {
+    return fetchJSON<OverloadConfig>(`${API_BASE}/overload/config`, {
+      method: 'PUT',
+      body: JSON.stringify(config),
+    })
+  },
+}
+
+// WASM Plugins
+const wasmPluginsAPI = {
+  list: async (): Promise<WASMPluginStatus[]> => {
+    return fetchJSON<WASMPluginStatus[]>(`${API_BASE}/wasm/plugins`)
+  },
+  get: async (name: string): Promise<WASMPluginConfig> => {
+    return fetchJSON<WASMPluginConfig>(`${API_BASE}/wasm/plugins/${name}`)
   },
 }
 
@@ -379,6 +411,8 @@ export const api = {
   clusters: clustersAPI,
   federations: federationsAPI,
   remoteclusters: remoteclustersAPI,
+  overload: overloadAPI,
+  wasmPlugins: wasmPluginsAPI,
 
   // Agents
   agents: {

--- a/web/src/api/hooks.ts
+++ b/web/src/api/hooks.ts
@@ -11,6 +11,12 @@ import type {
   Certificate,
   IPPool,
   GenericResource,
+  Federation,
+  RemoteCluster,
+  OverloadConfig,
+  OverloadStatus,
+  WASMPluginConfig,
+  WASMPluginStatus,
   Trace,
   KubeEvent,
   WAFSummary,
@@ -548,14 +554,14 @@ export function useDeleteCluster() {
 
 // Federations
 export function useFederations(namespace: string) {
-  return useQuery<GenericResource[]>({
+  return useQuery<Federation[]>({
     queryKey: ['federations', namespace],
     queryFn: () => api.federations.list(namespace),
   })
 }
 
 export function useFederation(namespace: string, name: string) {
-  return useQuery<GenericResource>({
+  return useQuery<Federation>({
     queryKey: ['federations', namespace, name],
     queryFn: () => api.federations.get(namespace, name),
     enabled: !!namespace && !!name,
@@ -565,7 +571,7 @@ export function useFederation(namespace: string, name: string) {
 export function useCreateFederation() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (federation: GenericResource) => api.federations.create(federation),
+    mutationFn: (federation: Federation) => api.federations.create(federation),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['federations'] })
       toast({ title: 'Federation created successfully', variant: 'success' as const })
@@ -579,7 +585,7 @@ export function useCreateFederation() {
 export function useUpdateFederation() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ namespace, name, federation }: { namespace: string; name: string; federation: GenericResource }) =>
+    mutationFn: ({ namespace, name, federation }: { namespace: string; name: string; federation: Federation }) =>
       api.federations.update(namespace, name, federation),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['federations'] })
@@ -608,14 +614,14 @@ export function useDeleteFederation() {
 
 // Remote Clusters
 export function useRemoteClusters(namespace: string) {
-  return useQuery<GenericResource[]>({
+  return useQuery<RemoteCluster[]>({
     queryKey: ['remoteclusters', namespace],
     queryFn: () => api.remoteclusters.list(namespace),
   })
 }
 
 export function useRemoteCluster(namespace: string, name: string) {
-  return useQuery<GenericResource>({
+  return useQuery<RemoteCluster>({
     queryKey: ['remoteclusters', namespace, name],
     queryFn: () => api.remoteclusters.get(namespace, name),
     enabled: !!namespace && !!name,
@@ -625,7 +631,7 @@ export function useRemoteCluster(namespace: string, name: string) {
 export function useCreateRemoteCluster() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (remoteCluster: GenericResource) => api.remoteclusters.create(remoteCluster),
+    mutationFn: (rc: RemoteCluster) => api.remoteclusters.create(rc),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['remoteclusters'] })
       toast({ title: 'Remote cluster created successfully', variant: 'success' as const })
@@ -639,8 +645,8 @@ export function useCreateRemoteCluster() {
 export function useUpdateRemoteCluster() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ namespace, name, remoteCluster }: { namespace: string; name: string; remoteCluster: GenericResource }) =>
-      api.remoteclusters.update(namespace, name, remoteCluster),
+    mutationFn: ({ namespace, name, rc }: { namespace: string; name: string; rc: RemoteCluster }) =>
+      api.remoteclusters.update(namespace, name, rc),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['remoteclusters'] })
       toast({ title: 'Remote cluster updated successfully', variant: 'success' as const })
@@ -663,6 +669,52 @@ export function useDeleteRemoteCluster() {
     onError: (error: Error) => {
       toast({ title: 'Failed to delete remote cluster', description: error.message, variant: 'destructive' })
     },
+  })
+}
+
+// Overload/Load Shedding
+export function useOverloadStatus() {
+  return useQuery<OverloadStatus>({
+    queryKey: ['overload', 'status'],
+    queryFn: () => api.overload.status(),
+    refetchInterval: 5000,
+  })
+}
+
+export function useOverloadConfig() {
+  return useQuery<OverloadConfig>({
+    queryKey: ['overload', 'config'],
+    queryFn: () => api.overload.config(),
+  })
+}
+
+export function useUpdateOverloadConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config: OverloadConfig) => api.overload.updateConfig(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['overload'] })
+      toast({ title: 'Load shedding config updated', variant: 'success' as const })
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to update config', description: error.message, variant: 'destructive' })
+    },
+  })
+}
+
+// WASM Plugins
+export function useWASMPlugins() {
+  return useQuery<WASMPluginStatus[]>({
+    queryKey: ['wasm', 'plugins'],
+    queryFn: () => api.wasmPlugins.list(),
+  })
+}
+
+export function useWASMPlugin(name: string) {
+  return useQuery<WASMPluginConfig>({
+    queryKey: ['wasm', 'plugins', name],
+    queryFn: () => api.wasmPlugins.get(name),
+    enabled: !!name,
   })
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -90,6 +90,8 @@ export interface RouteSpec {
   parentRefs?: ObjectRef[]
   hostnames?: string[]
   rules?: RouteRule[]
+  faultInjection?: FaultInjectionConfig
+  bodyTransform?: BodyTransformConfig
 }
 
 export interface RouteRule {
@@ -181,6 +183,8 @@ export interface BackendSpec {
   circuitBreaker?: CircuitBreaker
   connectionPool?: ConnectionPool
   tls?: BackendTLS
+  slowStart?: SlowStartConfig
+  outlierDetection?: OutlierDetectionConfig
 }
 
 export interface BackendStatus {
@@ -631,6 +635,158 @@ export interface ConfigSnapshot {
 export interface ConfigDiff {
   from: ConfigSnapshot
   to: ConfigSnapshot
+}
+
+// Federation types
+export interface FederationSpec {
+  mode: 'hub-spoke' | 'mesh' | 'unified'
+  syncInterval?: string
+  conflictResolution?: string
+  members?: FederationMember[]
+  antiEntropy?: {
+    enabled: boolean
+    interval?: string
+    repairMode?: string
+  }
+  splitBrain?: {
+    enabled: boolean
+    quorum?: number
+    partitionTimeout?: string
+    autoHeal?: boolean
+  }
+}
+
+export interface FederationMember {
+  name: string
+  endpoint: string
+  role?: string
+}
+
+export interface FederationStatus {
+  phase: string
+  conditions?: Condition[]
+  members?: FederationMemberStatus[]
+  lastSyncTime?: string
+  splitBrainState?: string
+}
+
+export interface FederationMemberStatus {
+  name: string
+  connected: boolean
+  lastSeen?: string
+  syncState?: string
+  endpointCount?: number
+}
+
+export interface Federation {
+  metadata: ResourceMetadata
+  spec: FederationSpec
+  status?: FederationStatus
+}
+
+export interface RemoteClusterSpec {
+  endpoint: string
+  federationRef?: string
+  tunnel?: {
+    type: 'wireguard' | 'ssh' | 'websocket' | 'none'
+    config?: Record<string, string>
+  }
+  tls?: {
+    secretName?: string
+    insecureSkipVerify?: boolean
+  }
+}
+
+export interface RemoteClusterStatus {
+  connected: boolean
+  lastSeen?: string
+  tunnelState?: string
+  conditions?: Condition[]
+}
+
+export interface RemoteCluster {
+  metadata: ResourceMetadata
+  spec: RemoteClusterSpec
+  status?: RemoteClusterStatus
+}
+
+// Fault injection types
+export interface FaultInjectionConfig {
+  delayDuration?: string
+  delayPercent?: number
+  abortStatusCode?: number
+  abortPercent?: number
+  headerActivation?: string
+}
+
+// Slow start types
+export interface SlowStartConfig {
+  window?: string
+  aggression?: number
+}
+
+// Outlier detection types
+export interface OutlierDetectionConfig {
+  interval?: string
+  consecutive5xxThreshold?: number
+  baseEjectionDuration?: string
+  maxEjectionPercent?: number
+  successRateMinHosts?: number
+  successRateMinRequests?: number
+  successRateStdevFactor?: number
+}
+
+// Body transformation types
+export interface TransformOperation {
+  op: 'add' | 'remove' | 'replace' | 'move' | 'copy'
+  path: string
+  value?: unknown
+  from?: string
+}
+
+export interface BodyTransformConfig {
+  requestTransforms?: TransformOperation[]
+  responseTransforms?: TransformOperation[]
+  maxBodySize?: number
+}
+
+// Overload/Load shedding types
+export interface OverloadConfig {
+  enabled: boolean
+  heapMemoryTriggerPercent?: number
+  heapMemoryRecoverPercent?: number
+  goroutineTriggerCount?: number
+  goroutineRecoverCount?: number
+  activeConnectionTriggerCount?: number
+  activeConnectionRecoverCount?: number
+  checkInterval?: string
+}
+
+export interface OverloadStatus {
+  state: 'normal' | 'overloaded'
+  heapUsageRatio: number
+  goroutineCount: number
+  activeConnections: number
+  totalShed: number
+}
+
+// WASM plugin types
+export interface WASMPluginConfig {
+  name: string
+  path: string
+  phase?: 'request' | 'response'
+  priority?: number
+  config?: Record<string, unknown>
+  memoryLimitMB?: number
+  timeoutMs?: number
+}
+
+export interface WASMPluginStatus {
+  name: string
+  loaded: boolean
+  invocations: number
+  errors: number
+  avgLatencyMs: number
 }
 
 // Resource type for generic handling

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -21,6 +21,8 @@ import {
   Download,
   Upload,
   History,
+  Puzzle,
+  Zap,
   type LucideIcon,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -52,6 +54,7 @@ const navGroups: NavGroup[] = [
       { name: 'Routes', path: '/routes', icon: GitBranch },
       { name: 'Backends', path: '/backends', icon: Server },
       { name: 'Policies', path: '/policies', icon: Shield },
+      { name: 'Load Shedding', path: '/load-shedding', icon: Zap },
     ],
   },
   {
@@ -84,6 +87,12 @@ const navGroups: NavGroup[] = [
       { name: 'Traces', path: '/traces', icon: Waypoints },
       { name: 'Logs', path: '/logs', icon: ScrollText },
       { name: 'WAF Events', path: '/waf', icon: ShieldAlert },
+    ],
+  },
+  {
+    label: 'Extensions',
+    items: [
+      { name: 'WASM Plugins', path: '/wasm-plugins', icon: Puzzle },
     ],
   },
   {

--- a/web/src/pages/Backends.tsx
+++ b/web/src/pages/Backends.tsx
@@ -104,6 +104,21 @@ export default function Backends() {
       ),
     },
     {
+      key: 'slowStart',
+      header: 'Slow Start',
+      accessor: (row) => row.spec?.slowStart?.window ?? '-',
+    },
+    {
+      key: 'outlierDetection',
+      header: 'Outlier Detection',
+      accessor: (row) =>
+        row.spec?.outlierDetection ? (
+          <Badge className="bg-blue-500 hover:bg-blue-600">Enabled</Badge>
+        ) : (
+          '-'
+        ),
+    },
+    {
       key: 'age',
       header: 'Age',
       accessor: (row) =>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -13,6 +13,8 @@ import {
   useRemoteClusters,
   useAgents,
   useEvents,
+  useOverloadStatus,
+  useWASMPlugins,
 } from '@/api/hooks'
 import { MetricCard } from '@/components/metrics/MetricCard'
 import { MetricsChart } from '@/components/metrics/MetricsChart'
@@ -34,6 +36,9 @@ import {
   Globe,
   MonitorCheck,
   CalendarClock,
+  Zap,
+  Puzzle,
+  ShieldAlert,
 } from 'lucide-react'
 import { formatBytes, formatUptime } from '@/lib/utils'
 import {
@@ -61,6 +66,8 @@ export default function Dashboard() {
   const { data: remoteClusters = [] } = useRemoteClusters(namespace)
   const { data: agents = [] } = useAgents()
   const { data: events = [] } = useEvents()
+  const { data: overloadStatus } = useOverloadStatus()
+  const { data: wasmPlugins = [] } = useWASMPlugins()
 
   const readyAgents = agents.filter((a) => a.ready).length
   const totalAgents = agents.length
@@ -79,6 +86,29 @@ export default function Dashboard() {
   ]
 
   const hasMetrics = metrics && !metricsError
+
+  // Federation derived data
+  const connectedClusters = remoteClusters.filter(
+    (rc) => rc.status?.connected === true
+  ).length
+
+  // Fault injection: count routes that have faultInjection configured
+  const faultInjectionCount = routes.filter(
+    (r) => r.spec?.faultInjection
+  ).length
+
+  // Slow start: count backends that have slowStart configured
+  const slowStartCount = backends.filter(
+    (b) => b.spec?.slowStart
+  ).length
+
+  // Outlier detection ejected: count backends with outlierDetection
+  const outlierDetectionCount = backends.filter(
+    (b) => b.spec?.outlierDetection
+  ).length
+
+  // WASM plugins loaded
+  const loadedPlugins = wasmPlugins.filter((p) => p.loaded).length
 
   // Recent events (last 10)
   const recentEvents = events.slice(0, 10)
@@ -126,6 +156,106 @@ export default function Dashboard() {
             />
           </Link>
         ))}
+      </div>
+
+      {/* Federation Status, Load Shedding, Active Features */}
+      <div className="grid gap-4 md:grid-cols-3">
+        {/* Federation Status */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Globe className="h-4 w-4" />
+              Federation Status
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {federations.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No federations configured</p>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Federations</span>
+                  <span className="font-medium">{federations.length}</span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Connected Clusters</span>
+                  <Badge variant="outline">{connectedClusters}/{remoteClusters.length}</Badge>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Sync Status</span>
+                  <Badge className={connectedClusters === remoteClusters.length && remoteClusters.length > 0 ? 'bg-green-500' : remoteClusters.length > 0 ? 'bg-yellow-500' : ''}>
+                    {connectedClusters === remoteClusters.length && remoteClusters.length > 0 ? 'Synced' : remoteClusters.length > 0 ? 'Partial' : 'N/A'}
+                  </Badge>
+                </div>
+                <Link to="/federation" className="text-xs text-primary hover:underline block pt-1">
+                  View Federation Details
+                </Link>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Load Shedding Status */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <ShieldAlert className="h-4 w-4" />
+              Load Shedding
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">State</span>
+                <Badge className={overloadStatus?.state === 'overloaded' ? 'bg-red-500' : 'bg-green-500'}>
+                  {overloadStatus?.state === 'overloaded' ? 'Overloaded' : 'Normal'}
+                </Badge>
+              </div>
+              {overloadStatus?.state === 'overloaded' && (
+                <div className="flex items-center gap-2 text-sm text-yellow-600 dark:text-yellow-400">
+                  <Zap className="h-3 w-3" />
+                  <span>Shedding active</span>
+                </div>
+              )}
+              {overloadStatus && (
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Total Shed</span>
+                  <span className="font-medium">{overloadStatus.totalShed}</span>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Active Features Summary */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Puzzle className="h-4 w-4" />
+              Active Features
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Fault Injection Rules</span>
+                <span className="font-medium">{faultInjectionCount}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Endpoints in Slow Start</span>
+                <span className="font-medium">{slowStartCount}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Outlier Detection</span>
+                <span className="font-medium">{outlierDetectionCount}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">WASM Plugins Loaded</span>
+                <span className="font-medium">{loadedPlugins}</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       {/* Recent Events */}

--- a/web/src/pages/Federation.tsx
+++ b/web/src/pages/Federation.tsx
@@ -10,7 +10,7 @@ import {
   useUpdateRemoteCluster,
   useDeleteRemoteCluster,
 } from '@/api/hooks'
-import type { GenericResource } from '@/api/types'
+import type { Federation as FederationType, RemoteCluster } from '@/api/types'
 import { DataTable, Column } from '@/components/common/DataTable'
 import { ConfirmDialog } from '@/components/common/ConfirmDialog'
 import { ResourceDialog } from '@/components/resources/ResourceDialog'
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Plus, Trash2 } from 'lucide-react'
+import { formatAge } from '@/lib/utils'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/api/client'
 import { toast } from '@/hooks/use-toast'
@@ -25,11 +26,20 @@ import { toast } from '@/hooks/use-toast'
 const DEFAULT_FEDERATION_YAML = `apiVersion: novaedge.io/v1alpha1
 kind: NovaEdgeFederation
 metadata:
-  name: example-federation
+  name: my-federation
   namespace: novaedge-system
 spec:
-  mode: hub-spoke
-  clusters: []
+  mode: mesh
+  syncInterval: "30s"
+  antiEntropy:
+    enabled: true
+    interval: "60s"
+    repairMode: bidirectional
+  splitBrain:
+    enabled: true
+    quorum: 2
+    partitionTimeout: "30s"
+    autoHeal: true
 `
 
 const DEFAULT_REMOTE_CLUSTER_YAML = `apiVersion: novaedge.io/v1alpha1
@@ -38,35 +48,144 @@ metadata:
   name: remote-cluster-1
   namespace: novaedge-system
 spec:
-  endpoint: https://remote-cluster:6443
-  secretRef:
-    name: remote-kubeconfig
+  endpoint: "https://remote-cluster:6443"
+  tunnel:
+    type: wireguard
+  tls:
+    secretName: remote-cluster-tls
 `
 
-function getGenericStatus(resource: GenericResource): { text: string; ready: boolean } {
-  const phase = resource.status?.phase as string | undefined
-  if (phase) {
-    return { text: phase, ready: phase === 'Ready' || phase === 'Running' || phase === 'Active' }
-  }
-
-  const conditions = resource.status?.conditions as Array<{ type: string; status: string }> | undefined
-  if (conditions) {
-    const readyCondition = conditions.find((c) => c.type === 'Ready')
-    if (readyCondition) {
-      return { text: readyCondition.status === 'True' ? 'Ready' : 'Not Ready', ready: readyCondition.status === 'True' }
-    }
-  }
-
-  return { text: 'Unknown', ready: false }
-}
-
-function formatLastSync(lastSyncTime: unknown): string {
-  if (!lastSyncTime || typeof lastSyncTime !== 'string') return 'N/A'
+function formatLastSync(lastSyncTime: string | undefined): string {
+  if (!lastSyncTime) return 'N/A'
   try {
     return new Date(lastSyncTime).toLocaleString()
   } catch {
     return String(lastSyncTime)
   }
+}
+
+function getModeBadge(mode: string | undefined) {
+  const modeStr = (mode ?? '').toLowerCase()
+  switch (modeStr) {
+    case 'hub-spoke':
+      return (
+        <Badge className="bg-blue-500 hover:bg-blue-600 text-white">
+          hub-spoke
+        </Badge>
+      )
+    case 'mesh':
+      return (
+        <Badge className="bg-purple-500 hover:bg-purple-600 text-white">
+          mesh
+        </Badge>
+      )
+    case 'unified':
+      return (
+        <Badge className="bg-green-500 hover:bg-green-600 text-white">
+          unified
+        </Badge>
+      )
+    default:
+      return <Badge variant="secondary">{mode ?? '-'}</Badge>
+  }
+}
+
+function getSplitBrainBadge(state: string | undefined) {
+  const stateStr = (state ?? '').toLowerCase()
+  switch (stateStr) {
+    case 'healthy':
+      return (
+        <Badge className="bg-green-500 hover:bg-green-600 text-white">
+          healthy
+        </Badge>
+      )
+    case 'detected':
+      return (
+        <Badge className="bg-red-500 hover:bg-red-600 text-white">
+          detected
+        </Badge>
+      )
+    case 'healing':
+      return (
+        <Badge className="bg-yellow-500 hover:bg-yellow-600 text-white">
+          healing
+        </Badge>
+      )
+    default:
+      return <Badge variant="outline">{state ?? 'N/A'}</Badge>
+  }
+}
+
+function getSyncStatusBadge(phase: string | undefined) {
+  const phaseStr = (phase ?? '').toLowerCase()
+  if (phaseStr === 'synced' || phaseStr === 'insync' || phaseStr === 'in-sync' || phaseStr === 'ready' || phaseStr === 'active') {
+    return (
+      <Badge className="bg-green-500 hover:bg-green-600 text-white">
+        {phase}
+      </Badge>
+    )
+  }
+  if (phaseStr === 'syncing' || phaseStr === 'pending' || phaseStr === 'reconciling') {
+    return (
+      <Badge className="bg-yellow-500 hover:bg-yellow-600 text-white">
+        {phase}
+      </Badge>
+    )
+  }
+  if (phaseStr === 'error' || phaseStr === 'failed' || phaseStr === 'degraded') {
+    return (
+      <Badge className="bg-red-500 hover:bg-red-600 text-white">
+        {phase}
+      </Badge>
+    )
+  }
+  return <Badge variant="outline">{phase ?? 'N/A'}</Badge>
+}
+
+function getTunnelTypeBadge(tunnelType: string | undefined) {
+  const typeStr = (tunnelType ?? '').toLowerCase()
+  switch (typeStr) {
+    case 'wireguard':
+      return (
+        <Badge className="bg-blue-500 hover:bg-blue-600 text-white">
+          wireguard
+        </Badge>
+      )
+    case 'ssh':
+      return (
+        <Badge className="bg-yellow-500 hover:bg-yellow-600 text-white">
+          ssh
+        </Badge>
+      )
+    case 'websocket':
+      return (
+        <Badge className="bg-purple-500 hover:bg-purple-600 text-white">
+          websocket
+        </Badge>
+      )
+    case 'none':
+    case '':
+      return <Badge variant="secondary">none</Badge>
+    default:
+      return <Badge variant="outline">{tunnelType ?? 'none'}</Badge>
+  }
+}
+
+function getConnectedIndicator(connected: boolean | undefined) {
+  if (connected) {
+    return (
+      <span className="flex items-center gap-2">
+        <span className="inline-block h-2.5 w-2.5 rounded-full bg-green-500" />
+        Yes
+      </span>
+    )
+  }
+  return (
+    <span className="flex items-center gap-2">
+      <span className="inline-block h-2.5 w-2.5 rounded-full bg-red-500" />
+      No
+    </span>
+  )
 }
 
 // --- Federations Sub-Component ---
@@ -106,12 +225,12 @@ function FederationsTab() {
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set())
   const [dialogOpen, setDialogOpen] = useState(false)
   const [dialogMode, setDialogMode] = useState<'create' | 'edit' | 'view'>('create')
-  const [currentFederation, setCurrentFederation] = useState<GenericResource | undefined>()
+  const [currentFederation, setCurrentFederation] = useState<FederationType | undefined>()
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [federationToDelete, setFederationToDelete] = useState<GenericResource | null>(null)
+  const [federationToDelete, setFederationToDelete] = useState<FederationType | null>(null)
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false)
 
-  const columns: Column<GenericResource>[] = [
+  const columns: Column<FederationType>[] = [
     {
       key: 'name',
       header: 'Name',
@@ -119,42 +238,45 @@ function FederationsTab() {
       sortable: true,
     },
     {
-      key: 'namespace',
-      header: 'Namespace',
-      accessor: (row) => (
-        <Badge variant="outline">{row.metadata?.namespace ?? '-'}</Badge>
-      ),
+      key: 'mode',
+      header: 'Mode',
+      accessor: (row) => getModeBadge(row.spec?.mode),
+    },
+    {
+      key: 'members',
+      header: 'Members',
+      accessor: (row) => {
+        const specMembers = row.spec?.members
+        const statusMembers = row.status?.members
+        const count = specMembers?.length ?? statusMembers?.length ?? 0
+        return count
+      },
       sortable: true,
     },
     {
-      key: 'mode',
-      header: 'Mode',
-      accessor: (row) => (row.spec?.mode as string) ?? '-',
+      key: 'syncStatus',
+      header: 'Sync Status',
+      accessor: (row) => getSyncStatusBadge(row.status?.phase),
     },
     {
-      key: 'status',
-      header: 'Status',
-      accessor: (row) => {
-        const { text, ready } = getGenericStatus(row)
-        return (
-          <Badge
-            variant={ready ? 'default' : 'secondary'}
-            className={ready ? 'bg-green-500 hover:bg-green-600' : ''}
-          >
-            {text}
-          </Badge>
-        )
-      },
+      key: 'splitBrain',
+      header: 'Split-Brain State',
+      accessor: (row) => getSplitBrainBadge(row.status?.splitBrainState),
     },
     {
-      key: 'clusters',
-      header: 'Clusters',
-      accessor: (row) => {
-        const clusters = row.spec?.clusters as unknown[] | undefined
-        const statusClusters = row.status?.clusters as unknown[] | undefined
-        const count = clusters?.length ?? statusClusters?.length ?? 0
-        return count
-      },
+      key: 'lastSync',
+      header: 'Last Sync',
+      accessor: (row) => formatLastSync(row.status?.lastSyncTime),
+      sortable: true,
+    },
+    {
+      key: 'age',
+      header: 'Age',
+      accessor: (row) =>
+        row.metadata?.creationTimestamp
+          ? formatAge(row.metadata.creationTimestamp)
+          : 'N/A',
+      sortable: true,
     },
   ]
 
@@ -164,13 +286,13 @@ function FederationsTab() {
     setDialogOpen(true)
   }
 
-  const handleEdit = (federation: GenericResource) => {
+  const handleEdit = (federation: FederationType) => {
     setCurrentFederation(federation)
     setDialogMode(readOnly ? 'view' : 'edit')
     setDialogOpen(true)
   }
 
-  const handleDelete = (federation: GenericResource) => {
+  const handleDelete = (federation: FederationType) => {
     setFederationToDelete(federation)
     setDeleteDialogOpen(true)
   }
@@ -198,7 +320,7 @@ function FederationsTab() {
     })
   }
 
-  const handleSubmit = async (federation: GenericResource) => {
+  const handleSubmit = async (federation: FederationType) => {
     if (dialogMode === 'create') {
       await createFederation.mutateAsync(federation)
     } else {
@@ -210,7 +332,7 @@ function FederationsTab() {
     }
   }
 
-  const getRowKey = (row: GenericResource) =>
+  const getRowKey = (row: FederationType) =>
     `${row.metadata?.namespace}/${row.metadata?.name}`
 
   if (error) {
@@ -258,7 +380,7 @@ function FederationsTab() {
         searchFilter={(row, query) =>
           row.metadata?.name?.toLowerCase().includes(query) ||
           row.metadata?.namespace?.toLowerCase().includes(query) ||
-          (row.spec?.mode as string)?.toLowerCase().includes(query) ||
+          row.spec?.mode?.toLowerCase().includes(query) ||
           false
         }
         actions={(row) =>
@@ -360,12 +482,12 @@ function RemoteClustersTab() {
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set())
   const [dialogOpen, setDialogOpen] = useState(false)
   const [dialogMode, setDialogMode] = useState<'create' | 'edit' | 'view'>('create')
-  const [currentRemoteCluster, setCurrentRemoteCluster] = useState<GenericResource | undefined>()
+  const [currentRemoteCluster, setCurrentRemoteCluster] = useState<RemoteCluster | undefined>()
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [remoteClusterToDelete, setRemoteClusterToDelete] = useState<GenericResource | null>(null)
+  const [remoteClusterToDelete, setRemoteClusterToDelete] = useState<RemoteCluster | null>(null)
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false)
 
-  const columns: Column<GenericResource>[] = [
+  const columns: Column<RemoteCluster>[] = [
     {
       key: 'name',
       header: 'Name',
@@ -373,37 +495,33 @@ function RemoteClustersTab() {
       sortable: true,
     },
     {
-      key: 'namespace',
-      header: 'Namespace',
-      accessor: (row) => (
-        <Badge variant="outline">{row.metadata?.namespace ?? '-'}</Badge>
-      ),
+      key: 'endpoint',
+      header: 'Endpoint',
+      accessor: (row) => row.spec?.endpoint ?? '-',
+    },
+    {
+      key: 'tunnelType',
+      header: 'Tunnel Type',
+      accessor: (row) => getTunnelTypeBadge(row.spec?.tunnel?.type),
+    },
+    {
+      key: 'connected',
+      header: 'Connected',
+      accessor: (row) => getConnectedIndicator(row.status?.connected),
+    },
+    {
+      key: 'lastSeen',
+      header: 'Last Seen',
+      accessor: (row) => formatLastSync(row.status?.lastSeen),
       sortable: true,
     },
     {
-      key: 'endpoint',
-      header: 'Endpoint',
-      accessor: (row) => (row.spec?.endpoint as string) ?? '-',
-    },
-    {
-      key: 'status',
-      header: 'Status',
-      accessor: (row) => {
-        const { text, ready } = getGenericStatus(row)
-        return (
-          <Badge
-            variant={ready ? 'default' : 'secondary'}
-            className={ready ? 'bg-green-500 hover:bg-green-600' : ''}
-          >
-            {text}
-          </Badge>
-        )
-      },
-    },
-    {
-      key: 'lastSync',
-      header: 'Last Sync',
-      accessor: (row) => formatLastSync(row.status?.lastSyncTime),
+      key: 'age',
+      header: 'Age',
+      accessor: (row) =>
+        row.metadata?.creationTimestamp
+          ? formatAge(row.metadata.creationTimestamp)
+          : 'N/A',
       sortable: true,
     },
   ]
@@ -414,13 +532,13 @@ function RemoteClustersTab() {
     setDialogOpen(true)
   }
 
-  const handleEdit = (remoteCluster: GenericResource) => {
+  const handleEdit = (remoteCluster: RemoteCluster) => {
     setCurrentRemoteCluster(remoteCluster)
     setDialogMode(readOnly ? 'view' : 'edit')
     setDialogOpen(true)
   }
 
-  const handleDelete = (remoteCluster: GenericResource) => {
+  const handleDelete = (remoteCluster: RemoteCluster) => {
     setRemoteClusterToDelete(remoteCluster)
     setDeleteDialogOpen(true)
   }
@@ -448,19 +566,19 @@ function RemoteClustersTab() {
     })
   }
 
-  const handleSubmit = async (remoteCluster: GenericResource) => {
+  const handleSubmit = async (remoteCluster: RemoteCluster) => {
     if (dialogMode === 'create') {
       await createRemoteCluster.mutateAsync(remoteCluster)
     } else {
       await updateRemoteCluster.mutateAsync({
         namespace: remoteCluster.metadata?.namespace ?? '',
         name: remoteCluster.metadata?.name ?? '',
-        remoteCluster,
+        rc: remoteCluster,
       })
     }
   }
 
-  const getRowKey = (row: GenericResource) =>
+  const getRowKey = (row: RemoteCluster) =>
     `${row.metadata?.namespace}/${row.metadata?.name}`
 
   if (error) {
@@ -508,7 +626,7 @@ function RemoteClustersTab() {
         searchFilter={(row, query) =>
           row.metadata?.name?.toLowerCase().includes(query) ||
           row.metadata?.namespace?.toLowerCase().includes(query) ||
-          (row.spec?.endpoint as string)?.toLowerCase().includes(query) ||
+          row.spec?.endpoint?.toLowerCase().includes(query) ||
           false
         }
         actions={(row) =>

--- a/web/src/pages/LoadShedding.tsx
+++ b/web/src/pages/LoadShedding.tsx
@@ -1,0 +1,366 @@
+import { useState, useEffect } from 'react'
+import { useApp } from '@/contexts/AppContext'
+import {
+  useOverloadStatus,
+  useOverloadConfig,
+  useUpdateOverloadConfig,
+} from '@/api/hooks'
+import type { OverloadConfig } from '@/api/types'
+import { MetricCard } from '@/components/metrics/MetricCard'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  ShieldAlert,
+  MemoryStick,
+  Activity,
+  Server,
+  AlertTriangle,
+  CheckCircle,
+  Save,
+  Info,
+} from 'lucide-react'
+
+export default function LoadShedding() {
+  const { readOnly } = useApp()
+  const { data: status, isLoading: statusLoading, error: statusError } = useOverloadStatus()
+  const { data: config, isLoading: configLoading, error: configError } = useOverloadConfig()
+  const updateConfig = useUpdateOverloadConfig()
+
+  const [formConfig, setFormConfig] = useState<OverloadConfig>({
+    enabled: false,
+    heapMemoryTriggerPercent: 90,
+    heapMemoryRecoverPercent: 80,
+    goroutineTriggerCount: 10000,
+    goroutineRecoverCount: 8000,
+    activeConnectionTriggerCount: 50000,
+    activeConnectionRecoverCount: 40000,
+    checkInterval: '1s',
+  })
+
+  useEffect(() => {
+    if (config) {
+      setFormConfig(config)
+    }
+  }, [config])
+
+  const handleSave = () => {
+    updateConfig.mutate(formConfig)
+  }
+
+  const isOverloaded = status?.state === 'overloaded'
+
+  return (
+    <div className="space-y-6">
+      {/* Status Header */}
+      <Card className={isOverloaded ? 'border-red-500/50' : 'border-green-500/50'}>
+        <CardContent className="py-4">
+          <div className="flex items-center gap-4">
+            <div
+              className={`flex h-12 w-12 items-center justify-center rounded-full ${
+                isOverloaded
+                  ? 'bg-red-500/20 text-red-500'
+                  : 'bg-green-500/20 text-green-500'
+              }`}
+            >
+              {isOverloaded ? (
+                <AlertTriangle className="h-6 w-6" />
+              ) : (
+                <CheckCircle className="h-6 w-6" />
+              )}
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold">Load Shedding Status</h2>
+              <div className="flex items-center gap-2 mt-1">
+                {statusLoading ? (
+                  <Badge variant="secondary">Loading...</Badge>
+                ) : statusError ? (
+                  <Badge variant="destructive">Error</Badge>
+                ) : (
+                  <Badge
+                    className={
+                      isOverloaded
+                        ? 'bg-red-500 hover:bg-red-600'
+                        : 'bg-green-500 hover:bg-green-600'
+                    }
+                  >
+                    {isOverloaded ? 'Overloaded' : 'Normal'}
+                  </Badge>
+                )}
+                <span className="text-sm text-muted-foreground">
+                  Auto-refreshes every 5 seconds
+                </span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Status Metrics Grid */}
+      {statusError ? (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center h-40 text-muted-foreground">
+            <ShieldAlert className="h-12 w-12 mb-4" />
+            <p className="text-lg font-medium">Status Unavailable</p>
+            <p className="text-sm mt-1">{statusError.message}</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <MetricCard
+            title="Heap Memory Usage"
+            value={status ? `${(status.heapUsageRatio * 100).toFixed(1)}%` : '-'}
+            icon={<MemoryStick className="h-4 w-4" />}
+            subtitle="Current heap utilization"
+          />
+          <MetricCard
+            title="Goroutine Count"
+            value={status?.goroutineCount ?? '-'}
+            icon={<Activity className="h-4 w-4" />}
+            subtitle="Active goroutines"
+          />
+          <MetricCard
+            title="Active Connections"
+            value={status?.activeConnections ?? '-'}
+            icon={<Server className="h-4 w-4" />}
+            subtitle="Current open connections"
+          />
+          <MetricCard
+            title="Total Requests Shed"
+            value={status?.totalShed ?? '-'}
+            icon={<ShieldAlert className="h-4 w-4" />}
+            subtitle="Requests rejected due to overload"
+          />
+        </div>
+      )}
+
+      {/* Configuration Section */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2">
+            <ShieldAlert className="h-4 w-4" />
+            Load Shedding Configuration
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {configLoading ? (
+            <div className="flex items-center justify-center h-40">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+            </div>
+          ) : configError ? (
+            <div className="text-center py-8 text-muted-foreground">
+              Failed to load configuration: {configError.message}
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {/* Enable/Disable Toggle */}
+              <div className="flex items-center gap-3">
+                <Label htmlFor="enabled" className="font-medium">
+                  Enable Load Shedding
+                </Label>
+                <Button
+                  id="enabled"
+                  variant={formConfig.enabled ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() =>
+                    setFormConfig((prev) => ({ ...prev, enabled: !prev.enabled }))
+                  }
+                  disabled={readOnly}
+                >
+                  {formConfig.enabled ? 'Enabled' : 'Disabled'}
+                </Button>
+              </div>
+
+              {/* Hysteresis Info */}
+              <div className="rounded-md bg-muted/50 p-3 flex items-start gap-2">
+                <Info className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+                <p className="text-sm text-muted-foreground">
+                  Load shedding uses hysteresis to prevent flapping. The trigger threshold activates shedding,
+                  and the recover threshold (which must be lower) deactivates it.
+                  This prevents rapid on/off cycling when values hover near a single threshold.
+                </p>
+              </div>
+
+              {/* Threshold Forms */}
+              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {/* Heap Memory */}
+                <div className="space-y-3">
+                  <h4 className="font-medium text-sm flex items-center gap-2">
+                    <MemoryStick className="h-4 w-4" />
+                    Heap Memory
+                  </h4>
+                  <div className="space-y-2">
+                    <div>
+                      <Label htmlFor="heapTrigger" className="text-xs text-muted-foreground">
+                        Trigger (%)
+                      </Label>
+                      <Input
+                        id="heapTrigger"
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={formConfig.heapMemoryTriggerPercent ?? ''}
+                        onChange={(e) =>
+                          setFormConfig((prev) => ({
+                            ...prev,
+                            heapMemoryTriggerPercent: Number(e.target.value),
+                          }))
+                        }
+                        disabled={readOnly}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="heapRecover" className="text-xs text-muted-foreground">
+                        Recover (%)
+                      </Label>
+                      <Input
+                        id="heapRecover"
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={formConfig.heapMemoryRecoverPercent ?? ''}
+                        onChange={(e) =>
+                          setFormConfig((prev) => ({
+                            ...prev,
+                            heapMemoryRecoverPercent: Number(e.target.value),
+                          }))
+                        }
+                        disabled={readOnly}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Goroutines */}
+                <div className="space-y-3">
+                  <h4 className="font-medium text-sm flex items-center gap-2">
+                    <Activity className="h-4 w-4" />
+                    Goroutines
+                  </h4>
+                  <div className="space-y-2">
+                    <div>
+                      <Label htmlFor="goroutineTrigger" className="text-xs text-muted-foreground">
+                        Trigger Count
+                      </Label>
+                      <Input
+                        id="goroutineTrigger"
+                        type="number"
+                        min={0}
+                        value={formConfig.goroutineTriggerCount ?? ''}
+                        onChange={(e) =>
+                          setFormConfig((prev) => ({
+                            ...prev,
+                            goroutineTriggerCount: Number(e.target.value),
+                          }))
+                        }
+                        disabled={readOnly}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="goroutineRecover" className="text-xs text-muted-foreground">
+                        Recover Count
+                      </Label>
+                      <Input
+                        id="goroutineRecover"
+                        type="number"
+                        min={0}
+                        value={formConfig.goroutineRecoverCount ?? ''}
+                        onChange={(e) =>
+                          setFormConfig((prev) => ({
+                            ...prev,
+                            goroutineRecoverCount: Number(e.target.value),
+                          }))
+                        }
+                        disabled={readOnly}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Active Connections */}
+                <div className="space-y-3">
+                  <h4 className="font-medium text-sm flex items-center gap-2">
+                    <Server className="h-4 w-4" />
+                    Active Connections
+                  </h4>
+                  <div className="space-y-2">
+                    <div>
+                      <Label htmlFor="connTrigger" className="text-xs text-muted-foreground">
+                        Trigger Count
+                      </Label>
+                      <Input
+                        id="connTrigger"
+                        type="number"
+                        min={0}
+                        value={formConfig.activeConnectionTriggerCount ?? ''}
+                        onChange={(e) =>
+                          setFormConfig((prev) => ({
+                            ...prev,
+                            activeConnectionTriggerCount: Number(e.target.value),
+                          }))
+                        }
+                        disabled={readOnly}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="connRecover" className="text-xs text-muted-foreground">
+                        Recover Count
+                      </Label>
+                      <Input
+                        id="connRecover"
+                        type="number"
+                        min={0}
+                        value={formConfig.activeConnectionRecoverCount ?? ''}
+                        onChange={(e) =>
+                          setFormConfig((prev) => ({
+                            ...prev,
+                            activeConnectionRecoverCount: Number(e.target.value),
+                          }))
+                        }
+                        disabled={readOnly}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Check Interval */}
+              <div className="max-w-xs">
+                <Label htmlFor="checkInterval" className="text-xs text-muted-foreground">
+                  Check Interval (e.g. "1s", "500ms")
+                </Label>
+                <Input
+                  id="checkInterval"
+                  type="text"
+                  value={formConfig.checkInterval ?? ''}
+                  onChange={(e) =>
+                    setFormConfig((prev) => ({
+                      ...prev,
+                      checkInterval: e.target.value,
+                    }))
+                  }
+                  disabled={readOnly}
+                />
+              </div>
+
+              {/* Save Button */}
+              {!readOnly && (
+                <div className="flex justify-end">
+                  <Button
+                    onClick={handleSave}
+                    disabled={updateConfig.isPending}
+                  >
+                    <Save className="h-4 w-4 mr-2" />
+                    {updateConfig.isPending ? 'Saving...' : 'Save Configuration'}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/web/src/pages/Routes.tsx
+++ b/web/src/pages/Routes.tsx
@@ -91,6 +91,28 @@ export default function Routes() {
       accessor: (row) => row.spec?.rules?.length ?? 0,
     },
     {
+      key: 'faultInjection',
+      header: 'Fault Injection',
+      accessor: (row) => {
+        const fi = row.spec?.faultInjection
+        if (!fi) return '-'
+        const parts: string[] = []
+        if (fi.delayPercent) parts.push(`Delay ${fi.delayPercent}%`)
+        if (fi.abortPercent) parts.push(`Abort ${fi.abortPercent}%`)
+        return parts.length > 0 ? parts.join(' / ') : '-'
+      },
+    },
+    {
+      key: 'bodyTransform',
+      header: 'Body Transform',
+      accessor: (row) => {
+        const bt = row.spec?.bodyTransform
+        if (!bt) return '-'
+        const count = (bt.requestTransforms?.length ?? 0) + (bt.responseTransforms?.length ?? 0)
+        return count > 0 ? `${count} ops` : '-'
+      },
+    },
+    {
       key: 'age',
       header: 'Age',
       accessor: (row) =>

--- a/web/src/pages/WASMPlugins.tsx
+++ b/web/src/pages/WASMPlugins.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react'
+import { useWASMPlugins, useWASMPlugin } from '@/api/hooks'
+import type { WASMPluginStatus } from '@/api/types'
+import { DataTable, Column } from '@/components/common/DataTable'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import {
+  Puzzle,
+  AlertCircle,
+  Activity,
+  Clock,
+  MemoryStick,
+  Timer,
+} from 'lucide-react'
+import { MetricCard } from '@/components/metrics/MetricCard'
+
+export default function WASMPlugins() {
+  const { data: plugins = [], isLoading, error } = useWASMPlugins()
+  const [selectedPlugin, setSelectedPlugin] = useState<string>('')
+  const [detailOpen, setDetailOpen] = useState(false)
+  const { data: pluginDetail } = useWASMPlugin(selectedPlugin)
+
+  const columns: Column<WASMPluginStatus>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      accessor: (row) => row.name,
+      sortable: true,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      accessor: (row) => (
+        <Badge
+          className={
+            row.loaded
+              ? 'bg-green-500 hover:bg-green-600'
+              : 'bg-red-500 hover:bg-red-600'
+          }
+        >
+          {row.loaded ? 'Loaded' : 'Error'}
+        </Badge>
+      ),
+    },
+    {
+      key: 'invocations',
+      header: 'Invocations',
+      accessor: (row) => row.invocations.toLocaleString(),
+      sortable: true,
+    },
+    {
+      key: 'errors',
+      header: 'Errors',
+      accessor: (row) => (
+        <span className={row.errors > 0 ? 'text-red-500 font-medium' : ''}>
+          {row.errors.toLocaleString()}
+        </span>
+      ),
+      sortable: true,
+    },
+    {
+      key: 'avgLatency',
+      header: 'Avg Latency',
+      accessor: (row) => `${row.avgLatencyMs.toFixed(2)} ms`,
+      sortable: true,
+    },
+  ]
+
+  const handleRowClick = (row: WASMPluginStatus) => {
+    setSelectedPlugin(row.name)
+    setDetailOpen(true)
+  }
+
+  const getRowKey = (row: WASMPluginStatus) => row.name
+
+  if (error) {
+    return (
+      <div className="text-center py-12 text-destructive">
+        Failed to load WASM plugins: {error.message}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <DataTable
+        data={plugins}
+        columns={columns}
+        getRowKey={getRowKey}
+        onRowClick={handleRowClick}
+        isLoading={isLoading}
+        emptyMessage="No WASM plugins loaded"
+        searchPlaceholder="Search plugins..."
+        searchFilter={(row, query) =>
+          row.name.toLowerCase().includes(query) || false
+        }
+      />
+
+      {/* Plugin Detail Dialog */}
+      <Dialog open={detailOpen} onOpenChange={setDetailOpen}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Puzzle className="h-5 w-5" />
+              {selectedPlugin}
+            </DialogTitle>
+            <DialogDescription>WASM plugin details and metrics</DialogDescription>
+          </DialogHeader>
+
+          {pluginDetail ? (
+            <div className="space-y-6">
+              {/* Plugin Metrics */}
+              <div className="grid gap-4 md:grid-cols-3">
+                <MetricCard
+                  title="Invocations"
+                  value={
+                    plugins
+                      .find((p) => p.name === selectedPlugin)
+                      ?.invocations.toLocaleString() ?? '-'
+                  }
+                  icon={<Activity className="h-4 w-4" />}
+                />
+                <MetricCard
+                  title="Errors"
+                  value={
+                    plugins
+                      .find((p) => p.name === selectedPlugin)
+                      ?.errors.toLocaleString() ?? '-'
+                  }
+                  icon={<AlertCircle className="h-4 w-4" />}
+                />
+                <MetricCard
+                  title="Avg Latency"
+                  value={`${
+                    plugins
+                      .find((p) => p.name === selectedPlugin)
+                      ?.avgLatencyMs.toFixed(2) ?? '-'
+                  } ms`}
+                  icon={<Clock className="h-4 w-4" />}
+                />
+              </div>
+
+              {/* Resource Limits */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium">Resource Limits</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="flex items-center gap-2">
+                      <MemoryStick className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-sm text-muted-foreground">Memory Limit:</span>
+                      <span className="text-sm font-medium">
+                        {pluginDetail.memoryLimitMB
+                          ? `${pluginDetail.memoryLimitMB} MB`
+                          : 'Unlimited'}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Timer className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-sm text-muted-foreground">Timeout:</span>
+                      <span className="text-sm font-medium">
+                        {pluginDetail.timeoutMs
+                          ? `${pluginDetail.timeoutMs} ms`
+                          : 'No limit'}
+                      </span>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Plugin Configuration */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium">Configuration</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3">
+                    <div className="grid gap-2 text-sm">
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Path</span>
+                        <span className="font-mono text-xs">{pluginDetail.path}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Phase</span>
+                        <Badge variant="outline">{pluginDetail.phase ?? 'request'}</Badge>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Priority</span>
+                        <span>{pluginDetail.priority ?? 0}</span>
+                      </div>
+                    </div>
+                    {pluginDetail.config && Object.keys(pluginDetail.config).length > 0 && (
+                      <div>
+                        <p className="text-sm text-muted-foreground mb-2">Plugin Config:</p>
+                        <pre className="rounded-md bg-muted p-3 text-xs overflow-x-auto">
+                          {JSON.stringify(pluginDetail.config, null, 2)}
+                        </pre>
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-40">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Updates the Web UI to cover all features added in v1.2.0 and v1.2.1.

- **Federation management** (#427, #428): Strongly typed `Federation` and `RemoteCluster` interfaces replacing `GenericResource`. Two-tab page with colored badges for mode (hub-spoke/mesh/unified), sync status, split-brain state, tunnel type, and connection indicators.
- **Fault injection UI** (#429): New columns on Routes page showing delay/abort percentages
- **Slow start & outlier detection UI** (#430): New columns on Backends page showing window duration and enabled status
- **Body transformation UI** (#431): New column on Routes page showing operation count
- **Load shedding page** (#432): Real-time status with colored indicator, metric cards (heap, goroutines, connections, shed count), configuration form with hysteresis thresholds
- **WASM plugins page** (#433): Plugin list with status badges, invocation/error/latency metrics, detail dialog with config viewer and resource limits
- **Dashboard updates** (#434): Federation status widget, load shedding indicator, active features summary

### Files changed (11)
- `web/src/api/types.ts` — 15 new typed interfaces
- `web/src/api/client.ts` — Overload and WASM plugin API endpoints
- `web/src/api/hooks.ts` — 12 new React Query hooks
- `web/src/pages/Federation.tsx` — Rewritten with typed interfaces and two-tab layout
- `web/src/pages/LoadShedding.tsx` — New page
- `web/src/pages/WASMPlugins.tsx` — New page
- `web/src/pages/Dashboard.tsx` — Three new widgets
- `web/src/pages/Routes.tsx` — Two new columns
- `web/src/pages/Backends.tsx` — Two new columns
- `web/src/App.tsx` — Two new routes
- `web/src/components/layout/Sidebar.tsx` — Two new nav items

## Test plan
- [x] `npx tsc --noEmit` passes (zero TypeScript errors)
- [x] `pnpm run build` succeeds (2.27s)
- [ ] CI pipeline

Resolves #427, Resolves #428, Resolves #429, Resolves #430, Resolves #431, Resolves #432, Resolves #433, Resolves #434