### PR TITLE
[Fix] Quick fixes: stale comments, standalone agent data, CRD field docs

### DIFF
--- a/api/v1alpha1/proxygateway_types.go
+++ b/api/v1alpha1/proxygateway_types.go
@@ -485,15 +485,21 @@ type ProxyGatewaySpec struct {
 	// +optional
 	RedirectScheme *RedirectSchemeConfig `json:"redirectScheme,omitempty"`
 
-	// HTTP3 defines HTTP/3 (QUIC) protocol configuration
+	// HTTP3 defines HTTP/3 (QUIC) protocol configuration at the gateway level.
+	// RESERVED FOR FUTURE USE: this field is not currently consumed by the controller.
+	// To enable HTTP/3, configure QUIC settings on individual listeners instead.
 	// +optional
 	HTTP3 *HTTP3Config `json:"http3,omitempty"`
 
-	// SSE defines Server-Sent Events configuration
+	// SSE defines Server-Sent Events configuration at the gateway level.
+	// RESERVED FOR FUTURE USE: this field is not currently consumed by the controller.
+	// SSE behaviour is configured through ProxyRoute middleware today.
 	// +optional
 	SSE *SSEConfig `json:"sse,omitempty"`
 
-	// GRPCRoute defines gRPC-specific routing configuration
+	// GRPCRoute defines gRPC-specific routing configuration at the gateway level.
+	// RESERVED FOR FUTURE USE: this field is not currently consumed by the controller.
+	// gRPC routing is handled via ProxyRoute resources with gRPC match rules.
 	// +optional
 	GRPCRoute *GRPCRouteConfig `json:"grpcRoute,omitempty"`
 }

--- a/cmd/novactl/pkg/webui/server.go
+++ b/cmd/novactl/pkg/webui/server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -25,6 +26,9 @@ import (
 const (
 	defaultNamespace = "novaedge-system"
 )
+
+// serverStartTime records when the process started, used for standalone agent info.
+var serverStartTime = metav1.Now()
 
 // Server represents the web UI server
 type Server struct {
@@ -1138,16 +1142,25 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// In standalone mode, return empty list or mock agent
+	// In standalone mode, return agent info derived from the running process.
 	if s.backend != nil && s.backend.Mode() == mode.ModeStandalone {
-		// Return a single "standalone" agent
+		hostname, _ := os.Hostname()
+		if hostname == "" {
+			hostname = "localhost"
+		}
+		listenAddr := s.addr
+		if listenAddr == "" {
+			listenAddr = "127.0.0.1"
+		}
+		startTime := serverStartTime
 		agents := []AgentInfo{{
 			Name:      "standalone-agent",
 			Namespace: "standalone",
-			NodeName:  "localhost",
-			PodIP:     "127.0.0.1",
+			NodeName:  hostname,
+			PodIP:     listenAddr,
 			Phase:     "Running",
 			Ready:     true,
+			StartTime: &startTime,
 		}}
 		writeJSON(w, http.StatusOK, agents)
 		return

--- a/internal/agent/server/http.go
+++ b/internal/agent/server/http.go
@@ -59,7 +59,8 @@ func NewHTTPServer(logger *zap.Logger) *HTTPServer {
 	}
 }
 
-// Start starts the HTTP server (placeholder for now)
+// Start blocks until the context is cancelled, keeping the server goroutine alive.
+// The actual listener setup and traffic handling are driven by ApplyConfig().
 func (s *HTTPServer) Start(ctx context.Context) error {
 	s.logger.Info("HTTP server started, waiting for configuration")
 	<-ctx.Done()


### PR DESCRIPTION
## Summary

- **#451**: Updated the `Start()` comment in `internal/agent/server/http.go` to accurately describe that it blocks until context cancellation while `ApplyConfig()` drives the real listener/traffic work.
- **#452**: Replaced hardcoded synthetic data in the standalone `/api/v1/agents` endpoint (`cmd/novactl/pkg/webui/server.go`) with real runtime info: `os.Hostname()`, server listen address, and process start time.
- **#450**: Added `RESERVED FOR FUTURE USE` documentation to the gateway-level `HTTP3`, `SSE`, and `GRPCRoute` fields in `api/v1alpha1/proxygateway_types.go`, clarifying the current configuration paths (listener QUIC, ProxyRoute middleware, ProxyRoute gRPC match rules).

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go vet ./...` passes on affected packages (verified locally)
- [ ] `gofmt -s -w` applied to all modified files (verified locally)
- [ ] Standalone mode `/api/v1/agents` returns real hostname and start time
- [ ] CRD field comments render correctly in generated API docs

Resolves #450, #451, #452