### PR TITLE
[Fix] Use correct Linux capability names for eBPF (BPF, PERFMON)

### DIFF
--- a/charts/novaedge/templates/agent-daemonset.yaml
+++ b/charts/novaedge/templates/agent-daemonset.yaml
@@ -144,7 +144,8 @@ spec:
             - NET_RAW
             - NET_BIND_SERVICE
             {{- if .Values.agent.ebpf.enabled }}
-            - SYS_BPF
+            - BPF
+            - PERFMON
             - SYS_RESOURCE
             {{- end }}
             drop:


### PR DESCRIPTION
## Summary

- Fixes `SYS_BPF` → `BPF` (correct Linux capability name, CAP_BPF bit 39)
- Adds `PERFMON` (CAP_PERFMON bit 38, needed for some BPF operations)
- `SYS_RESOURCE` was already correct

## Problem

`SYS_BPF` is not a valid Linux capability name. Kubernetes silently ignores unknown capabilities, so the agent was running without `CAP_BPF`. The cilium/ebpf `features.HaveProgramType(ebpf.SkLookup)` probe then fails because it can't load a test BPF program, causing the fallback to nftables.

Debug log from agent: `kernel does not support BPF_PROG_TYPE_SK_LOOKUP, skipping eBPF mesh backend`

The kernel actually supports it (6.12.58, CONFIG_BPF=y), but the probe failed due to missing CAP_BPF.

## Test plan

- [ ] `helm template` renders `BPF`, `PERFMON`, `SYS_RESOURCE` capabilities — verified
- [ ] Deploy to cluster and verify agent logs show `using eBPF sk_lookup backend for mesh interception`

🤖 Generated with [Claude Code](https://claude.com/claude-code)