### PR TITLE
Extract shared eBPF test skip helper and add CI feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,17 @@ jobs:
       - name: Run unit tests
         run: |
           ulimit -l unlimited 2>/dev/null || true
-          go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+          go test -v -race -coverprofile=coverage.out -covermode=atomic ./... 2>&1 | tee test-output.log
+
+      - name: Check for skipped eBPF tests
+        if: always()
+        run: |
+          if grep -q "Skipping: eBPF unavailable" test-output.log 2>/dev/null; then
+            echo "::notice::Some eBPF tests were skipped due to insufficient privileges. Run with CAP_BPF/CAP_SYS_ADMIN to execute them."
+            echo "### eBPF Tests Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "Some eBPF tests were skipped because the CI runner lacks CAP_BPF/CAP_SYS_ADMIN privileges." >> $GITHUB_STEP_SUMMARY
+            echo "These tests require a privileged environment to run." >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Display coverage
         run: |

--- a/internal/agent/ebpf/conntrack/conntrack_test.go
+++ b/internal/agent/ebpf/conntrack/conntrack_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/piwi3910/novaedge/internal/agent/ebpf/testutil"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -33,10 +34,11 @@ func TestNewConntrack(t *testing.T) {
 		}
 		return
 	}
-	// On Linux, this may fail if BPF objects aren't generated.
+	// On Linux, this may fail if BPF objects aren't generated or
+	// if running without sufficient privileges.
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Logf("NewConntrack failed (expected in CI without BPF objects): %v", err)
-		return
+		t.Fatalf("NewConntrack() returned error: %v", err)
 	}
 	defer ct.Close()
 }
@@ -103,7 +105,8 @@ func TestConntrackCloseNil(t *testing.T) {
 	// but test that the types are well-formed.
 	logger := zaptest.NewLogger(t)
 	_, err := NewConntrack(logger, 1024, 30*time.Second)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Logf("NewConntrack failed (expected in CI): %v", err)
+		t.Fatalf("NewConntrack() returned error: %v", err)
 	}
 }

--- a/internal/agent/ebpf/health/health_test.go
+++ b/internal/agent/ebpf/health/health_test.go
@@ -18,26 +18,11 @@ package health
 
 import (
 	"runtime"
-	"strings"
 	"testing"
 
+	"github.com/piwi3910/novaedge/internal/agent/ebpf/testutil"
 	"go.uber.org/zap/zaptest"
 )
-
-// skipIfBPFUnavailable skips the test if the error indicates that eBPF map
-// creation failed due to insufficient privileges (MEMLOCK limit or missing
-// CAP_BPF/CAP_SYS_ADMIN). This allows tests to pass in unprivileged CI.
-func skipIfBPFUnavailable(t *testing.T, err error) {
-	t.Helper()
-	if err == nil {
-		return
-	}
-	msg := err.Error()
-	if strings.Contains(msg, "operation not permitted") ||
-		strings.Contains(msg, "MEMLOCK") {
-		t.Skipf("Skipping: eBPF unavailable (insufficient privileges): %v", err)
-	}
-}
 
 func TestNewHealthMonitor(t *testing.T) {
 	logger := zaptest.NewLogger(t)
@@ -50,7 +35,7 @@ func TestNewHealthMonitor(t *testing.T) {
 		return
 	}
 
-	skipIfBPFUnavailable(t, err)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("NewHealthMonitor() returned error: %v", err)
 	}
@@ -72,7 +57,7 @@ func TestHealthMonitorPoll(t *testing.T) {
 		return
 	}
 
-	skipIfBPFUnavailable(t, err)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("NewHealthMonitor() returned error: %v", err)
 	}
@@ -101,7 +86,7 @@ func TestHealthMonitorCloseIdempotent(t *testing.T) {
 		return
 	}
 
-	skipIfBPFUnavailable(t, err)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("NewHealthMonitor() returned error: %v", err)
 	}

--- a/internal/agent/ebpf/ratelimit/ratelimit_test.go
+++ b/internal/agent/ebpf/ratelimit/ratelimit_test.go
@@ -19,26 +19,11 @@ package ratelimit
 import (
 	"net"
 	"runtime"
-	"strings"
 	"testing"
 
+	"github.com/piwi3910/novaedge/internal/agent/ebpf/testutil"
 	"go.uber.org/zap/zaptest"
 )
-
-// skipIfBPFUnavailable skips the test if the error indicates that eBPF map
-// creation failed due to insufficient privileges (MEMLOCK limit or missing
-// CAP_BPF/CAP_SYS_ADMIN). This allows tests to pass in unprivileged CI.
-func skipIfBPFUnavailable(t *testing.T, err error) {
-	t.Helper()
-	if err == nil {
-		return
-	}
-	msg := err.Error()
-	if strings.Contains(msg, "operation not permitted") ||
-		strings.Contains(msg, "MEMLOCK") {
-		t.Skipf("Skipping: eBPF unavailable (insufficient privileges): %v", err)
-	}
-}
 
 func TestNewRateLimiter(t *testing.T) {
 	logger := zaptest.NewLogger(t)
@@ -52,7 +37,7 @@ func TestNewRateLimiter(t *testing.T) {
 		return
 	}
 
-	skipIfBPFUnavailable(t, err)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("NewRateLimiter() returned error: %v", err)
 	}
@@ -74,7 +59,7 @@ func TestRateLimiterConfigure(t *testing.T) {
 		return
 	}
 
-	skipIfBPFUnavailable(t, err)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("NewRateLimiter() returned error: %v", err)
 	}
@@ -96,7 +81,7 @@ func TestRateLimiterGetStats(t *testing.T) {
 		return
 	}
 
-	skipIfBPFUnavailable(t, err)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("NewRateLimiter() returned error: %v", err)
 	}
@@ -125,7 +110,7 @@ func TestRateLimiterCheckAllowed(t *testing.T) {
 		return
 	}
 
-	skipIfBPFUnavailable(t, err)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("NewRateLimiter() returned error: %v", err)
 	}
@@ -153,7 +138,7 @@ func TestRateLimiterCloseIdempotent(t *testing.T) {
 		return
 	}
 
-	skipIfBPFUnavailable(t, err)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("NewRateLimiter() returned error: %v", err)
 	}

--- a/internal/agent/ebpf/service/service_test.go
+++ b/internal/agent/ebpf/service/service_test.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/piwi3910/novaedge/internal/agent/ebpf/testutil"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -145,8 +146,9 @@ func TestNewServiceMap(t *testing.T) {
 		return
 	}
 
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("ServiceMap creation failed (expected in unprivileged environments): %v", err)
+		t.Fatalf("NewServiceMap() returned error: %v", err)
 	}
 	defer sm.Close()
 }
@@ -158,8 +160,9 @@ func TestServiceMapCloseIdempotent(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	sm, err := NewServiceMap(logger, 100, 32)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("ServiceMap creation failed: %v", err)
+		t.Fatalf("NewServiceMap() returned error: %v", err)
 	}
 
 	if err := sm.Close(); err != nil {
@@ -177,8 +180,9 @@ func TestServiceMapUpsertAndDelete(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	sm, err := NewServiceMap(logger, 100, 32)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("ServiceMap creation failed: %v", err)
+		t.Fatalf("NewServiceMap() returned error: %v", err)
 	}
 	defer sm.Close()
 
@@ -216,8 +220,9 @@ func TestServiceMapReconcile(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	sm, err := NewServiceMap(logger, 100, 32)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("ServiceMap creation failed: %v", err)
+		t.Fatalf("NewServiceMap() returned error: %v", err)
 	}
 	defer sm.Close()
 
@@ -253,8 +258,9 @@ func TestServiceMapOperationsAfterClose(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	sm, err := NewServiceMap(logger, 100, 32)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("ServiceMap creation failed: %v", err)
+		t.Fatalf("NewServiceMap() returned error: %v", err)
 	}
 
 	sm.Close()
@@ -279,8 +285,9 @@ func TestServiceMapDefaultParams(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	// Pass 0 for both params to test defaults.
 	sm, err := NewServiceMap(logger, 0, 0)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("ServiceMap creation with defaults failed: %v", err)
+		t.Fatalf("NewServiceMap() returned error: %v", err)
 	}
 	defer sm.Close()
 }

--- a/internal/agent/ebpf/sockmap/sockmap_test.go
+++ b/internal/agent/ebpf/sockmap/sockmap_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/piwi3910/novaedge/internal/agent/ebpf/testutil"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -74,8 +75,9 @@ func TestNewSockMapManager(t *testing.T) {
 
 	// On Linux, the manager may or may not succeed depending on
 	// kernel capabilities and permissions.
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("SOCKMAP manager creation failed (expected in unprivileged environments): %v", err)
+		t.Fatalf("NewSockMapManager() returned error: %v", err)
 	}
 	defer mgr.Close()
 
@@ -91,8 +93,9 @@ func TestManagerCloseIdempotent(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	mgr, err := NewSockMapManager(logger)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("SOCKMAP manager creation failed: %v", err)
+		t.Fatalf("NewSockMapManager() returned error: %v", err)
 	}
 
 	// First close should succeed.
@@ -113,8 +116,9 @@ func TestManagerAddRemoveEndpoint(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	mgr, err := NewSockMapManager(logger)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("SOCKMAP manager creation failed: %v", err)
+		t.Fatalf("NewSockMapManager() returned error: %v", err)
 	}
 	defer mgr.Close()
 
@@ -147,8 +151,9 @@ func TestManagerSyncEndpoints(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	mgr, err := NewSockMapManager(logger)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("SOCKMAP manager creation failed: %v", err)
+		t.Fatalf("NewSockMapManager() returned error: %v", err)
 	}
 	defer mgr.Close()
 
@@ -178,8 +183,9 @@ func TestManagerGetStats(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	mgr, err := NewSockMapManager(logger)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("SOCKMAP manager creation failed: %v", err)
+		t.Fatalf("NewSockMapManager() returned error: %v", err)
 	}
 	defer mgr.Close()
 
@@ -204,8 +210,9 @@ func TestManagerOperationsAfterClose(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	mgr, err := NewSockMapManager(logger)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("SOCKMAP manager creation failed: %v", err)
+		t.Fatalf("NewSockMapManager() returned error: %v", err)
 	}
 
 	mgr.Close()
@@ -229,8 +236,9 @@ func TestManagerAddInvalidIP(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	mgr, err := NewSockMapManager(logger)
+	testutil.SkipIfBPFUnavailable(t, err)
 	if err != nil {
-		t.Skipf("SOCKMAP manager creation failed: %v", err)
+		t.Fatalf("NewSockMapManager() returned error: %v", err)
 	}
 	defer mgr.Close()
 

--- a/internal/agent/ebpf/testutil/skip.go
+++ b/internal/agent/ebpf/testutil/skip.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testutil provides shared test utilities for eBPF packages.
+package testutil
+
+import (
+	"strings"
+	"testing"
+)
+
+// SkipIfBPFUnavailable skips the test if the error indicates that BPF
+// operations are unavailable (insufficient privileges or MEMLOCK limits).
+func SkipIfBPFUnavailable(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "operation not permitted") ||
+		strings.Contains(msg, "MEMLOCK") ||
+		strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "EPERM") {
+		t.Skipf("Skipping: eBPF unavailable (insufficient privileges): %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Created a shared `testutil.SkipIfBPFUnavailable()` helper at `internal/agent/ebpf/testutil/skip.go` to replace duplicated/inconsistent BPF skip logic across all eBPF test files
- Updated 5 test files (`health`, `ratelimit`, `conntrack`, `service`, `sockmap`) to use the shared helper with consistent `t.Skipf()` messaging
- Added CI step that detects skipped eBPF tests and emits a GitHub Actions notice + step summary for visibility
- The shared helper checks for `operation not permitted`, `MEMLOCK`, `permission denied`, and `EPERM` error patterns

## Test plan
- [ ] Verify tests still pass on non-Linux (skip due to platform check)
- [ ] Verify tests skip gracefully in unprivileged CI (no BPF capabilities)
- [ ] Verify the CI step summary shows eBPF skip notice when tests are skipped
- [ ] Verify maglev tests are unaffected (pure data structure tests, no BPF)

Fixes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)