### PR TITLE
[Fix] Increase gRPC keepalive to avoid ENHANCE_YOUR_CALM reconnect loop

### DIFF
--- a/internal/agent/vip/novaroute_bgp.go
+++ b/internal/agent/vip/novaroute_bgp.go
@@ -120,8 +120,8 @@ func (h *NovaRouteBGPHandler) dial(_ context.Context) error {
 		"unix://"+h.socketPath,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                10 * time.Second,
-			Timeout:             5 * time.Second,
+			Time:                60 * time.Second,
+			Timeout:             10 * time.Second,
 			PermitWithoutStream: true,
 		}),
 	)


### PR DESCRIPTION
## Summary
- Follow-up to PR #667 — the 10s keepalive was too aggressive for NovaRoute's default gRPC server enforcement policy
- Server rejects pings with `ENHANCE_YOUR_CALM`/`too_many_pings`, causing an endless reconnect cycle every ~30s
- Increase keepalive to 60s/10s which works within server limits
- The event stream already provides connection health monitoring via `stream.Recv()` failures

## Test plan
- [ ] Deploy updated agent, verify no `ENHANCE_YOUR_CALM` errors in logs
- [ ] Verify reconnect still works when NovaRoute actually restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)