### PR TITLE
feat: add Rust dataplane to CI/CD pipeline

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -210,6 +210,8 @@ jobs:
             dockerfile: Dockerfile.operator
           - name: novaedge-webui
             dockerfile: Dockerfile.webui
+          - name: novaedge-dataplane
+            dockerfile: Dockerfile.dataplane
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -256,6 +258,7 @@ jobs:
           - novaedge-standalone
           - novaedge-operator
           - novaedge-webui
+          - novaedge-dataplane
     steps:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -298,6 +301,7 @@ jobs:
           - novaedge-standalone
           - novaedge-operator
           - novaedge-webui
+          - novaedge-dataplane
     steps:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
@@ -331,6 +335,7 @@ jobs:
           - novaedge-standalone
           - novaedge-operator
           - novaedge-webui
+          - novaedge-dataplane
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,8 @@ jobs:
             dockerfile: Dockerfile.standalone
           - name: novaedge-operator
             dockerfile: Dockerfile.operator
+          - name: novaedge-dataplane
+            dockerfile: Dockerfile.dataplane
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -290,7 +292,7 @@ jobs:
       - name: Sign images
         env:
           COSIGN_EXPERIMENTAL: true
-          IMAGES: novaedge-controller novaedge-agent novactl novaedge-standalone novaedge-operator novaedge-webui
+          IMAGES: novaedge-controller novaedge-agent novactl novaedge-standalone novaedge-operator novaedge-webui novaedge-dataplane
         run: |
           for image in $IMAGES; do
             echo "Signing ${IMAGE_PREFIX}/${image}:${GITHUB_REF_NAME}"

--- a/Dockerfile.dataplane
+++ b/Dockerfile.dataplane
@@ -1,4 +1,8 @@
-FROM rust:bookworm AS builder
+# Build stage: compile eBPF programs and Rust dataplane binary.
+# Uses TARGETARCH for multi-arch builds via docker buildx.
+FROM --platform=$BUILDPLATFORM rust:bookworm AS builder
+
+ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y \
     clang llvm libelf-dev \
@@ -8,22 +12,47 @@ RUN apt-get update && apt-get install -y \
 
 RUN rustup toolchain install nightly --component rust-src
 RUN rustup target add --toolchain nightly bpfel-unknown-none
+
+# Add cross-compilation targets for arm64/amd64
+RUN case "$TARGETARCH" in \
+      arm64) rustup target add aarch64-unknown-linux-gnu ;; \
+      amd64) rustup target add x86_64-unknown-linux-gnu ;; \
+    esac
+
+# Install cross-compilation linker for arm64 when building on amd64
+RUN if [ "$TARGETARCH" = "arm64" ] && [ "$(dpkg --print-architecture)" != "arm64" ]; then \
+      apt-get update && apt-get install -y gcc-aarch64-linux-gnu && rm -rf /var/lib/apt/lists/*; \
+    fi
+
 RUN cargo install bpf-linker
 
 WORKDIR /build
 COPY . .
 
-# Build eBPF
+# Build eBPF programs (BPF bytecode is architecture-independent)
 RUN cd dataplane && cargo +nightly build \
     --package novaedge-ebpf \
     --target bpfel-unknown-none \
     -Z build-std=core \
     --release
 
-# Build dataplane
-RUN cd dataplane && cargo build \
-    --package novaedge-dataplane \
-    --release
+# Build dataplane binary for target architecture
+RUN RUST_TARGET="" && \
+    LINKER_ENV="" && \
+    case "$TARGETARCH" in \
+      arm64) RUST_TARGET="aarch64-unknown-linux-gnu" && \
+             if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
+               LINKER_ENV="CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc"; \
+             fi ;; \
+      amd64) RUST_TARGET="x86_64-unknown-linux-gnu" ;; \
+    esac && \
+    cd dataplane && \
+    eval $LINKER_ENV cargo build \
+      --package novaedge-dataplane \
+      --target "$RUST_TARGET" \
+      --release && \
+    mkdir -p /build/out && \
+    cp "/build/dataplane/target/$RUST_TARGET/release/novaedge-dataplane" /build/out/
 
 # --- Runtime stage ---
 FROM debian:bookworm-slim
@@ -32,7 +61,7 @@ RUN apt-get update && apt-get install -y \
     libelf1 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/dataplane/target/release/novaedge-dataplane /usr/local/bin/
+COPY --from=builder /build/out/novaedge-dataplane /usr/local/bin/
 COPY --from=builder /build/dataplane/target/bpfel-unknown-none/release/novaedge-ebpf /opt/novaedge/
 
 ENTRYPOINT ["novaedge-dataplane"]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ IMG_NOVACTL ?= novaedge-novactl:latest
 IMG_STANDALONE ?= novaedge-standalone:latest
 IMG_OPERATOR ?= novaedge-operator:latest
 IMG_WEBUI ?= novaedge-webui:latest
+IMG_DATAPLANE ?= novaedge-dataplane:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -176,7 +177,7 @@ run-standalone: fmt vet ## Run standalone agent from your host.
 	go run ./cmd/novaedge-standalone/main.go --config=$(CONFIG_FILE)
 
 .PHONY: docker-build
-docker-build: docker-build-controller docker-build-agent docker-build-novactl docker-build-standalone docker-build-operator docker-build-webui ## Build all docker images.
+docker-build: docker-build-controller docker-build-agent docker-build-novactl docker-build-standalone docker-build-operator docker-build-webui docker-build-dataplane ## Build all docker images.
 
 .PHONY: test-agent
 test-agent: ## Run agent tests.
@@ -206,8 +207,12 @@ docker-build-standalone: ## Build standalone agent docker image.
 docker-build-operator: ## Build operator docker image.
 	docker build -t ${IMG_OPERATOR} -f Dockerfile.operator .
 
+.PHONY: docker-build-dataplane
+docker-build-dataplane: ## Build Rust dataplane docker image.
+	docker build -t ${IMG_DATAPLANE} -f Dockerfile.dataplane .
+
 .PHONY: docker-push
-docker-push: docker-push-controller docker-push-agent docker-push-novactl docker-push-operator docker-push-webui ## Push all docker images.
+docker-push: docker-push-controller docker-push-agent docker-push-novactl docker-push-operator docker-push-webui docker-push-dataplane ## Push all docker images.
 
 .PHONY: docker-push-controller
 docker-push-controller: ## Push controller docker image.
@@ -228,6 +233,10 @@ docker-push-operator: ## Push operator docker image.
 .PHONY: docker-push-webui
 docker-push-webui: ## Push web UI frontend docker image.
 	docker push ${IMG_WEBUI}
+
+.PHONY: docker-push-dataplane
+docker-push-dataplane: ## Push Rust dataplane docker image.
+	docker push ${IMG_DATAPLANE}
 
 ##@ Deployment
 


### PR DESCRIPTION
## Summary
- Add `novaedge-dataplane` Docker image to nightly and release workflows with multi-arch (amd64/arm64) support
- Update `Dockerfile.dataplane` for proper cross-compilation using `BUILDPLATFORM`/`TARGETARCH`
- Add `docker-build-dataplane` and `docker-push-dataplane` targets to Makefile
- Include dataplane in vulnerability scan, SBOM generation, and image signing jobs