### PR TITLE
[Fix] Remove non-existent --ingress-class flag from Helm controller template

### DIFF
--- a/charts/novaedge/templates/controller-deployment.yaml
+++ b/charts/novaedge/templates/controller-deployment.yaml
@@ -63,9 +63,7 @@ spec:
         {{- if .Values.controller.controllerClass }}
         - --controller-class={{ .Values.controller.controllerClass }}
         {{- end }}
-        {{- if .Values.controller.ingressClass }}
-        - --ingress-class={{ .Values.controller.ingressClass }}
-        {{- end }}
+        {{- /* NOTE: ingress class is hardcoded to "novaedge" in the controller binary */}}
         {{- if .Values.controller.defaultVIPRef }}
         - --default-vip-ref={{ .Values.controller.defaultVIPRef }}
         {{- end }}


### PR DESCRIPTION
## Summary
- Remove `--ingress-class` arg from controller deployment template — the binary doesn't have this flag (ingress class is hardcoded to "novaedge")
- This was causing controller pods to CrashLoopBackOff with "flag provided but not defined: -ingress-class"

Follow-up to #535.

## Test plan
- [ ] Controller pods start without "flag provided but not defined" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)