### PR TITLE
[Performance] Event debouncing, generation-skip reconciliation, and snapshot dedup

### DIFF
--- a/internal/controller/proxybackend_controller.go
+++ b/internal/controller/proxybackend_controller.go
@@ -64,6 +64,12 @@ func (r *ProxyBackendReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	// Skip if already reconciled this generation (ObservedGeneration > 0
+	// ensures first-ever reconciliation always proceeds)
+	if backend.Status.ObservedGeneration != 0 && backend.Status.ObservedGeneration == backend.Generation {
+		return ctrl.Result{}, nil
+	}
+
 	logger.Info("Reconciling ProxyBackend", "name", backend.Name, "lbPolicy", backend.Spec.LBPolicy)
 
 	// Validate and update status

--- a/internal/controller/proxygateway_controller.go
+++ b/internal/controller/proxygateway_controller.go
@@ -80,6 +80,12 @@ func (r *ProxyGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	// Skip if already reconciled this generation (ObservedGeneration > 0
+	// ensures first-ever reconciliation always proceeds)
+	if gateway.Status.ObservedGeneration != 0 && gateway.Status.ObservedGeneration == gateway.Generation {
+		return ctrl.Result{}, nil
+	}
+
 	logger.Info("Reconciling ProxyGateway", "name", gateway.Name, "vipRef", gateway.Spec.VIPRef)
 
 	// Check loadBalancerClass: only reconcile gateways matching our class

--- a/internal/controller/proxypolicy_controller.go
+++ b/internal/controller/proxypolicy_controller.go
@@ -64,6 +64,12 @@ func (r *ProxyPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	// Skip if already reconciled this generation (ObservedGeneration > 0
+	// ensures first-ever reconciliation always proceeds)
+	if policy.Status.ObservedGeneration != 0 && policy.Status.ObservedGeneration == policy.Generation {
+		return ctrl.Result{}, nil
+	}
+
 	logger.Info("Reconciling ProxyPolicy", "name", policy.Name, "type", policy.Spec.Type, "target", policy.Spec.TargetRef.Name)
 
 	// Validate and update status

--- a/internal/controller/proxyroute_controller.go
+++ b/internal/controller/proxyroute_controller.go
@@ -61,6 +61,12 @@ func (r *ProxyRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// Skip if already reconciled this generation (ObservedGeneration > 0
+	// ensures first-ever reconciliation always proceeds)
+	if route.Status.ObservedGeneration != 0 && route.Status.ObservedGeneration == route.Generation {
+		return ctrl.Result{}, nil
+	}
+
 	logger.Info("Reconciling ProxyRoute", "name", route.Name, "hostnames", route.Spec.Hostnames)
 
 	// Validate and update status

--- a/internal/controller/proxyvip_controller.go
+++ b/internal/controller/proxyvip_controller.go
@@ -73,6 +73,12 @@ func (r *ProxyVIPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
+	// Skip if already reconciled this generation (ObservedGeneration > 0
+	// ensures first-ever reconciliation always proceeds)
+	if vip.Status.ObservedGeneration != 0 && vip.Status.ObservedGeneration == vip.Generation {
+		return ctrl.Result{}, nil
+	}
+
 	logger.Info("Reconciling ProxyVIP", "name", vip.Name, "mode", vip.Spec.Mode, "address", vip.Spec.Address)
 
 	// Handle IPAM allocation if poolRef is set and no address allocated yet

--- a/internal/controller/snapshot/server.go
+++ b/internal/controller/snapshot/server.go
@@ -99,6 +99,12 @@ type Server struct {
 	// on the hot path.
 	dirty atomic.Bool
 
+	// debounceTimer coalesces rapid TriggerUpdate calls within a 100ms window.
+	// Instead of notifying agents on every watch event, the timer is reset on
+	// each call and the actual notification fires only after 100ms of quiet.
+	debounceTimer *time.Timer
+	debounceMu    sync.Mutex
+
 	// Shutdown channel for cleanup goroutine
 	shutdownCh chan struct{}
 }
@@ -249,6 +255,11 @@ func (s *Server) StreamConfig(req *pb.StreamConfigRequest, stream pb.ConfigServi
 				continue
 			}
 
+			// Skip if version hasn't changed since last push (content-hash dedup)
+			if newSnapshot.Version == lastVersion {
+				continue
+			}
+
 			if err := stream.Send(newSnapshot); err != nil {
 				logger.Error(err, "Failed to send triggered snapshot")
 				return status.Errorf(codes.Internal, "failed to send snapshot: %v", err)
@@ -297,13 +308,29 @@ func (s *Server) ReportStatus(ctx context.Context, req *pb.AgentStatus) (*pb.Sta
 // TriggerUpdate triggers a config update for all nodes or a specific node.
 // It also marks the server as dirty so the periodic fallback rebuild knows
 // that resources have changed.
+//
+// Rapid calls are debounced within a 100ms coalescing window: the actual
+// notification is delayed until 100ms after the last call, preventing
+// unnecessary snapshot rebuilds during bursts of watch events.
 func (s *Server) TriggerUpdate(nodeName string) {
 	s.dirty.Store(true)
+
+	s.debounceMu.Lock()
+	defer s.debounceMu.Unlock()
+
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+	}
+	s.debounceTimer = time.AfterFunc(100*time.Millisecond, func() {
+		s.doTrigger(nodeName)
+	})
+}
+
+// doTrigger performs the actual cache notification after the debounce window.
+func (s *Server) doTrigger(nodeName string) {
 	if nodeName == "" {
-		// Trigger update for all nodes
 		s.cache.NotifyAll()
 	} else {
-		// Trigger update for specific node
 		s.cache.Notify(nodeName)
 	}
 }
@@ -546,6 +573,11 @@ func (s *Server) RequestMeshCertificate(ctx context.Context, req *pb.MeshCertifi
 
 // Shutdown gracefully shuts down the server
 func (s *Server) Shutdown() {
+	s.debounceMu.Lock()
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+	}
+	s.debounceMu.Unlock()
 	close(s.shutdownCh)
 }
 


### PR DESCRIPTION
## Summary
- **Event debouncing (100ms):** `TriggerUpdate()` now uses a debounce timer that coalesces rapid watch events into a single notification after 100ms of quiet, preventing burst rebuilds when multiple CRDs change in rapid succession.
- **Generation-based reconciliation skip:** All five core reconcilers (ProxyRoute, ProxyGateway, ProxyBackend, ProxyPolicy, ProxyVIP) now check `ObservedGeneration == Generation` at the top of `Reconcile()` and skip no-op work when the generation has already been processed.
- **Content-hash dedup for triggered snapshots:** The `StreamConfig` triggered-update path now compares `newSnapshot.Version` against `lastVersion` and skips sending identical snapshots, matching the behavior already present in the periodic rebuild path.

Closes #636, partially addresses #634.

## Files Modified
- `internal/controller/snapshot/server.go` — debounce timer, `doTrigger()`, content-hash dedup, shutdown cleanup
- `internal/controller/proxyroute_controller.go` — generation skip
- `internal/controller/proxygateway_controller.go` — generation skip
- `internal/controller/proxybackend_controller.go` — generation skip
- `internal/controller/proxypolicy_controller.go` — generation skip
- `internal/controller/proxyvip_controller.go` — generation skip

## Test plan
- [x] `go build ./cmd/novaedge-controller/...` compiles successfully
- [x] `go test ./internal/controller/...` — all tests pass (7 sub-packages)
- [x] `go test ./internal/controller/snapshot/...` — all tests pass
- [ ] Manual verification: deploy to dev cluster and confirm debounce reduces snapshot push frequency during CRD bursts
- [ ] Verify agents still receive updates within ~100ms of the last change event

🤖 Generated with [Claude Code](https://claude.com/claude-code)