### PR TITLE
Fix CI: upgrade golangci-lint to v2 and add eBPF code generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
               - 'go.sum'
               - 'Makefile'
               - '.golangci.yml'
+              - 'bpf/**'
             helm:
               - 'charts/**'
               - 'config/crd/**'
@@ -67,6 +68,22 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Install eBPF toolchain
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends clang llvm libbpf-dev linux-headers-$(uname -r) || \
+            sudo apt-get install -y --no-install-recommends clang llvm libbpf-dev
+          # Create asm symlink for eBPF compilation on multiarch Ubuntu
+          sudo ln -sf /usr/include/x86_64-linux-gnu/asm /usr/include/asm 2>/dev/null || true
+
+      - name: Generate eBPF code (bpf2go)
+        run: |
+          go generate ./internal/agent/ebpf/conntrack/
+          go generate ./internal/agent/ebpf/maglev/
+          go generate ./internal/agent/xdplb/
+          go generate ./internal/agent/ebpfmesh/
+          go generate ./internal/agent/afxdp/
+
       - name: Run gofmt
         run: |
           if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
@@ -78,7 +95,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.62.0
+          version: v2.10.1
           args: --timeout=10m
 
       - name: Check go mod tidy
@@ -133,6 +150,25 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+
+      - name: Install eBPF toolchain
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends clang llvm libbpf-dev linux-headers-$(uname -r) || \
+            sudo apt-get install -y --no-install-recommends clang llvm libbpf-dev
+          # Create asm symlink for eBPF compilation on multiarch Ubuntu
+          sudo ln -sf /usr/include/x86_64-linux-gnu/asm /usr/include/asm 2>/dev/null || true
+
+      - name: Generate eBPF code (bpf2go)
+        run: |
+          go generate ./internal/agent/ebpf/conntrack/
+          go generate ./internal/agent/ebpf/maglev/
+          go generate ./internal/agent/xdplb/
+          go generate ./internal/agent/ebpfmesh/
+          go generate ./internal/agent/afxdp/
+
+      - name: Raise MEMLOCK rlimit for eBPF tests
+        run: ulimit -l unlimited || true
 
       - name: Run unit tests
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
@@ -189,6 +225,22 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+
+      - name: Install eBPF toolchain
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends clang llvm libbpf-dev linux-headers-$(uname -r) || \
+            sudo apt-get install -y --no-install-recommends clang llvm libbpf-dev
+          # Create asm symlink for eBPF compilation on multiarch Ubuntu
+          sudo ln -sf /usr/include/x86_64-linux-gnu/asm /usr/include/asm 2>/dev/null || true
+
+      - name: Generate eBPF code (bpf2go)
+        run: |
+          go generate ./internal/agent/ebpf/conntrack/
+          go generate ./internal/agent/ebpf/maglev/
+          go generate ./internal/agent/xdplb/
+          go generate ./internal/agent/ebpfmesh/
+          go generate ./internal/agent/afxdp/
 
       - name: Build ${{ matrix.binary.name }}
         env:

--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ PROTOC_GEN_GO_GRPC ?= $(LOCALBIN)/protoc-gen-go-grpc
 
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
-GOLANGCI_LINT_VERSION ?= v1.62.0
+GOLANGCI_LINT_VERSION ?= v2.10.1
 PROTOC_GEN_GO_VERSION ?= v1.35.1
 PROTOC_GEN_GO_GRPC_VERSION ?= v1.5.1
 
@@ -326,7 +326,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: protoc-gen-go
 protoc-gen-go: $(PROTOC_GEN_GO) ## Download protoc-gen-go locally if necessary.


### PR DESCRIPTION
## Summary
- **Upgrade golangci-lint from v1.62.0 to v2.10.1** in both CI workflow and Makefile, fixing the `golangci-lint-action@v7` incompatibility (`invalid version string 'v1.62.0', golangci-lint v1 is not supported by golangci-lint-action v7`). The `.golangci.yml` already uses v2 config format, so this completes the migration.
- **Add eBPF toolchain installation and `go generate` steps** to the lint, test, and build CI jobs. The `conntrack` and `maglev` eBPF packages are missing their bpf2go-generated Go bindings (`loadConntrack`, `loadMaglevLookup`), causing undefined symbol build failures on Linux CI. Installing `clang`, `llvm`, and `libbpf-dev` and running `go generate` for all five eBPF packages resolves this.
- **Raise MEMLOCK rlimit** in the test job to prevent eBPF map creation failures.
- **Add `bpf/**` to change detection filter** so CI re-runs when BPF C sources change.

## Test plan
- [ ] Verify the "Lint Code" job passes with golangci-lint v2.10.1
- [ ] Verify `go generate` successfully produces `_bpfel.go` and `_bpfel.o` for all eBPF packages
- [ ] Verify "Unit Tests" job passes (including eBPF package tests)
- [ ] Verify "Build Binaries" job succeeds for all five binaries
- [ ] Verify `make lint` works locally with the updated Makefile version

🤖 Generated with [Claude Code](https://claude.com/claude-code)