### PR TITLE
[Feature] Complete NovaRoute integration (shutdown, events, peer cleanup)

### DIFF
--- a/internal/agent/vip/bgp.go
+++ b/internal/agent/vip/bgp.go
@@ -108,6 +108,22 @@ func (h *BGPHandler) Start(ctx context.Context) error {
 	return nil
 }
 
+// Stop gracefully shuts down the GoBGP server and BFD manager.
+func (h *BGPHandler) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.bfdManager != nil {
+		h.bfdManager.Stop()
+	}
+	if h.bgpServer != nil {
+		h.bgpServer.Stop()
+	}
+	h.started = false
+	h.logger.Info("BGP handler stopped")
+	return nil
+}
+
 // AddVIP adds a VIP with BGP announcement (IPv4 or IPv6).
 // If the VIP already exists, it performs in-place reconfiguration of changed
 // BGP/BFD parameters without releasing the VIP address.

--- a/internal/agent/vip/bgp_backend.go
+++ b/internal/agent/vip/bgp_backend.go
@@ -35,4 +35,8 @@ type BGPBackend interface {
 
 	// RemoveVIP withdraws a VIP from BGP announcements.
 	RemoveVIP(ctx context.Context, assignment *pb.VIPAssignment) error
+
+	// Stop gracefully shuts down the backend, deregistering from upstream
+	// services and closing connections.
+	Stop(ctx context.Context) error
 }

--- a/internal/agent/vip/manager.go
+++ b/internal/agent/vip/manager.go
@@ -364,6 +364,13 @@ func (m *DefaultManager) Release() error {
 
 	m.assignments = make(map[string]*pb.VIPAssignment)
 
+	// Stop the BGP backend (deregisters from NovaRoute, closes connections).
+	if m.bgpBackend != nil {
+		if err := m.bgpBackend.Stop(context.Background()); err != nil {
+			errs = append(errs, fmt.Errorf("stop BGP backend: %w", err))
+		}
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("failed to release some VIPs: %v", errs)
 	}

--- a/internal/agent/vip/novaroute_bgp.go
+++ b/internal/agent/vip/novaroute_bgp.go
@@ -46,8 +46,9 @@ type NovaRouteBGPHandler struct {
 	ownerName  string
 	ownerToken string
 
-	conn   *grpc.ClientConn
-	client nrv1.RouteControlClient
+	conn      *grpc.ClientConn
+	client    nrv1.RouteControlClient
+	cancelCtx context.CancelFunc // cancels the event stream goroutine
 
 	// configuredAS tracks the local AS that was last configured via the
 	// ConfigureBGP RPC so we only reconfigure when the AS actually changes.
@@ -108,7 +109,84 @@ func (h *NovaRouteBGPHandler) Start(ctx context.Context) error {
 	}
 
 	h.logger.Info("Registered with NovaRoute", zap.String("owner", h.ownerName))
+
+	// Start background event stream for peer/BFD failure monitoring.
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	h.cancelCtx = streamCancel
+	go h.streamEvents(streamCtx)
+
 	return nil
+}
+
+// Stop deregisters from NovaRoute and closes the gRPC connection.
+func (h *NovaRouteBGPHandler) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.cancelCtx != nil {
+		h.cancelCtx()
+	}
+
+	if h.client != nil {
+		_, err := h.client.Deregister(ctx, &nrv1.DeregisterRequest{
+			Owner:       h.ownerName,
+			Token:       h.ownerToken,
+			WithdrawAll: true,
+		})
+		if err != nil {
+			h.logger.Warn("Failed to deregister from NovaRoute", zap.Error(err))
+		}
+	}
+
+	if h.conn != nil {
+		h.conn.Close()
+	}
+
+	h.logger.Info("NovaRoute BGP handler stopped")
+	return nil
+}
+
+// streamEvents subscribes to NovaRoute's event stream and logs peer/BFD
+// state changes. This provides real-time visibility into routing events.
+func (h *NovaRouteBGPHandler) streamEvents(ctx context.Context) {
+	stream, err := h.client.StreamEvents(ctx, &nrv1.StreamEventsRequest{
+		OwnerFilter: h.ownerName,
+	})
+	if err != nil {
+		h.logger.Warn("Failed to start NovaRoute event stream", zap.Error(err))
+		return
+	}
+
+	h.logger.Info("NovaRoute event stream connected")
+
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			if ctx.Err() != nil {
+				return // shutdown
+			}
+			h.logger.Warn("NovaRoute event stream error", zap.Error(err))
+			return
+		}
+
+		switch ev.Type {
+		case nrv1.EventType_EVENT_TYPE_PEER_DOWN:
+			h.logger.Warn("BGP peer down", zap.String("detail", ev.Detail))
+		case nrv1.EventType_EVENT_TYPE_PEER_UP:
+			h.logger.Info("BGP peer up", zap.String("detail", ev.Detail))
+		case nrv1.EventType_EVENT_TYPE_BFD_DOWN:
+			h.logger.Warn("BFD session down", zap.String("detail", ev.Detail))
+		case nrv1.EventType_EVENT_TYPE_BFD_UP:
+			h.logger.Info("BFD session up", zap.String("detail", ev.Detail))
+		case nrv1.EventType_EVENT_TYPE_FRR_DISCONNECTED:
+			h.logger.Error("NovaRoute lost FRR connection", zap.String("detail", ev.Detail))
+		default:
+			h.logger.Debug("NovaRoute event",
+				zap.String("type", ev.Type.String()),
+				zap.String("detail", ev.Detail),
+			)
+		}
+	}
 }
 
 // AddVIP announces a VIP via NovaRoute's BGP. It:
@@ -293,6 +371,21 @@ func (h *NovaRouteBGPHandler) RemoveVIP(ctx context.Context, assignment *pb.VIPA
 					zap.Error(bfdErr),
 				)
 			}
+		}
+	}
+
+	// Remove peers for this VIP.
+	for _, peerAddr := range state.peerAddrs {
+		_, peerErr := h.client.RemovePeer(ctx, &nrv1.RemovePeerRequest{
+			Owner:           h.ownerName,
+			Token:           h.ownerToken,
+			NeighborAddress: peerAddr,
+		})
+		if peerErr != nil {
+			h.logger.Warn("Failed to remove peer via NovaRoute",
+				zap.String("peer", peerAddr),
+				zap.Error(peerErr),
+			)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `Stop()` to `BGPBackend` interface for graceful shutdown on SIGTERM
- `NovaRouteBGPHandler.Stop()` calls `Deregister(withdraw_all=true)` to cleanly remove all intents from NovaRoute before shutdown
- `RemoveVIP()` now calls `RemovePeer()` for each peer associated with the VIP, preventing stale peer accumulation
- `Start()` launches a background `StreamEvents` goroutine that monitors real-time peer/BFD state changes from NovaRoute
- GoBGP handler gets matching `Stop()` that shuts down BFD manager and BGP server
- VIP manager's `Release()` now calls `bgpBackend.Stop()` during shutdown

## Companion NovaRoute changes

The NovaRoute side (pushed to `piwi3910/NovaRoute` main) includes:
- FRR show command parsers for BGP/BFD/OSPF state
- Reconciler state monitoring with event publishing on state transitions
- Graceful shutdown with `WithdrawAll()` on SIGTERM
- `GetStatus` RPC returns real FRR state instead of placeholders
- EventBus wired into reconciler for FRR-sourced events

## Test plan

- [x] `go build ./internal/agent/vip/...` passes
- [x] `go vet ./internal/agent/vip/...` passes
- [x] `go test ./internal/agent/vip/...` passes
- [ ] Deploy both NovaRoute and NovaEdge agents, verify event stream connects
- [ ] Verify VIPs are announced and withdrawn correctly
- [ ] Verify graceful shutdown deregisters cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)