### PR TITLE
Fix federation stub, state provider wiring, endpoint sync, tunnel manager

### DIFF
--- a/cmd/novaedge-controller/main.go
+++ b/cmd/novaedge-controller/main.go
@@ -44,6 +44,7 @@ import (
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 	"github.com/piwi3910/novaedge/internal/controller"
 	"github.com/piwi3910/novaedge/internal/controller/certmanager"
+	"github.com/piwi3910/novaedge/internal/controller/federation"
 	"github.com/piwi3910/novaedge/internal/controller/ipam"
 	"github.com/piwi3910/novaedge/internal/controller/meshca"
 	"github.com/piwi3910/novaedge/internal/controller/snapshot"
@@ -108,6 +109,11 @@ func main() {
 	flag.StringVar(&vaultAuthMethod, "vault-auth-method", "kubernetes", "Vault auth method (kubernetes|approle|token)")
 	flag.StringVar(&vaultRole, "vault-role", "novaedge", "Vault auth role name")
 	flag.StringVar(&meshTrustDomain, "mesh-trust-domain", "cluster.local", "SPIFFE trust domain for mesh mTLS identity")
+
+	var federationID string
+	var federationLocalMember string
+	flag.StringVar(&federationID, "federation-id", "", "Federation identifier. When set, enables federation state on config snapshots.")
+	flag.StringVar(&federationLocalMember, "federation-local-member", "", "Name of this controller in the federation.")
 
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -341,6 +347,24 @@ func main() {
 	// Create and start gRPC server for config distribution
 	configServer := snapshot.NewServer(mgr.GetClient())
 	configServer.SetMeshCA(meshCA)
+
+	// Wire federation state provider into the snapshot builder when federation
+	// is configured. This allows built snapshots to include federation metadata
+	// and remote endpoints from federated clusters.
+	if federationID != "" && federationLocalMember != "" {
+		fedConfig := &federation.Config{
+			FederationID: federationID,
+			LocalMember: &federation.PeerInfo{
+				Name: federationLocalMember,
+			},
+		}
+		fedLogger, _ := uberzap.NewProduction()
+		fedManager := federation.NewManager(fedConfig, fedLogger)
+		configServer.SetFederationProvider(fedManager)
+		setupLog.Info("Federation state provider wired into snapshot builder",
+			"federationID", federationID,
+			"localMember", federationLocalMember)
+	}
 
 	// Create gRPC server with message size limits and interceptors
 	grpcLogger, _ := uberzap.NewProduction()

--- a/cmd/novaedge-operator/main.go
+++ b/cmd/novaedge-operator/main.go
@@ -168,19 +168,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create remote cluster registry for tracking connected spoke clusters
-	remoteClusterRegistry := controller.NewRemoteClusterRegistry()
-
-	if err = (&controller.NovaEdgeRemoteClusterReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Registry: remoteClusterRegistry,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "NovaEdgeRemoteCluster")
-		os.Exit(1)
-	}
-
-	// Set up NovaEdgeFederation controller
+	// Create zap logger for components that require go.uber.org/zap
 	zapLogger, zapErr := zap.NewProduction()
 	if logFormat == "text" {
 		zapLogger, zapErr = zap.NewDevelopment()
@@ -190,6 +178,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Create remote cluster registry for tracking connected spoke clusters
+	remoteClusterRegistry := controller.NewRemoteClusterRegistry()
+
+	tunnelManager := controller.NewInMemoryTunnelManager(zapLogger.Named("tunnel"))
+
+	if err = (&controller.NovaEdgeRemoteClusterReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Registry:      remoteClusterRegistry,
+		TunnelManager: tunnelManager,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "NovaEdgeRemoteCluster")
+		os.Exit(1)
+	}
+
+	// Set up NovaEdgeFederation controller
 	if err = (&controller.NovaEdgeFederationReconciler{
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),

--- a/internal/controller/federation/server.go
+++ b/internal/controller/federation/server.go
@@ -130,10 +130,9 @@ func (s *Server) Start(ctx context.Context) error {
 	// Start the tombstone cleanup goroutine
 	go s.cleanupTombstones(ctx)
 
-	// Start connecting to peers
-	for _, peer := range s.config.Peers {
-		go s.maintainPeerConnection(ctx, peer)
-	}
+	// Peer connections are managed by the federation Manager, not the Server.
+	// See Manager.Start() in manager.go which spawns maintainPeerConnection
+	// goroutines for each peer with proper gRPC client handling.
 
 	return nil
 }
@@ -989,40 +988,6 @@ func (s *Server) getPhase() Phase {
 	}
 
 	return PhaseDegraded
-}
-
-// maintainPeerConnection maintains a connection to a peer
-func (s *Server) maintainPeerConnection(ctx context.Context, peer *PeerInfo) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.shutdownCh:
-			return
-		default:
-		}
-
-		s.logger.Warn("Federation peer connection is not yet implemented",
-			zap.String("peer", peer.Name),
-			zap.String("endpoint", peer.Endpoint),
-		)
-
-		s.updatePeerState(peer.Name, func(state *PeerState) {
-			state.Connected = false
-			state.Healthy = false
-			state.LastError = "federation peer connection not yet implemented"
-			state.ConsecutiveFailures++
-		})
-
-		// Wait before reconnecting
-		select {
-		case <-time.After(5 * time.Second):
-		case <-ctx.Done():
-			return
-		case <-s.shutdownCh:
-			return
-		}
-	}
 }
 
 // cleanupTombstones removes old tombstones

--- a/internal/controller/snapshot/server.go
+++ b/internal/controller/snapshot/server.go
@@ -483,6 +483,13 @@ func (s *Server) SetMeshCA(ca *meshca.MeshCA) {
 	s.meshCA = ca
 }
 
+// SetFederationProvider sets the federation state provider on the underlying
+// snapshot builder so that built snapshots include federation metadata and
+// remote endpoints from federated clusters.
+func (s *Server) SetFederationProvider(provider FederationStateProvider) {
+	s.builder.SetFederationProvider(provider)
+}
+
 // RequestMeshCertificate implements the RequestMeshCertificate RPC.
 // Agents call this to obtain a signed mesh workload certificate.
 func (s *Server) RequestMeshCertificate(ctx context.Context, req *pb.MeshCertificateRequest) (*pb.MeshCertificateResponse, error) {

--- a/internal/operator/controller/federation_applier.go
+++ b/internal/operator/controller/federation_applier.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ import (
 
 	novaedgev1alpha1 "github.com/piwi3910/novaedge/api/v1alpha1"
 	"github.com/piwi3910/novaedge/internal/controller/federation"
+	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
 const (
@@ -48,6 +50,10 @@ type FederationResourceApplier struct {
 	client client.Client
 	scheme *runtime.Scheme
 	logger *zap.Logger
+
+	// serviceEndpoints caches ServiceEndpoints received from federated
+	// clusters, keyed by "namespace/serviceName".
+	serviceEndpoints sync.Map // map[string]*pb.ServiceEndpoints
 }
 
 // NewFederationResourceApplier creates a new FederationResourceApplier.
@@ -84,8 +90,7 @@ func (a *FederationResourceApplier) Apply(ctx context.Context, key federation.Re
 	case "Secret":
 		err = a.applySecret(ctx, key, changeType, data)
 	case "ServiceEndpoints":
-		log.Info("ServiceEndpoints received; caching in memory is not yet implemented")
-		return
+		err = a.applyServiceEndpoints(key, changeType, data)
 	default:
 		log.Warn("Unknown resource kind received from federation, skipping")
 		return
@@ -94,6 +99,48 @@ func (a *FederationResourceApplier) Apply(ctx context.Context, key federation.Re
 	if err != nil {
 		log.Error("Failed to apply federated resource change", zap.Error(err))
 	}
+}
+
+// applyServiceEndpoints caches or removes ServiceEndpoints received from
+// federated clusters. The data is stored in an in-memory sync.Map keyed by
+// "namespace/serviceName" for thread-safe concurrent access.
+func (a *FederationResourceApplier) applyServiceEndpoints(key federation.ResourceKey, changeType federation.ChangeType, data []byte) error {
+	cacheKey := key.Namespace + "/" + key.Name
+
+	if changeType == federation.ChangeTypeDeleted {
+		a.serviceEndpoints.Delete(cacheKey)
+		a.logger.Info("Deleted cached ServiceEndpoints",
+			zap.String("key", cacheKey),
+		)
+		return nil
+	}
+
+	var endpoints pb.ServiceEndpoints
+	if err := json.Unmarshal(data, &endpoints); err != nil {
+		return fmt.Errorf("failed to unmarshal ServiceEndpoints %s: %w", cacheKey, err)
+	}
+
+	a.serviceEndpoints.Store(cacheKey, &endpoints)
+	a.logger.Info("Cached ServiceEndpoints",
+		zap.String("key", cacheKey),
+		zap.Int("endpoint_count", len(endpoints.GetEndpoints())),
+	)
+	return nil
+}
+
+// GetCachedServiceEndpoints returns the cached ServiceEndpoints for a given
+// namespace and service name, or nil if not cached.
+func (a *FederationResourceApplier) GetCachedServiceEndpoints(namespace, serviceName string) *pb.ServiceEndpoints {
+	cacheKey := namespace + "/" + serviceName
+	val, ok := a.serviceEndpoints.Load(cacheKey)
+	if !ok {
+		return nil
+	}
+	endpoints, ok := val.(*pb.ServiceEndpoints)
+	if !ok {
+		return nil
+	}
+	return endpoints
 }
 
 // federatedObject is a minimal interface for objects that carry ObjectMeta,

--- a/internal/operator/controller/tunnel_manager.go
+++ b/internal/operator/controller/tunnel_manager.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// InMemoryTunnelManager tracks tunnel names and provides cleanup during
+// remote cluster deletion. It implements TunnelTeardown without depending
+// on Linux-specific networking packages (netlink, wgctrl), making it safe
+// for use in the operator which runs as a standard Deployment.
+type InMemoryTunnelManager struct {
+	mu      sync.Mutex
+	tunnels map[string]bool
+	logger  *zap.Logger
+}
+
+// NewInMemoryTunnelManager creates a new InMemoryTunnelManager.
+func NewInMemoryTunnelManager(logger *zap.Logger) *InMemoryTunnelManager {
+	return &InMemoryTunnelManager{
+		tunnels: make(map[string]bool),
+		logger:  logger.Named("tunnel-manager"),
+	}
+}
+
+// RegisterTunnel records a tunnel name so it can be cleaned up later.
+func (m *InMemoryTunnelManager) RegisterTunnel(clusterName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tunnels[clusterName] = true
+	m.logger.Info("Tunnel registered", zap.String("cluster", clusterName))
+}
+
+// RemoveTunnel removes the tunnel record for the given cluster name.
+// It satisfies the TunnelTeardown interface.
+func (m *InMemoryTunnelManager) RemoveTunnel(clusterName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.tunnels[clusterName] {
+		return fmt.Errorf("tunnel for cluster %q not found", clusterName)
+	}
+
+	delete(m.tunnels, clusterName)
+	m.logger.Info("Tunnel removed", zap.String("cluster", clusterName))
+	return nil
+}


### PR DESCRIPTION
## Summary

- **#442**: Remove stub `maintainPeerConnection` from `federation/server.go` that logged "not yet implemented" every 5 seconds. The real implementation exists in `Manager.maintainPeerConnection` in `manager.go`. Also removed the goroutine spawning loop from `Server.Start()`.
- **#441**: Wire `FederationStateProvider` into the snapshot builder by adding `SetFederationProvider` to the snapshot `Server` and creating a federation `Manager` in the controller's `main.go` when `--federation-id` and `--federation-local-member` flags are set.
- **#448**: Implement `ServiceEndpoints` caching in `FederationResourceApplier` using a `sync.Map` for thread-safe storage, with unmarshal on receive and a `GetCachedServiceEndpoints` retrieval method.
- **#443**: Create `InMemoryTunnelManager` implementing `TunnelTeardown` interface for the operator (avoids Linux-specific netlink/wgctrl dependencies) and wire it into `NovaEdgeRemoteClusterReconciler`.

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./cmd/novaedge-controller/` succeeds
- [x] `go build ./cmd/novaedge-operator/` succeeds
- [x] `go test ./internal/controller/federation/...` passes
- [x] `go test ./internal/controller/snapshot/...` passes
- [ ] Verify federation logs no longer spam "not yet implemented" messages
- [ ] Verify snapshot builder populates federation metadata when flags are set

Resolves #441, #442, #443, #448