### PR TITLE
[Performance] Add Go runtime tuning and verify splice/flush optimizations

### DIFF
--- a/charts/novaedge-agent/templates/daemonset.yaml
+++ b/charts/novaedge-agent/templates/daemonset.yaml
@@ -136,6 +136,18 @@ spec:
             - name: NOVAEDGE_CLUSTER_ZONE
               value: {{ .Values.cluster.zone | quote }}
             {{- end }}
+            {{- if .Values.goMemLimit }}
+            - name: GOMEMLIMIT
+              value: {{ .Values.goMemLimit | quote }}
+            {{- end }}
+            {{- if .Values.goGC }}
+            - name: GOGC
+              value: {{ .Values.goGC | quote }}
+            {{- end }}
+            {{- if .Values.goMaxProcs }}
+            - name: GOMAXPROCS
+              value: {{ .Values.goMaxProcs | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/novaedge-agent/values.yaml
+++ b/charts/novaedge-agent/values.yaml
@@ -772,6 +772,18 @@ podDisruptionBudget:
   enabled: true
   maxUnavailable: 1
 
+# -- Go runtime tuning
+# GOMEMLIMIT sets the soft memory limit for the Go garbage collector.
+# Should be ~90% of the container memory limit to avoid OOM kills.
+goMemLimit: "900MiB"
+# GOGC sets the garbage collection target percentage.
+# Higher values reduce GC frequency at the cost of more memory usage.
+# 200 is appropriate for latency-sensitive data-plane workloads.
+goGC: "200"
+# GOMAXPROCS limits the number of OS threads for Go goroutines.
+# Defaults to the number of CPU cores available. Set to match CPU limits.
+goMaxProcs: ""
+
 # -- Additional environment variables
 extraEnv: []
 # - name: MY_VAR

--- a/charts/novaedge/templates/agent-daemonset.yaml
+++ b/charts/novaedge/templates/agent-daemonset.yaml
@@ -99,6 +99,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        {{- if .Values.agent.goMemLimit }}
+        - name: GOMEMLIMIT
+          value: {{ .Values.agent.goMemLimit | quote }}
+        {{- end }}
+        {{- if .Values.agent.goGC }}
+        - name: GOGC
+          value: {{ .Values.agent.goGC | quote }}
+        {{- end }}
+        {{- if .Values.agent.goMaxProcs }}
+        - name: GOMAXPROCS
+          value: {{ .Values.agent.goMaxProcs | quote }}
+        {{- end }}
         {{- with .Values.agent.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/novaedge/templates/controller-deployment.yaml
+++ b/charts/novaedge/templates/controller-deployment.yaml
@@ -112,6 +112,18 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         env:
+        {{- if .Values.controller.goMemLimit }}
+        - name: GOMEMLIMIT
+          value: {{ .Values.controller.goMemLimit | quote }}
+        {{- end }}
+        {{- if .Values.controller.goGC }}
+        - name: GOGC
+          value: {{ .Values.controller.goGC | quote }}
+        {{- end }}
+        {{- if .Values.controller.goMaxProcs }}
+        - name: GOMAXPROCS
+          value: {{ .Values.controller.goMaxProcs | quote }}
+        {{- end }}
         {{- with .Values.controller.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/novaedge/values.yaml
+++ b/charts/novaedge/values.yaml
@@ -138,6 +138,17 @@ controller:
   tolerations: []
   affinity: {}
 
+  # Go runtime tuning
+  # GOMEMLIMIT sets the soft memory limit for the Go garbage collector.
+  # Should be ~90% of the container memory limit to avoid OOM kills.
+  goMemLimit: "460MiB"
+  # GOGC sets the garbage collection target percentage.
+  # 100 is the Go default, suitable for the controller's workload.
+  goGC: "100"
+  # GOMAXPROCS limits the number of OS threads for Go goroutines.
+  # Defaults to the number of CPU cores available. Set to match CPU limits.
+  goMaxProcs: ""
+
   # Additional environment variables
   extraEnv: []
 
@@ -264,6 +275,18 @@ agent:
   podDisruptionBudget:
     enabled: true
     maxUnavailable: 1
+
+  # Go runtime tuning
+  # GOMEMLIMIT sets the soft memory limit for the Go garbage collector.
+  # Should be ~90% of the container memory limit to avoid OOM kills.
+  goMemLimit: "900MiB"
+  # GOGC sets the garbage collection target percentage.
+  # Higher values reduce GC frequency at the cost of more memory usage.
+  # 200 is appropriate for latency-sensitive data-plane workloads.
+  goGC: "200"
+  # GOMAXPROCS limits the number of OS threads for Go goroutines.
+  # Defaults to the number of CPU cores available. Set to match CPU limits.
+  goMaxProcs: ""
 
   # Additional environment variables
   extraEnv: []

--- a/config/agent/daemonset.yaml
+++ b/config/agent/daemonset.yaml
@@ -74,6 +74,13 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
 
+        # Go runtime tuning: soft memory limit (90% of 1Gi memory limit)
+        - name: GOMEMLIMIT
+          value: "900MiB"
+        # Go runtime tuning: GC target percentage (200 = less frequent GC for latency-sensitive agent)
+        - name: GOGC
+          value: "200"
+
         ports:
         # HTTP/HTTPS proxy ports
         - name: http

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -28,6 +28,13 @@ spec:
         - --metrics-bind-address=:8080
         - --health-probe-bind-address=:8081
         - --grpc-bind-address=:9090
+        env:
+        # Go runtime tuning: soft memory limit (90% of 512Mi memory limit)
+        - name: GOMEMLIMIT
+          value: "460MiB"
+        # Go runtime tuning: GC target percentage (100 = Go default, suitable for controller)
+        - name: GOGC
+          value: "100"
         ports:
         - name: metrics
           containerPort: 8080


### PR DESCRIPTION
## Summary

- **Issue #637**: Adds `GOMEMLIMIT`, `GOGC`, and `GOMAXPROCS` environment variables to all agent DaemonSet and controller Deployment manifests (Helm charts and kustomize)
- **Issue #635**: Verified that splice(2) zero-copy TCP proxying and buffered flush optimization are **already implemented** in the codebase

### Changes for #637 (Go runtime tuning)

**Helm charts:**
- `charts/novaedge-agent/values.yaml` — Added `goMemLimit`, `goGC`, `goMaxProcs` values (defaults: 900MiB, 200, empty)
- `charts/novaedge-agent/templates/daemonset.yaml` — Template conditionals for GOMEMLIMIT/GOGC/GOMAXPROCS env vars
- `charts/novaedge/values.yaml` — Added tuning values for both controller (460MiB, 100) and agent (900MiB, 200) sections
- `charts/novaedge/templates/controller-deployment.yaml` — Controller env vars
- `charts/novaedge/templates/agent-daemonset.yaml` — Agent env vars

**Kustomize manifests:**
- `config/agent/daemonset.yaml` — GOMEMLIMIT=900MiB, GOGC=200
- `config/controller/deployment.yaml` — GOMEMLIMIT=460MiB, GOGC=100

### Verification for #635 (splice/flush already implemented)

The following optimizations were found to already be fully implemented:

1. **splice(2) zero-copy TCP proxying** (`internal/agent/l4/splice_linux.go`):
   - Direct `unix.Splice` syscalls with 1MB pipe buffer
   - Platform-specific build tags (`//go:build linux` / `//go:build !linux`)
   - Graceful fallback on non-Linux via `splice_other.go`
   - `tcp_proxy.go` calls `trySplice()` first in `copyOneDirection()`, falls back to userspace buffered copy

2. **Buffered flush writer** (`internal/agent/mesh/tunnel.go`):
   - `bufferedFlushWriter` with 32KB buffer and 1ms periodic timer flush
   - `bufferedWriteAdapter` for use with `io.Copy`
   - Proper `Close()` that flushes remaining data and stops timer

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/agent/l4/... ./internal/agent/mesh/...` all pass (76 tests)
- [x] `helm template` renders correctly for all three charts
- [x] GOMAXPROCS correctly omitted when empty, included when set
- [x] Kustomize YAML validates

Closes #637
Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)