### PR TITLE
[Fix] Replace corepack with direct pnpm install in Dockerfile.webui

### DIFF
--- a/Dockerfile.webui
+++ b/Dockerfile.webui
@@ -1,7 +1,7 @@
 # Stage 1: Build frontend
 FROM node:25-alpine AS builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Node.js 25 removed `corepack` from the default distribution, causing webui Docker builds to fail
- Replaced `corepack enable && corepack prepare pnpm@latest --activate` with `npm install -g pnpm`

Closes #533

## Test plan
- [ ] Verify `podman build -f Dockerfile.webui .` succeeds with node:25-alpine
- [ ] Verify webui container starts and serves the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)