### PR TITLE
[Fix] Correct Helm chart args to match binary flag names

### DIFF
--- a/charts/novaedge/templates/agent-daemonset.yaml
+++ b/charts/novaedge/templates/agent-daemonset.yaml
@@ -58,9 +58,8 @@ spec:
         - -controller-address={{ include "novaedge.fullname" . }}-controller.{{ include "novaedge.namespace" . }}.svc.cluster.local:{{ .Values.controller.grpc.port }}
         - -node-name=$(NODE_NAME)
         - -metrics-port={{ .Values.agent.metrics.port }}
-        - -health-probe-address=:{{ .Values.agent.healthProbe.port }}
+        - -health-probe-port={{ .Values.agent.healthProbe.port }}
         - -log-level={{ .Values.agent.logging.level }}
-        - -log-format={{ .Values.agent.logging.format }}
         {{- if .Values.agent.tracing.enabled }}
         - -tracing-enabled
         - -tracing-endpoint={{ .Values.agent.tracing.endpoint }}

--- a/charts/novaedge/templates/controller-deployment.yaml
+++ b/charts/novaedge/templates/controller-deployment.yaml
@@ -50,15 +50,16 @@ spec:
         args:
         {{- if .Values.controller.leaderElection.enabled }}
         - --leader-elect
-        - --leader-elect-lease-duration={{ .Values.controller.leaderElection.leaseDuration }}
-        - --leader-elect-renew-deadline={{ .Values.controller.leaderElection.renewDeadline }}
-        - --leader-elect-retry-period={{ .Values.controller.leaderElection.retryPeriod }}
         {{- end }}
         - --metrics-bind-address=:{{ .Values.controller.metrics.port }}
         - --health-probe-bind-address=:{{ .Values.controller.healthProbe.port }}
         - --grpc-bind-address=:{{ .Values.controller.grpc.port }}
-        - --log-level={{ .Values.controller.logging.level }}
-        - --log-format={{ .Values.controller.logging.format }}
+        {{- if eq .Values.controller.logging.format "json" }}
+        - --zap-encoder=json
+        {{- else }}
+        - --zap-encoder=console
+        {{- end }}
+        - --zap-log-level={{ .Values.controller.logging.level }}
         {{- if .Values.controller.controllerClass }}
         - --controller-class={{ .Values.controller.controllerClass }}
         {{- end }}


### PR DESCRIPTION
## Summary
- **Controller**: Remove non-existent `--leader-elect-lease-duration/renew-deadline/retry-period` flags; replace `--log-level/--log-format` with `--zap-log-level/--zap-encoder` (controller uses controller-runtime's zap flags)
- **Agent**: Change `-health-probe-address` to `-health-probe-port` (binary expects port number, not address); remove `-log-format` (flag doesn't exist)

These mismatches caused all controller and agent pods to CrashLoopBackOff when deployed via Helm.

## Test plan
- [ ] `helm template` renders correct args
- [ ] Controller pods start without "flag provided but not defined" errors
- [ ] Agent pods start without "flag provided but not defined" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)