### PR TITLE
fix: correct Dockerfile paths and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,7 @@ jobs:
     name: Docker Images
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         image:
           - name: novaedge-controller

--- a/Dockerfile.dataplane
+++ b/Dockerfile.dataplane
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup toolchain install nightly --component rust-src
-RUN rustup target add --toolchain nightly bpfel-unknown-none
 
 # Add cross-compilation targets for arm64/amd64
+# Note: bpfel-unknown-none is NOT a rustup target; it's compiled via -Z build-std=core
 RUN case "$TARGETARCH" in \
       arm64) rustup target add aarch64-unknown-linux-gnu ;; \
       amd64) rustup target add x86_64-unknown-linux-gnu ;; \

--- a/Dockerfile.webui.release
+++ b/Dockerfile.webui.release
@@ -7,10 +7,10 @@ FROM nginx:1.29-alpine
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy custom nginx config
-COPY web/nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf /etc/nginx/nginx.conf
 
 # Copy entrypoint script
-COPY web/docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 # Copy pre-built frontend

--- a/config/agent/daemonset.yaml
+++ b/config/agent/daemonset.yaml
@@ -176,7 +176,7 @@ spec:
 
       # Rust eBPF dataplane sidecar
       - name: novaedge-dataplane
-        image: ghcr.io/piwi3910/novaedge/novaedge-dataplane:latest
+        image: ghcr.io/piwi3910/novaedge-dataplane:latest
         imagePullPolicy: IfNotPresent
         args:
         - --socket-path=/run/novaedge/dataplane.sock


### PR DESCRIPTION
## Summary
- Remove invalid `rustup target add` for `bpfel-unknown-none` in Dockerfile.dataplane (it's compiled via `-Z build-std=core`, not a rustup target)
- Fix `Dockerfile.webui.release` COPY paths — build context is `web/`, so paths should not include `web/` prefix
- Add `fail-fast: false` to release docker strategy to prevent one image failure from cancelling all builds
- Fix dataplane sidecar image path in agent daemonset manifest (`ghcr.io/piwi3910/novaedge-dataplane:latest`)

## Context
The v1.3.0 release build failed due to these issues. This PR fixes them so the release can be re-triggered.