### PR TITLE
[Fix] Resolve OSPF handler data races (#523)

### DIFF
--- a/internal/agent/vip/ospf.go
+++ b/internal/agent/vip/ospf.go
@@ -610,8 +610,12 @@ func (h *OSPFHandler) ospfProtocolLoop() {
 
 	helloInterval := time.Duration(ospfDefaultHelloIvl) * time.Second
 	h.mu.RLock()
-	if h.ospfServer != nil && h.ospfServer.config.HelloInterval > 0 {
-		helloInterval = time.Duration(h.ospfServer.config.HelloInterval) * time.Second
+	if h.ospfServer != nil {
+		h.ospfServer.mu.RLock()
+		if h.ospfServer.config.HelloInterval > 0 {
+			helloInterval = time.Duration(h.ospfServer.config.HelloInterval) * time.Second
+		}
+		h.ospfServer.mu.RUnlock()
 	}
 	h.mu.RUnlock()
 
@@ -689,8 +693,8 @@ func (h *OSPFHandler) sendHelloPackets() {
 		return
 	}
 
-	h.ospfServer.mu.RLock()
-	defer h.ospfServer.mu.RUnlock()
+	h.ospfServer.mu.Lock()
+	defer h.ospfServer.mu.Unlock()
 
 	h.logger.Debug("Sending OSPF Hello packets",
 		zap.Int("neighbor_count", len(h.ospfServer.neighbors)),
@@ -744,8 +748,8 @@ func (h *OSPFHandler) maintainNeighbors() {
 		return
 	}
 
-	h.ospfServer.mu.RLock()
-	defer h.ospfServer.mu.RUnlock()
+	h.ospfServer.mu.Lock()
+	defer h.ospfServer.mu.Unlock()
 
 	deadInterval := time.Duration(ospfDefaultDeadIvl) * time.Second
 	if h.ospfServer.config.DeadInterval > 0 {


### PR DESCRIPTION
## Summary
- Fix 3 data races in `internal/agent/vip/ospf.go` detected by `go test -race`
- `ospfProtocolLoop()` now holds `h.ospfServer.mu.RLock()` when reading config (was only holding `h.mu.RLock()` while `reconfigureVIP()` writes under `h.ospfServer.mu`)
- `sendHelloPackets()` and `maintainNeighbors()` upgraded from `RLock` to `Lock` since they mutate neighbor state

## Test plan
- [x] `go test -race -count=1 -timeout 120s ./internal/agent/vip/...` passes (2.98s, no races)
- [x] `go build ./internal/agent/vip/...` compiles clean

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)