### PR TITLE
[Fix] Include endpoints in snapshot version hash

### DIFF
--- a/internal/controller/snapshot/builder.go
+++ b/internal/controller/snapshot/builder.go
@@ -1349,7 +1349,9 @@ func (b *Builder) loadWASMBinary(source, defaultNamespace string, bc *buildConte
 	return nil, fmt.Errorf("WASM binary not found in ConfigMap %s/%s (expected key: plugin.wasm)", namespace, name)
 }
 
-// generateVersion generates a version string based on content hash
+// generateVersion generates a version string based on content hash.
+// The hash must include ALL mutable snapshot fields so that downstream
+// consumers (e.g. the agent's HTTPServer.ApplyConfig) detect changes.
 func (b *Builder) generateVersion(snapshot *pb.ConfigSnapshot) string {
 	// Create a deterministic string representation
 	parts := make([]string, 0, len(snapshot.Gateways)+len(snapshot.Routes)+len(snapshot.Clusters)+len(snapshot.VipAssignments)+len(snapshot.Policies))
@@ -1363,6 +1365,13 @@ func (b *Builder) generateVersion(snapshot *pb.ConfigSnapshot) string {
 	}
 	for _, c := range snapshot.Clusters {
 		parts = append(parts, fmt.Sprintf("cluster:%s/%s", c.Namespace, c.Name))
+	}
+	// Include endpoint addresses and ports so that pod IP changes
+	// (e.g. after a scale-down/up) produce a different version hash.
+	for clusterName, epList := range snapshot.Endpoints {
+		for _, ep := range epList.Endpoints {
+			parts = append(parts, fmt.Sprintf("ep:%s:%s:%d:%v", clusterName, ep.Address, ep.Port, ep.Ready))
+		}
 	}
 	for _, vip := range snapshot.VipAssignments {
 		part := fmt.Sprintf("vip:%s:%s", vip.VipName, vip.Address)


### PR DESCRIPTION
## Summary

- **Bug**: `generateVersion()` only hashed gateway/route/cluster/VIP/policy names, completely omitting endpoint addresses and ports from the hash
- **Impact**: When backend pods were recycled (scale down/up, rolling restart, node drain), the snapshot version hash stayed the same. The agent's `HTTPServer.ApplyConfig()` uses this hash as a cache key — identical hash means "nothing changed", so it skipped reconfiguration. Health checkers retained stale pod IPs with open circuit breakers, causing **100% 502 errors** for all traffic through the VIP
- **Fix**: Include endpoint address, port, and ready status in the version hash so pod IP changes produce a different hash and trigger agent reconfiguration

### Root cause chain
1. `builder.go:generateVersion()` hashes only resource names, not endpoint data
2. Pod IPs change → snapshot rebuilt with new endpoints → same version hash
3. `server.go:StreamConfig()` sends triggered update (no version check on this path)
4. Agent receives snapshot → `HTTPServer.ApplyConfig()` compares `snapshot.Version` with `lastAppliedHash` → match → **skips entire config apply**
5. Router/health-checker never learns about new endpoints → circuit breakers stay open on dead IPs → 502

## Test plan

- [x] `go test ./internal/controller/snapshot/...` passes
- [x] `go build ./internal/controller/snapshot/` compiles
- [ ] Deploy to cluster, scale fortio 0→6, verify agents detect endpoint change and serve traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)