### PR TITLE
Fix Dockerfile.agent: add conntrack/maglev to go generate

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -31,7 +31,7 @@ COPY bpf/ bpf/
 # Generate BPF Go bindings from C sources (produces *_bpfel.go and *.o files).
 # Required — the generated loadMeshRedirect/loadXdpLb/loadAfxdpRedirect
 # functions are called at runtime and have no placeholder fallback.
-RUN go generate ./internal/agent/ebpfmesh/... ./internal/agent/xdplb/... ./internal/agent/afxdp/...
+RUN go generate ./internal/agent/ebpfmesh/... ./internal/agent/xdplb/... ./internal/agent/afxdp/... ./internal/agent/ebpf/conntrack/... ./internal/agent/ebpf/maglev/...
 
 # Build args for version injection
 ARG VERSION=dev


### PR DESCRIPTION
## Summary
- Add `./internal/agent/ebpf/conntrack/...` and `./internal/agent/ebpf/maglev/...` to the `go generate` line in Dockerfile.agent
- Without this, the agent Docker build fails with `undefined: loadConntrack` and `undefined: loadMaglevLookup`

## Test plan
- [ ] `docker build -f Dockerfile.agent .` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)