### PR TITLE
[Fix] Remove gRPC keepalive causing ENHANCE_YOUR_CALM reconnect loop

### DIFF
--- a/internal/agent/vip/novaroute_bgp.go
+++ b/internal/agent/vip/novaroute_bgp.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/keepalive"
 
 	nrv1 "github.com/piwi3910/novaedge/api/novaroute/v1"
 	"github.com/piwi3910/novaedge/internal/agent/metrics"
@@ -119,11 +118,6 @@ func (h *NovaRouteBGPHandler) dial(_ context.Context) error {
 	conn, err := grpc.NewClient(
 		"unix://"+h.socketPath,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                60 * time.Second,
-			Timeout:             10 * time.Second,
-			PermitWithoutStream: true,
-		}),
 	)
 	if err != nil {
 		return fmt.Errorf("novaroute: dial %s: %w", h.socketPath, err)


### PR DESCRIPTION
## Summary
- gRPC server default minimum ping enforcement is 5 minutes — any keepalive below that triggers `ENHANCE_YOUR_CALM`
- For Unix domain sockets, kernel handles connection drop detection natively
- Event stream `stream.Recv()` provides application-level health monitoring
- Removes keepalive entirely — cleaner than trying to match server enforcement policy

## Test plan
- [ ] Deploy, verify NO `ENHANCE_YOUR_CALM` or `too_many_pings` in logs
- [ ] Restart NovaRoute DaemonSet, verify reconnect still works via event stream detection
- [ ] Verify VIPs remain functional after NovaRoute restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)