### PR TITLE
[Fix] Replace cp with cat redirect in webui entrypoint

### DIFF
--- a/web/docker-entrypoint.sh
+++ b/web/docker-entrypoint.sh
@@ -5,10 +5,10 @@ set -e
 # Default: http://localhost:9080 (sidecar pattern, same Pod)
 API_BACKEND_URL="${API_BACKEND_URL:-http://localhost:9080}"
 
-# sed -i creates a temp file in the same directory which requires dir write access;
-# use redirect to /tmp instead, then copy back over the owned file
+# Perform in-place substitution using a temp file and shell redirection.
+# We avoid `sed -i` (needs dir write) and `cp` (fails on overlayfs).
 sed "s|API_BACKEND_URL|${API_BACKEND_URL}|g" /etc/nginx/nginx.conf > /tmp/nginx.conf.tmp
-cp /tmp/nginx.conf.tmp /etc/nginx/nginx.conf
+cat /tmp/nginx.conf.tmp > /etc/nginx/nginx.conf
 rm -f /tmp/nginx.conf.tmp
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- Fixes WebUI frontend CrashLoopBackOff caused by `cp: can't create '/etc/nginx/nginx.conf': File exists`
- Alpine busybox `cp` fails on overlayfs (container runtimes) when target file exists
- Uses `cat > file` shell redirection instead, which overwrites via the existing file descriptor

## Test plan
- [ ] Build webui image and verify container starts without crash
- [ ] Verify nginx serves the frontend with correct API_BACKEND_URL substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)