### PR TITLE
[Fix] Fix BPF compilation in Docker build for arm64

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -8,8 +8,9 @@ WORKDIR /workspace
 # Install BPF compilation tools for go generate (eBPF/XDP programs).
 # These are only needed at build time; the runtime image is separate.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang llvm libbpf-dev linux-headers-generic \
-    && rm -rf /var/lib/apt/lists/*
+    clang llvm libbpf-dev linux-libc-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/include/$(gcc -dumpmachine)/asm /usr/include/asm
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/bpf/afxdp_redirect.c
+++ b/bpf/afxdp_redirect.c
@@ -13,6 +13,15 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_endian.h>
 
+// Network constants needed for BPF target compilation where kernel
+// headers may not fully resolve (standard BPF practice).
+#ifndef IPPROTO_TCP
+#define IPPROTO_TCP 6
+#endif
+#ifndef IPPROTO_UDP
+#define IPPROTO_UDP 17
+#endif
+
 // VIP key for flow matching — same as xdp_lb.c for consistency.
 struct vip_key {
     __u32 addr;     // IPv4 address in network byte order

--- a/bpf/mesh_redirect.c
+++ b/bpf/mesh_redirect.c
@@ -19,6 +19,15 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_endian.h>
 
+// Network constants needed for BPF target compilation where kernel
+// headers may not fully resolve (standard BPF practice).
+#ifndef AF_INET
+#define AF_INET 2
+#endif
+#ifndef IPPROTO_TCP
+#define IPPROTO_TCP 6
+#endif
+
 // mesh_services maps {dst_ip, dst_port} -> {redirect_port}.
 // When a connection matches, we redirect it to the local TPROXY listener
 // on redirect_port.


### PR DESCRIPTION
## Summary
- Replace `linux-headers-generic` (Ubuntu-only) with `linux-libc-dev` (Debian) in `Dockerfile.agent`
- Add `asm` → arch-specific `asm` symlink for BPF target compilation (`clang -target bpfel`)
- Define `IPPROTO_TCP`, `IPPROTO_UDP`, `AF_INET` directly in BPF C sources where kernel headers don't resolve for the BPF target (standard practice used by cilium and other eBPF projects)

Fixes #545

## Root Cause
The `golang:1.26` Docker image is Debian-based. On Debian with multi-arch, `asm/types.h` lives at `/usr/include/aarch64-linux-gnu/asm/types.h`, but `clang -target bpfel` only looks in `/usr/include/asm/`. Additionally, some kernel headers (like `AF_INET`) don't resolve when compiling for the BPF target.

## Test plan
- [x] `podman build --platform linux/arm64` succeeds — all 3 BPF programs (mesh_redirect, xdp_lb, afxdp_redirect) compile
- [x] Agent binary builds and image pushed to ghcr.io
- [ ] Deploy to cluster and verify eBPF sk_lookup backend activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)