### PR TITLE
[Performance] Eliminate hot-path lock contention in agent request handling

### DIFF
--- a/internal/agent/health/checker.go
+++ b/internal/agent/health/checker.go
@@ -104,6 +104,16 @@ type Checker struct {
 	// Stop channel
 	stopCh chan struct{}
 	wg     sync.WaitGroup
+
+	// recordCh is used for async passive health recording (RecordSuccess/RecordFailure).
+	// Sending to this channel is non-blocking, keeping the hot request path lock-free.
+	recordCh chan passiveRecord
+}
+
+// passiveRecord carries a single passive health event (success or failure).
+type passiveRecord struct {
+	endpoint *pb.Endpoint
+	success  bool
 }
 
 // Result stores the result of a health check
@@ -156,8 +166,9 @@ func NewChecker(cluster *pb.Cluster, endpoints []*pb.Endpoint, logger *zap.Logge
 				},
 			},
 		},
-		config: config,
-		stopCh: make(chan struct{}),
+		config:   config,
+		stopCh:   make(chan struct{}),
+		recordCh: make(chan passiveRecord, 10000),
 	}
 
 	// Configure gRPC health checking if the cluster specifies it
@@ -255,6 +266,10 @@ func (hc *Checker) Start(ctx context.Context) {
 	// Start health check loop
 	hc.wg.Add(1)
 	go hc.healthCheckLoop(ctx)
+
+	// Start passive record processor
+	hc.wg.Add(1)
+	go hc.processPassiveRecords(ctx)
 }
 
 // Stop stops the health checker
@@ -325,35 +340,80 @@ func (hc *Checker) IsHealthy(endpoint *pb.Endpoint) bool {
 	return result.Healthy
 }
 
-// RecordSuccess records a successful request (for passive health checking)
+// RecordSuccess records a successful request (for passive health checking).
+// This is called on every request so it must be lock-free — it sends a
+// non-blocking event to the background processor.
 func (hc *Checker) RecordSuccess(endpoint *pb.Endpoint) {
-	hc.mu.Lock()
-	defer hc.mu.Unlock()
-
-	key := endpointKey(endpoint)
-	if cb, exists := hc.circuitBreakers[key]; exists {
-		cb.RecordSuccess()
+	select {
+	case hc.recordCh <- passiveRecord{endpoint: endpoint, success: true}:
+	default:
+		// Channel full — drop event. Passive records are best-effort;
+		// active health checks provide the authoritative health state.
 	}
 }
 
-// RecordFailure records a failed request (for passive health checking)
+// RecordFailure records a failed request (for passive health checking).
+// This is called on every failed request so it must be lock-free — it sends
+// a non-blocking event to the background processor.
 func (hc *Checker) RecordFailure(endpoint *pb.Endpoint) {
+	select {
+	case hc.recordCh <- passiveRecord{endpoint: endpoint, success: false}:
+	default:
+		// Channel full — drop event (see RecordSuccess comment).
+	}
+}
+
+// processPassiveRecords drains the recordCh channel and applies passive
+// health events under the write lock. Running as a single goroutine
+// serializes all passive updates without blocking the request hot path.
+func (hc *Checker) processPassiveRecords(ctx context.Context) {
+	defer hc.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-hc.stopCh:
+			return
+		case rec := <-hc.recordCh:
+			hc.applyPassiveRecord(rec)
+		}
+	}
+}
+
+// applyPassiveRecord applies a single passive health record under the write lock.
+func (hc *Checker) applyPassiveRecord(rec passiveRecord) {
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	key := endpointKey(endpoint)
-	if cb, exists := hc.circuitBreakers[key]; exists {
-		cb.RecordFailure()
+	key := endpointKey(rec.endpoint)
+	if rec.success {
+		if cb, exists := hc.circuitBreakers[key]; exists {
+			cb.RecordSuccess()
+		}
+	} else {
+		if cb, exists := hc.circuitBreakers[key]; exists {
+			cb.RecordFailure()
+		}
+		if result, exists := hc.results[key]; exists {
+			result.ConsecutiveSuccesses = 0
+			result.ConsecutiveFailures++
+			if result.ConsecutiveFailures >= DefaultUnhealthyThreshold {
+				result.Healthy = false
+			}
+		}
 	}
+}
 
-	// Also update health result
-	if result, exists := hc.results[key]; exists {
-		result.ConsecutiveSuccesses = 0
-		result.ConsecutiveFailures++
-
-		// Mark unhealthy after threshold
-		if result.ConsecutiveFailures >= DefaultUnhealthyThreshold {
-			result.Healthy = false
+// drainRecordCh synchronously processes all buffered passive records.
+// It is intended for use in tests only, where the background goroutine
+// started by Start() is not running.
+func (hc *Checker) drainRecordCh() {
+	for {
+		select {
+		case rec := <-hc.recordCh:
+			hc.applyPassiveRecord(rec)
+		default:
+			return
 		}
 	}
 }

--- a/internal/agent/health/checker_test.go
+++ b/internal/agent/health/checker_test.go
@@ -223,6 +223,7 @@ func TestHealthChecker_RecordFailure_ThresholdBehavior(t *testing.T) {
 	for i := uint32(0); i < DefaultUnhealthyThreshold-1; i++ {
 		hc.RecordFailure(ep)
 	}
+	hc.drainRecordCh()
 
 	// Should still be healthy (below threshold)
 	if !hc.results[key].Healthy {
@@ -231,6 +232,7 @@ func TestHealthChecker_RecordFailure_ThresholdBehavior(t *testing.T) {
 
 	// One more failure to cross threshold
 	hc.RecordFailure(ep)
+	hc.drainRecordCh()
 
 	if hc.results[key].Healthy {
 		t.Error("endpoint should be unhealthy after crossing failure threshold")
@@ -260,9 +262,10 @@ func TestHealthChecker_RecordSuccess_ResetsFailures(t *testing.T) {
 	cb.SetCluster(clusterKey)
 	hc.circuitBreakers[key] = cb
 
-	// Record a failure then a success
+	// Record a failure then a success (enqueued in order, processed in order)
 	hc.RecordFailure(ep)
 	hc.RecordSuccess(ep)
+	hc.drainRecordCh()
 
 	// The circuit breaker success doesn't reset the health result failure counter
 	// but the circuit breaker's internal state should be reset

--- a/internal/agent/server/drain.go
+++ b/internal/agent/server/drain.go
@@ -65,9 +65,7 @@ func NewDrainManager(logger *zap.Logger, timeout time.Duration) *DrainManager {
 // The provided context can be used for early cancellation.
 func (dm *DrainManager) StartDrain(ctx context.Context) {
 	dm.draining.Store(true)
-	dm.mu.Lock()
-	active := dm.activeCount
-	dm.mu.Unlock()
+	active := atomic.LoadInt64(&dm.activeCount)
 	dm.logger.Info("Connection draining started",
 		zap.Duration("timeout", dm.drainTimeout),
 		zap.Int64("active_connections", active),
@@ -77,10 +75,12 @@ func (dm *DrainManager) StartDrain(ctx context.Context) {
 	defer cancel()
 
 	// Wait for all active connections to complete or for the timeout.
+	// activeCount is modified atomically (without the mutex) so we use
+	// atomic.LoadInt64 inside the wait loop.
 	done := make(chan struct{})
 	go func() {
 		dm.mu.Lock()
-		for dm.activeCount > 0 {
+		for atomic.LoadInt64(&dm.activeCount) > 0 {
 			dm.zeroCond.Wait()
 		}
 		dm.mu.Unlock()
@@ -91,9 +91,7 @@ func (dm *DrainManager) StartDrain(ctx context.Context) {
 	case <-done:
 		dm.logger.Info("All active connections drained successfully")
 	case <-timeoutCtx.Done():
-		dm.mu.Lock()
-		remaining := dm.activeCount
-		dm.mu.Unlock()
+		remaining := atomic.LoadInt64(&dm.activeCount)
 		dm.logger.Warn("Drain timeout reached, proceeding with config swap",
 			zap.Int64("remaining_connections", remaining),
 		)
@@ -112,28 +110,26 @@ func (dm *DrainManager) IsDraining() bool {
 
 // TrackConnection increments the active connection counter. Each call must
 // be paired with a corresponding ReleaseConnection call.
+// Uses atomic add to avoid mutex contention in the hot request path.
 func (dm *DrainManager) TrackConnection() {
-	dm.mu.Lock()
-	dm.activeCount++
-	dm.mu.Unlock()
+	atomic.AddInt64(&dm.activeCount, 1)
 }
 
 // ReleaseConnection decrements the active connection counter.
+// Uses atomic add to avoid mutex contention in the hot request path.
+// When draining, broadcasts once the count reaches zero so StartDrain unblocks.
 func (dm *DrainManager) ReleaseConnection() {
-	dm.mu.Lock()
-	dm.activeCount--
-	if dm.activeCount <= 0 {
+	if atomic.AddInt64(&dm.activeCount, -1) == 0 {
+		// Broadcast doesn't require holding the lock (see sync.Cond documentation).
+		// StartDrain re-reads the count atomically inside its wait loop, so a
+		// spurious broadcast when not draining is harmless.
 		dm.zeroCond.Broadcast()
 	}
-	dm.mu.Unlock()
 }
 
 // ActiveConnections returns the current number of tracked active connections.
 func (dm *DrainManager) ActiveConnections() int64 {
-	dm.mu.Lock()
-	count := dm.activeCount
-	dm.mu.Unlock()
-	return count
+	return atomic.LoadInt64(&dm.activeCount)
 }
 
 // DrainMiddleware returns an HTTP middleware that integrates with the

--- a/internal/agent/server/http.go
+++ b/internal/agent/server/http.go
@@ -270,14 +270,15 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Route the request
 	s.router.ServeHTTP(w, r)
 
-	// Log request completion
-	duration := time.Since(startTime)
-	s.logger.Info("Request completed",
-		zap.String("method", r.Method),
-		zap.String("host", r.Host),
-		zap.String("path", r.URL.Path),
-		zap.Duration("duration", duration),
-	)
+	// Log request completion at debug level to keep the hot path lock-free
+	if ce := s.logger.Check(zap.DebugLevel, "Request completed"); ce != nil {
+		ce.Write(
+			zap.String("method", r.Method),
+			zap.String("host", r.Host),
+			zap.String("path", r.URL.Path),
+			zap.Duration("duration", time.Since(startTime)),
+		)
+	}
 }
 
 // Shutdown gracefully shuts down all HTTP servers with timeout

--- a/internal/agent/upstream/pool.go
+++ b/internal/agent/upstream/pool.go
@@ -312,8 +312,11 @@ func (p *Pool) createProxies() {
 		proxy := httputil.NewSingleHostReverseProxy(target)
 		proxy.Transport = p.transport
 
-		// Enable flushing for streaming responses (required for gRPC and WebSockets)
-		proxy.FlushInterval = -1 // Flush immediately for streaming
+		// Flush periodically for streaming; the ReverseProxy automatically
+		// flushes immediately for detected streaming responses (Content-Length: -1,
+		// e.g. gRPC and WebSocket), so -1 (flush-per-write) is unnecessary and
+		// adds overhead for regular HTTP responses.
+		proxy.FlushInterval = 100 * time.Millisecond
 
 		// Custom error handler
 		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {


### PR DESCRIPTION
## Problem

Comparative load testing revealed ~17x throughput gap between NovaEdge (~3k QPS) and direct backend access (~53k QPS) despite workers at only 13-18% CPU — a clear sign of lock serialization, not compute saturation.

## Root Causes & Fixes

### 1. `logger.Info` on every request — `internal/agent/server/http.go`

`ServeHTTP` called `s.logger.Info("Request completed", ...)` on every request, serializing all goroutines through the zap log writer.

**Fix:** Changed to `s.logger.Check(zap.DebugLevel, ...)` — zero allocation and no serialization in production (INFO level).

### 2. `sync.Mutex` per request in DrainManager — `internal/agent/server/drain.go`

`TrackConnection()` and `ReleaseConnection()` both acquired a `sync.Mutex` on every request just to increment/decrement a counter.

**Fix:** Replaced with `atomic.AddInt64`. The mutex is retained only for `StartDrain`'s `sync.Cond` wait (rare: only on config reload). `ReleaseConnection` broadcasts the cond var when count reaches 0 without holding the lock — safe per `sync.Cond` documentation.

### 3. Global write lock per request in health checker — `internal/agent/health/checker.go`

`RecordSuccess`/`RecordFailure` both took `hc.mu.Lock()` (full write lock) on every request to update circuit breaker counters — a single lock shared across all concurrent requests.

**Fix:** Both methods now do a non-blocking send to a buffered channel (capacity 10,000). A dedicated background goroutine drains the channel and applies updates under the lock. Passive records are best-effort; active health checks remain authoritative for health state.

### 4. Flush-per-write for all responses — `internal/agent/upstream/pool.go`

`FlushInterval = -1` caused `httputil.ReverseProxy` to flush after every write chunk for all responses, including regular HTTP.

**Fix:** Changed to `100ms` periodic flushing. Go's ReverseProxy already auto-detects streaming responses (`Content-Length: -1`, gRPC, WebSocket) and flushes them immediately regardless of `FlushInterval`.

## Test Plan

- [x] `go test ./internal/agent/server/... ./internal/agent/health/... ./internal/agent/upstream/...` — all pass
- [x] `go test ./internal/agent/...` — all pass (18 packages)
- [x] `go vet ./internal/agent/server/... ./internal/agent/health/... ./internal/agent/upstream/...` — clean
- [ ] Deploy to cluster and re-run fortio load test to measure QPS improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)