### PR TITLE
Fix broken Dockerfile, Makefile target, and Helm chart RBAC

### DIFF
--- a/Dockerfile.webui.release
+++ b/Dockerfile.webui.release
@@ -7,10 +7,10 @@ FROM nginx:1.29-alpine
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy custom nginx config
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY web/nginx.conf /etc/nginx/nginx.conf
 
 # Copy entrypoint script
-COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY web/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 # Copy pre-built frontend

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ run-standalone: fmt vet ## Run standalone agent from your host.
 	go run ./cmd/novaedge-standalone/main.go --config=$(CONFIG_FILE)
 
 .PHONY: docker-build
-docker-build: docker-build-controller docker-build-agent docker-build-novactl docker-build-standalone docker-build-webui ## Build all docker images.
+docker-build: docker-build-controller docker-build-agent docker-build-novactl docker-build-standalone docker-build-operator docker-build-webui ## Build all docker images.
 
 .PHONY: test-agent
 test-agent: ## Run agent tests.

--- a/charts/novaedge/templates/controller-rbac.yaml
+++ b/charts/novaedge/templates/controller-rbac.yaml
@@ -58,7 +58,6 @@ rules:
   - get
   - list
   - watch
-  - watch
 - apiGroups:
   - gateway.networking.k8s.io
   resources:


### PR DESCRIPTION
Closes #659

## Summary
- **Dockerfile.webui.release**: Fixed COPY paths to include `web/` prefix for `nginx.conf` and `docker-entrypoint.sh`, matching the correct paths in `Dockerfile.webui`
- **Makefile**: Added missing `docker-build-operator` to the `docker-build` target dependency list so `make docker-build` builds all six images
- **Helm chart controller-rbac.yaml**: Removed duplicate `watch` verb for `endpointslices` resources (was listed twice at lines 60-61)

## Test plan
- [ ] Verify `docker build -f Dockerfile.webui.release .` succeeds (COPY finds files at `web/` paths)
- [ ] Verify `make docker-build` now includes the operator image build
- [ ] Verify `helm template novaedge charts/novaedge` produces valid RBAC with no duplicate verbs