### PR TITLE
[Fix] Correct E2E CI workflow label selectors and Helm config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,16 +70,22 @@ jobs:
             --set controller.image.repository=novaedge-controller \
             --set controller.image.tag=latest \
             --set controller.image.pullPolicy=Never \
+            --set controller.replicaCount=1 \
             --set agent.image.repository=novaedge-agent \
             --set agent.image.tag=latest \
             --set agent.image.pullPolicy=Never \
+            --set webui.enabled=false \
             --wait \
             --timeout 300s
 
       - name: Wait for pods to be ready
         run: |
-          kubectl wait --for=condition=ready --timeout=300s pod -l app=novaedge-controller -n novaedge-system
-          kubectl wait --for=condition=ready --timeout=300s pod -l app=novaedge-agent -n novaedge-system
+          kubectl wait --for=condition=ready --timeout=300s pod \
+            -l app.kubernetes.io/name=novaedge,app.kubernetes.io/component=controller \
+            -n novaedge-system
+          kubectl wait --for=condition=ready --timeout=300s pod \
+            -l app.kubernetes.io/name=novaedge,app.kubernetes.io/component=agent \
+            -n novaedge-system
 
       - name: Show pod status
         run: |
@@ -94,8 +100,12 @@ jobs:
         if: failure()
         run: |
           mkdir -p logs
-          kubectl logs -l app=novaedge-controller -n novaedge-system > logs/controller.log || true
-          kubectl logs -l app=novaedge-agent -n novaedge-system > logs/agent.log || true
+          kubectl logs \
+            -l app.kubernetes.io/name=novaedge,app.kubernetes.io/component=controller \
+            -n novaedge-system > logs/controller.log || true
+          kubectl logs \
+            -l app.kubernetes.io/name=novaedge,app.kubernetes.io/component=agent \
+            -n novaedge-system > logs/agent.log || true
           kubectl describe pods -n novaedge-system > logs/pods.log || true
           kubectl get events -n novaedge-system --sort-by='.lastTimestamp' > logs/events.log || true
 


### PR DESCRIPTION
## Summary
Fixes #524

- **Fix label selector mismatch**: `kubectl wait` and log collection commands used `app=novaedge-controller` / `app=novaedge-agent`, but the Helm chart produces `app.kubernetes.io/name=novaedge` with `app.kubernetes.io/component=controller|agent`. Updated all selectors to match the chart's `_helpers.tpl` definitions.
- **Disable webui in E2E tests**: The workflow only builds controller and agent images, but the chart deploys webui by default, causing `ImagePullBackOff`. Added `--set webui.enabled=false`.
- **Set controller replica count**: Added `--set controller.replicaCount=1` for the single-node kind cluster to avoid scheduling issues.

## Test plan
- [ ] Verify E2E workflow passes on all three k8s versions (v1.28, v1.29, v1.30)
- [ ] Confirm `kubectl wait` correctly finds pods with the new label selectors
- [ ] Confirm log collection on failure uses correct selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)