### PR TITLE
fix: exclude eBPF .o binaries from CI generated files check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,10 @@ jobs:
 
       - name: Verify generated eBPF files are committed
         run: |
-          if [ -n "$(git diff --name-only)" ]; then
-            echo "::error::Generated eBPF files are out of date. Run 'go generate ./internal/agent/ebpf/...' on Linux and commit the results."
-            git diff --name-only
+          # Only check generated Go files, not .o binaries which vary by clang/llvm version
+          if [ -n "$(git diff --name-only -- '*.go')" ]; then
+            echo "::error::Generated eBPF Go files are out of date. Run 'go generate ./internal/agent/ebpf/...' on Linux and commit the results."
+            git diff --name-only -- '*.go'
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Fix the "Verify generated eBPF files are committed" CI step that always fails
- eBPF `.o` binary files vary by clang/llvm version, causing false positives
- Now only checks generated `.go` wrapper files which are deterministic

## Root cause
The CI step runs `go generate` which compiles eBPF C to `.o` bytecode using CI's clang/llvm. These binaries differ from committed versions compiled with a different toolchain, triggering a spurious failure on every run.