### PR TITLE
[Performance] L7 HTTP proxy quick-win optimizations

### DIFF
--- a/internal/agent/metrics/metrics.go
+++ b/internal/agent/metrics/metrics.go
@@ -19,8 +19,8 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -69,9 +69,11 @@ var (
 	lastBucketUpdate   time.Time
 )
 
-// trackedEndpoint holds metadata for a tracked endpoint
+// trackedEndpoint holds metadata for a tracked endpoint.
+// lastSeen is stored as UnixNano via atomic.Int64 to allow lock-free updates
+// on the hot path (shouldTrackEndpoint is called on every request).
 type trackedEndpoint struct {
-	lastSeen time.Time
+	lastSeen atomic.Int64 // UnixNano timestamp
 }
 
 // endpointCardinalityTracker tracks endpoints per cluster to limit metric cardinality
@@ -80,9 +82,11 @@ type endpointCardinalityTracker struct {
 	mu        sync.RWMutex
 }
 
-// shouldTrackEndpoint determines if we should track metrics for this endpoint
+// shouldTrackEndpoint determines if we should track metrics for this endpoint.
+// The hot path (already-tracked endpoint) uses only an RLock + atomic store,
+// avoiding the write lock that previously caused contention under load.
 func (t *endpointCardinalityTracker) shouldTrackEndpoint(cluster, endpoint string) bool {
-	now := time.Now()
+	nowNano := time.Now().UnixNano()
 
 	t.mu.RLock()
 	clusterEndpoints, exists := t.endpoints[cluster]
@@ -90,10 +94,12 @@ func (t *endpointCardinalityTracker) shouldTrackEndpoint(cluster, endpoint strin
 		ep, tracked := clusterEndpoints[endpoint]
 		t.mu.RUnlock()
 		if tracked {
-			// Update lastSeen under write lock
-			t.mu.Lock()
-			ep.lastSeen = now
-			t.mu.Unlock()
+			// Atomic update — no write lock needed.
+			// Only update when delta > 1s to reduce cache-line bouncing.
+			prev := ep.lastSeen.Load()
+			if nowNano-prev > int64(time.Second) {
+				ep.lastSeen.Store(nowNano)
+			}
 			return true
 		}
 	} else {
@@ -111,7 +117,7 @@ func (t *endpointCardinalityTracker) shouldTrackEndpoint(cluster, endpoint strin
 
 	// Check if already added by another goroutine
 	if ep, ok := t.endpoints[cluster][endpoint]; ok {
-		ep.lastSeen = now
+		ep.lastSeen.Store(nowNano)
 		return true
 	}
 
@@ -122,7 +128,9 @@ func (t *endpointCardinalityTracker) shouldTrackEndpoint(cluster, endpoint strin
 	}
 
 	// Add endpoint to tracking
-	t.endpoints[cluster][endpoint] = &trackedEndpoint{lastSeen: now}
+	ep := &trackedEndpoint{}
+	ep.lastSeen.Store(nowNano)
+	t.endpoints[cluster][endpoint] = ep
 	return true
 }
 
@@ -142,14 +150,13 @@ func (t *endpointCardinalityTracker) cleanupCluster(cluster string) {
 // cleanupStaleEndpoints removes endpoints not seen within the given TTL
 // and deletes their Prometheus metric series.
 func (t *endpointCardinalityTracker) cleanupStaleEndpoints(ttl time.Duration) {
-	now := time.Now()
-	cutoff := now.Add(-ttl)
+	cutoffNano := time.Now().Add(-ttl).UnixNano()
 
 	t.mu.Lock()
 	stale := make(map[string][]string) // cluster -> []endpoint
 	for cluster, endpoints := range t.endpoints {
 		for endpoint, ep := range endpoints {
-			if ep.lastSeen.Before(cutoff) {
+			if ep.lastSeen.Load() < cutoffNano {
 				stale[cluster] = append(stale[cluster], endpoint)
 			}
 		}
@@ -237,17 +244,25 @@ func getTimeBucket() string {
 	return cachedTimeBucket
 }
 
+// fnv32a computes an FNV-1a hash inline without allocating a hash.Hash.
+func fnv32a(s string) uint32 {
+	h := uint32(2166136261)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= 16777619
+	}
+	return h
+}
+
 // shouldSample determines if we should record this metric based on sampling rate
 func shouldSample(key string) bool {
 	if !defaultConfig.EnableSampling {
 		return true
 	}
 
-	// Use hash-based sampling for consistent decisions
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(key))
-	_, _ = h.Write([]byte(getTimeBucket()))
-	hash := h.Sum32()
+	// Use hash-based sampling for consistent decisions.
+	// Inline FNV avoids allocating fnv.New32a() per call.
+	hash := fnv32a(key + getTimeBucket())
 
 	return int(hash%100) < defaultConfig.SampleRate
 }

--- a/internal/agent/router/access_log.go
+++ b/internal/agent/router/access_log.go
@@ -18,11 +18,10 @@ package router
 
 import (
 	"bytes"
-	"crypto/rand"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"os"
@@ -300,17 +299,13 @@ func (alm *AccessLogMiddleware) Wrap(next http.Handler) http.Handler {
 	})
 }
 
-// shouldSample returns true if this request should be logged based on sample rate
+// shouldSample returns true if this request should be logged based on sample rate.
+// Uses math/rand/v2 (ChaCha8 PRNG) instead of crypto/rand to avoid a syscall per request.
 func (alm *AccessLogMiddleware) shouldSample() bool {
 	if alm.sampleRate >= 1.0 {
 		return true
 	}
-	var buf [8]byte
-	if _, err := rand.Read(buf[:]); err != nil {
-		return true // on error, default to logging
-	}
-	randVal := float64(binary.LittleEndian.Uint64(buf[:])) / float64(^uint64(0))
-	return randVal < alm.sampleRate
+	return rand.Float64() < alm.sampleRate
 }
 
 // shouldLog returns true if the given status code should be logged

--- a/internal/agent/router/forwarding.go
+++ b/internal/agent/router/forwarding.go
@@ -36,16 +36,10 @@ import (
 	pb "github.com/piwi3910/novaedge/internal/proto/gen"
 )
 
-// handleRoute handles a matched route
-func (r *Router) handleRoute(snap *routerState, entry *RouteEntry, w http.ResponseWriter, req *http.Request) {
-	// Wrap response writer with response filter if needed
-	responseWriter := w
-	if entry.ResponseFilter != nil && entry.ResponseFilter.HasModifications() {
-		responseWriter = NewResponseHeaderWriter(w, entry.ResponseFilter)
-	}
-
-	// Pipeline state is already injected into the context by ServeHTTP
-
+// buildHandler pre-composes the full middleware chain for a RouteEntry at config
+// time. This eliminates 5-7 closure allocations per request that previously
+// occurred in handleRoute.
+func (r *Router) buildHandler(snap *routerState, entry *RouteEntry) http.Handler {
 	// Create the final handler that forwards to backend (with optional retry)
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		r.forwardToBackend(snap, entry, w, req)
@@ -94,7 +88,28 @@ func (r *Router) handleRoute(snap *routerState, entry *RouteEntry, w http.Respon
 	if snap.errorPages != nil && snap.errorPages.IsEnabled() {
 		handler = snap.errorPages.Wrap(handler)
 	}
-	// Execute the handler chain: policies -> limits -> req buffering -> cache -> compression -> resp buffering -> error pages -> pipeline -> backend
+
+	return handler
+}
+
+// handleRoute handles a matched route using the pre-built middleware chain.
+// Only the response filter wrapper and optional trace span are per-request.
+func (r *Router) handleRoute(_ *routerState, entry *RouteEntry, w http.ResponseWriter, req *http.Request) {
+	// Wrap response writer with response filter if needed
+	responseWriter := w
+	if entry.ResponseFilter != nil && entry.ResponseFilter.HasModifications() {
+		responseWriter = NewResponseHeaderWriter(w, entry.ResponseFilter)
+	}
+
+	// Use the pre-built handler chain (single interface dispatch, no per-request allocations).
+	// Fallback: if handler wasn't pre-built (e.g. tests that bypass ApplyConfig),
+	// load the current state and build on-the-fly.
+	handler := entry.handler
+	if handler == nil {
+		snap := r.state.Load()
+		handler = r.buildHandler(snap, entry)
+	}
+
 	// In detailed trace mode, wrap the middleware chain in a child span.
 	if DefaultTraceVerbosity.ShouldTraceDetailed() {
 		ctx := req.Context()
@@ -353,8 +368,8 @@ func (r *Router) executeForward(ctx context.Context, snap *routerState, entry *R
 		w.Header().Set("X-Cache", "MISS")
 	}
 
-	// Check for retry configuration on this route rule
-	retryPolicy := NewRetryPolicy(entry.Rule.Retry)
+	// Use pre-built retry policy (built at config time to avoid per-request allocations)
+	retryPolicy := entry.retryPolicy
 
 	if retryPolicy != nil && !isGRPC {
 		var loadBalancer lb.LoadBalancer

--- a/internal/agent/router/route_entry.go
+++ b/internal/agent/router/route_entry.go
@@ -17,10 +17,10 @@ limitations under the License.
 package router
 
 import (
-	"crypto/rand"
 	"fmt"
 	"hash/fnv"
-	"math/big"
+	"math/rand/v2"
+	"net/http"
 	"regexp"
 	"sort"
 
@@ -47,6 +47,17 @@ type RouteEntry struct {
 	// ApplyConfig to avoid per-request string concatenation in the
 	// forwarding hot path.
 	BackendClusterKeys map[*pb.BackendRef]string
+
+	// retryPolicy is the pre-built retry policy for this route rule.
+	// Built once at config time to avoid per-request NewRetryPolicy allocations
+	// (struct + 2 maps per request).
+	retryPolicy *RetryPolicy
+
+	// handler is the pre-built middleware chain for this route.
+	// Composed once at config time (in BuildHandler) to avoid 5-7 closure
+	// allocations per request from re-wrapping middleware on every call.
+	// handleRoute becomes a single interface dispatch: entry.handler.ServeHTTP(w, req)
+	handler http.Handler
 }
 
 // compileHeaderRegexes pre-compiles all header regex patterns for a route rule
@@ -94,13 +105,9 @@ func selectWeightedBackend(backends []*pb.BackendRef) *pb.BackendRef {
 		totalWeight += weight
 	}
 
-	// Generate random number between 0 and totalWeight using crypto/rand
-	bigRand, err := rand.Int(rand.Reader, big.NewInt(int64(totalWeight)))
-	if err != nil {
-		// Fallback to first backend if crypto/rand fails
-		return backends[0]
-	}
-	randVal := bigRand.Int64()
+	// Generate random number between 0 and totalWeight using math/rand/v2
+	// (ChaCha8 PRNG — no syscall, no alloc; crypto strength unnecessary for traffic splitting)
+	randVal := rand.Int64N(int64(totalWeight))
 
 	// Select backend based on weight (use int64 arithmetic to avoid integer overflow)
 	var currentWeight int64

--- a/internal/agent/router/router.go
+++ b/internal/agent/router/router.go
@@ -76,6 +76,29 @@ func formatEndpointKey(address string, port int32) string {
 // tracerName is the instrumentation name for the router tracer
 const tracerName = "github.com/piwi3910/novaedge/internal/agent/router"
 
+// httpSpanNames is a pre-computed lookup table for OTel span names,
+// avoiding "HTTP " + req.Method string concatenation on every request.
+var httpSpanNames = map[string]string{
+	"GET":     "HTTP GET",
+	"POST":    "HTTP POST",
+	"PUT":     "HTTP PUT",
+	"DELETE":  "HTTP DELETE",
+	"PATCH":   "HTTP PATCH",
+	"HEAD":    "HTTP HEAD",
+	"OPTIONS": "HTTP OPTIONS",
+	"CONNECT": "HTTP CONNECT",
+	"TRACE":   "HTTP TRACE",
+}
+
+// httpSpanName returns the pre-computed span name for the given HTTP method,
+// falling back to concatenation for unknown methods.
+func httpSpanName(method string) string {
+	if name, ok := httpSpanNames[method]; ok {
+		return name
+	}
+	return "HTTP " + method
+}
+
 // routerState holds the immutable routing state that is atomically swapped
 // on each configuration update. ServeHTTP loads a snapshot of this state
 // once per request, so in-flight requests are never blocked by config updates.
@@ -309,6 +332,15 @@ func (r *Router) ApplyConfig(ctx context.Context, snapshot *config.Snapshot) err
 	// Create sticky session wrappers for clusters with session affinity
 	newState.stickyWrappers = r.buildStickyWrappers(snapshot, newLoadBalancers)
 
+	// Pre-build middleware handler chains for all route entries now that pools
+	// and balancers are ready. This moves 5-7 closure allocations per request
+	// to a one-time cost at config time.
+	for _, entries := range newState.routes {
+		for _, entry := range entries {
+			entry.handler = r.buildHandler(newState, entry)
+		}
+	}
+
 	// Atomically publish the new state so ServeHTTP picks it up without locking.
 	r.state.Store(newState)
 
@@ -380,6 +412,9 @@ func (r *Router) buildRouteEntry(ctx context.Context, route *pb.Route, rule *pb.
 			)
 		}
 	}
+
+	// Pre-build retry policy at config time (avoids struct + 2 map allocs per request)
+	entry.retryPolicy = NewRetryPolicy(rule.Retry)
 
 	// Pre-compute cluster keys for all backend refs
 	if len(rule.BackendRefs) > 0 {
@@ -649,7 +684,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Start the main request span. Attributes are set lazily below to avoid
 	// allocating attribute.String values when the span is not sampled (#131).
 	tracer := otel.Tracer(tracerName)
-	ctx, span := tracer.Start(ctx, "HTTP "+req.Method,
+	ctx, span := tracer.Start(ctx, httpSpanName(req.Method),
 		trace.WithSpanKind(trace.SpanKindServer),
 	)
 	defer span.End()

--- a/internal/agent/server/sockopts.go
+++ b/internal/agent/server/sockopts.go
@@ -34,6 +34,18 @@ func reusePortControl(_, _ string, c syscall.RawConn) error {
 	var opErr error
 	err := c.Control(func(fd uintptr) {
 		opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+		if opErr != nil {
+			return
+		}
+
+		// Disable delayed ACKs so the kernel ACKs SYN-ACK and early data
+		// immediately, shaving ~40ms off the first RTT on Linux.
+		_ = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_QUICKACK, 1)
+
+		// Increase socket buffer sizes to 256KB for better throughput
+		// under high concurrency. Errors are non-fatal (kernel may cap).
+		_ = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUF, 256*1024)
+		_ = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUF, 256*1024)
 	})
 	if err != nil {
 		return err

--- a/internal/agent/upstream/pool.go
+++ b/internal/agent/upstream/pool.go
@@ -54,6 +54,11 @@ type Pool struct {
 	// Reverse proxies per endpoint - atomic for lock-free reads in Forward()
 	proxies atomic.Pointer[map[string]*httputil.ReverseProxy]
 
+	// endpointKeys caches pre-computed "host:port" strings per endpoint ID
+	// (address + port) to avoid per-request strconv + JoinHostPort allocations.
+	// Atomically swapped alongside proxies.
+	endpointKeys atomic.Pointer[map[endpointID]string]
+
 	// Mutex only needed for endpoint updates (write path)
 	mu sync.Mutex
 
@@ -117,11 +122,11 @@ func NewPool(ctx context.Context, cluster *pb.Cluster, endpoints []*pb.Endpoint,
 	}
 	writeBufferSize := int(poolConfig.WriteBufferSize)
 	if writeBufferSize <= 0 {
-		writeBufferSize = 32 * 1024 // Default: 32KB
+		writeBufferSize = 64 * 1024 // Default: 64KB
 	}
 	readBufferSize := int(poolConfig.ReadBufferSize)
 	if readBufferSize <= 0 {
-		readBufferSize = 32 * 1024 // Default: 32KB
+		readBufferSize = 64 * 1024 // Default: 64KB
 	}
 
 	// Create HTTP transport with connection pooling
@@ -144,6 +149,7 @@ func NewPool(ctx context.Context, cluster *pb.Cluster, endpoints []*pb.Endpoint,
 		ForceAttemptHTTP2:      true,
 		WriteBufferSize:        writeBufferSize,
 		ReadBufferSize:         readBufferSize,
+		DisableCompression:     true, // Proxy handles compression; avoid double-compress to backends
 	}
 
 	// Configure backend TLS if enabled
@@ -165,9 +171,11 @@ func NewPool(ctx context.Context, cluster *pb.Cluster, endpoints []*pb.Endpoint,
 		clusterKey:         clusterKey,
 		hasExplicitTimeout: cluster.ConnectTimeoutMs > 0,
 	}
-	// Initialize atomic proxies
+	// Initialize atomic proxies and endpoint key cache
 	emptyProxies := make(map[string]*httputil.ReverseProxy)
 	pool.proxies.Store(&emptyProxies)
+	emptyKeys := make(map[endpointID]string)
+	pool.endpointKeys.Store(&emptyKeys)
 
 	// Create and start health checker
 	pool.healthChecker = health.NewChecker(cluster, endpoints, logger)
@@ -410,6 +418,7 @@ func (p *Pool) createProxies() {
 // under the lock or from NewPool before any concurrent access).
 func (p *Pool) createProxiesFrom(endpoints []*pb.Endpoint) {
 	newProxies := make(map[string]*httputil.ReverseProxy)
+	newKeys := make(map[endpointID]string, len(endpoints))
 
 	// Load current proxies for reuse
 	currentProxies := *p.proxies.Load()
@@ -420,6 +429,7 @@ func (p *Pool) createProxiesFrom(endpoints []*pb.Endpoint) {
 		}
 
 		key := endpointKey(ep)
+		newKeys[endpointID{ep.Address, ep.Port}] = key
 
 		// Reuse existing proxy if available (pool hit)
 		if proxy, ok := currentProxies[key]; ok {
@@ -479,11 +489,12 @@ func (p *Pool) createProxiesFrom(endpoints []*pb.Endpoint) {
 	}
 
 	p.proxies.Store(&newProxies)
+	p.endpointKeys.Store(&newKeys)
 }
 
 // Forward forwards an HTTP request to the specified endpoint
 func (p *Pool) Forward(endpoint *pb.Endpoint, req *http.Request, w http.ResponseWriter) error {
-	key := endpointKey(endpoint)
+	key := p.cachedEndpointKey(endpoint)
 	proxies := *p.proxies.Load()
 	proxy, ok := proxies[key]
 	if !ok {
@@ -521,9 +532,26 @@ func connectTimeout(ms int64) time.Duration {
 	return timeout
 }
 
+// endpointID is a value type used as a map key for cached endpoint strings.
+type endpointID struct {
+	Address string
+	Port    int32
+}
+
 // endpointKey builds a key for an endpoint using net.JoinHostPort
 func endpointKey(ep *pb.Endpoint) string {
 	return net.JoinHostPort(ep.Address, strconv.FormatInt(int64(ep.Port), 10))
+}
+
+// cachedEndpointKey returns the pre-computed key string for an endpoint,
+// falling back to endpointKey if the cache misses (should not happen).
+func (p *Pool) cachedEndpointKey(ep *pb.Endpoint) string {
+	if keys := p.endpointKeys.Load(); keys != nil {
+		if key, ok := (*keys)[endpointID{ep.Address, ep.Port}]; ok {
+			return key
+		}
+	}
+	return endpointKey(ep)
 }
 
 // Close closes the pool and all connections
@@ -607,7 +635,7 @@ func (p *Pool) GetBackendURL(endpoint *pb.Endpoint) string {
 	if p.cluster.Tls != nil && p.cluster.Tls.Enabled {
 		scheme = "https"
 	}
-	return scheme + "://" + endpointKey(endpoint)
+	return scheme + "://" + p.cachedEndpointKey(endpoint)
 }
 
 // GetClusterKey returns the cached cluster key (namespace/name)


### PR DESCRIPTION
## Summary

- **Pre-build middleware chain at config time** — moves 5-7 closure allocations per request to a one-time cost when config is applied; `handleRoute` becomes a single interface dispatch
- **Pre-build RetryPolicy at config time** — eliminates per-request struct + 2 map allocations
- **Replace `crypto/rand` with `math/rand/v2`** — removes `/dev/urandom` syscalls from traffic splitting (`selectWeightedBackend`) and access log sampling (`shouldSample`)
- **Pre-compute OTel span names** — lookup table replaces `"HTTP " + req.Method` string concatenation per request
- **Add `TCP_QUICKACK` + 256KB socket buffers** to listener sockets for lower first-RTT latency and better throughput
- **Bump upstream transport buffers** from 32KB → 64KB, add `DisableCompression: true` to avoid double-compression
- **Inline FNV hasher** — replaces `fnv.New32a()` heap allocation in metrics sampling with zero-alloc inline function
- **Atomic `lastSeen` in endpoint tracker** — converts write-lock-per-request to `atomic.Int64` with 1s throttle, eliminating lock contention
- **Cache endpoint key strings** — pre-computes `host:port` strings at config time, avoids per-request `strconv.FormatInt` + `net.JoinHostPort`

Expected improvement: ~14-16 allocs/req → ~3-4 allocs/req, targeting 2-3x QPS gain (from ~3.4K to ~8-12K).

## Test plan
- [x] `go build` (Linux cross-compile) passes for all modified packages
- [x] `go vet` (Linux) passes
- [x] `go test ./internal/agent/router/...` passes
- [x] `go test ./internal/agent/metrics/...` passes
- [x] `go test ./internal/agent/upstream/...` passes
- [x] Docker image build (`Dockerfile.agent` with `go generate` + full build) succeeds
- [ ] Run `test/performance/run-perf.sh --scenario http --duration 30` at c=128 and compare against baseline 3,413 QPS
- [ ] Verify zero errors under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)