### PR TITLE
fix: resolve E2E agent DaemonSet readiness failures in kind clusters

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,11 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
 
+      - name: Label kind nodes
+        run: |
+          kubectl get nodes -o name | xargs -I{} kubectl label {} novaedge.io/role=edge
+          kubectl get nodes --show-labels
+
       - name: Build Docker images
         run: |
           docker build -t novaedge-controller:latest -f Dockerfile.controller .
@@ -76,16 +81,28 @@ jobs:
             --set agent.image.pullPolicy=Never \
             --set webui.enabled=false \
             --wait \
-            --timeout 300s
+            --timeout 600s
+
+      - name: Show initial pod status
+        run: |
+          echo "=== Pods ==="
+          kubectl get pods -n nova-system -o wide
+          echo "=== DaemonSets ==="
+          kubectl get daemonsets -n nova-system
+          echo "=== Deployments ==="
+          kubectl get deployments -n nova-system
 
       - name: Wait for pods to be ready
         run: |
+          echo "Waiting for controller pods..."
           kubectl wait --for=condition=ready --timeout=300s pod \
             -l app.kubernetes.io/name=novaedge,app.kubernetes.io/component=controller \
             -n nova-system
-          kubectl wait --for=condition=ready --timeout=300s pod \
+          echo "Controller pods ready. Waiting for agent pods..."
+          kubectl wait --for=condition=ready --timeout=600s pod \
             -l app.kubernetes.io/name=novaedge,app.kubernetes.io/component=agent \
             -n nova-system
+          echo "All pods ready."
 
       - name: Show pod status
         run: |
@@ -100,14 +117,33 @@ jobs:
         if: failure()
         run: |
           mkdir -p logs
+          echo "=== Pod status ==="
+          kubectl get pods -n nova-system -o wide | tee logs/pod-status.log || true
+          echo ""
+          echo "=== DaemonSet status ==="
+          kubectl get daemonsets -n nova-system -o wide | tee logs/daemonset-status.log || true
+          echo ""
+          echo "=== Describe DaemonSet ==="
+          kubectl describe daemonset -n nova-system | tee logs/daemonset-describe.log || true
+          echo ""
+          echo "=== Controller logs ==="
           kubectl logs \
             -l app.kubernetes.io/name=novaedge,app.kubernetes.io/component=controller \
-            -n nova-system > logs/controller.log || true
+            -n nova-system --tail=200 | tee logs/controller.log || true
+          echo ""
+          echo "=== Agent logs ==="
           kubectl logs \
             -l app.kubernetes.io/name=novaedge,app.kubernetes.io/component=agent \
-            -n nova-system > logs/agent.log || true
-          kubectl describe pods -n nova-system > logs/pods.log || true
-          kubectl get events -n nova-system --sort-by='.lastTimestamp' > logs/events.log || true
+            -n nova-system --tail=200 | tee logs/agent.log || true
+          echo ""
+          echo "=== Pod descriptions ==="
+          kubectl describe pods -n nova-system | tee logs/pods.log || true
+          echo ""
+          echo "=== Events ==="
+          kubectl get events -n nova-system --sort-by='.lastTimestamp' | tee logs/events.log || true
+          echo ""
+          echo "=== Node info ==="
+          kubectl get nodes -o wide --show-labels | tee logs/nodes.log || true
 
       - name: Upload logs on failure
         if: failure()

--- a/charts/novaedge/templates/agent-daemonset.yaml
+++ b/charts/novaedge/templates/agent-daemonset.yaml
@@ -134,19 +134,19 @@ spec:
             path: /healthz
             port: health
             scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 20
-          timeoutSeconds: 5
-          failureThreshold: 3
+          initialDelaySeconds: {{ .Values.agent.livenessProbe.initialDelaySeconds | default 30 }}
+          periodSeconds: {{ .Values.agent.livenessProbe.periodSeconds | default 20 }}
+          timeoutSeconds: {{ .Values.agent.livenessProbe.timeoutSeconds | default 5 }}
+          failureThreshold: {{ .Values.agent.livenessProbe.failureThreshold | default 3 }}
         readinessProbe:
           httpGet:
             path: /readyz
             port: health
             scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
+          initialDelaySeconds: {{ .Values.agent.readinessProbe.initialDelaySeconds | default 30 }}
+          periodSeconds: {{ .Values.agent.readinessProbe.periodSeconds | default 10 }}
+          timeoutSeconds: {{ .Values.agent.readinessProbe.timeoutSeconds | default 5 }}
+          failureThreshold: {{ .Values.agent.readinessProbe.failureThreshold | default 6 }}
         resources:
           {{- toYaml .Values.agent.resources | nindent 10 }}
         securityContext:

--- a/charts/novaedge/values.yaml
+++ b/charts/novaedge/values.yaml
@@ -247,6 +247,23 @@ agent:
   healthProbe:
     port: 9091
 
+  # Readiness probe configuration
+  # The agent readiness depends on receiving its first config snapshot from the
+  # controller via gRPC. Increase these values if the controller takes longer
+  # to become ready (e.g. in CI or resource-constrained environments).
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  # Liveness probe configuration
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+
   resources:
     limits:
       cpu: 2000m

--- a/config/agent/daemonset.yaml
+++ b/config/agent/daemonset.yaml
@@ -29,9 +29,11 @@ spec:
 
       serviceAccountName: novaedge-agent
 
-      # Node selector for edge nodes (optional - remove if agents should run on all nodes)
-      nodeSelector:
-        novaedge.io/role: edge
+      # Node selector for edge nodes (optional)
+      # Uncomment the following for production edge-only deployments:
+      # nodeSelector:
+      #   novaedge.io/role: edge
+      nodeSelector: {}
 
       # Tolerations to allow running on control plane nodes if needed
       tolerations:
@@ -120,10 +122,10 @@ spec:
             path: /readyz
             port: health
             scheme: HTTP
-          initialDelaySeconds: 10
+          initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
-          failureThreshold: 3
+          failureThreshold: 6
 
         resources:
           # Resource recommendations based on traffic load:


### PR DESCRIPTION
## Summary

Fixes #699 - E2E Tests: novaedge-agent DaemonSet fails to become ready in kind cluster.

The E2E test failure had three root causes, all addressed in this PR:

- **Static manifest nodeSelector mismatch**: `config/agent/daemonset.yaml` had `nodeSelector: novaedge.io/role: edge` but kind nodes lack this label. Commented out the nodeSelector (with a note to uncomment for production edge-only deployments) so the DaemonSet schedules on all nodes by default.

- **Agent readiness probe too aggressive**: The agent only becomes ready after receiving its first config snapshot from the controller via gRPC. The previous readiness probe settings (initialDelaySeconds=10, failureThreshold=3) gave only ~40 seconds, which is insufficient when the controller itself is still starting. Increased to initialDelaySeconds=30, failureThreshold=6 (~90 seconds total) in both the static manifest and Helm chart defaults.

- **Helm chart readiness/liveness probes not configurable**: The agent DaemonSet template had hardcoded probe values. Made them configurable via `agent.readinessProbe.*` and `agent.livenessProbe.*` in values.yaml.

- **E2E workflow lacks proper sequencing and diagnostics**: Added a step to label kind nodes with `novaedge.io/role=edge`, added diagnostic output before the readiness wait, increased wait timeouts from 300s to 600s for the agent, and enhanced failure diagnostics (DaemonSet describe, node labels, structured log output).

## Test plan

- [ ] E2E workflow succeeds on kind clusters across all Kubernetes versions (v1.28, v1.29, v1.30)
- [ ] Agent DaemonSet pods become ready within the extended timeout window
- [ ] Helm chart renders correctly with new configurable probe values (`helm template`)
- [ ] Static manifest deploys correctly without nodeSelector blocking scheduling
- [ ] Failure diagnostics capture sufficient detail for debugging