### PR TITLE
fix: add both rustup targets unconditionally in dataplane Dockerfile

### DIFF
--- a/Dockerfile.dataplane
+++ b/Dockerfile.dataplane
@@ -12,17 +12,13 @@ RUN apt-get update && apt-get install -y \
 
 RUN rustup toolchain install nightly --component rust-src
 
-# Add cross-compilation targets for arm64/amd64
-# Note: bpfel-unknown-none is NOT a rustup target; it's compiled via -Z build-std=core
-RUN case "$TARGETARCH" in \
-      arm64) rustup target add aarch64-unknown-linux-gnu ;; \
-      amd64) rustup target add x86_64-unknown-linux-gnu ;; \
-    esac
+# Add cross-compilation targets for both architectures unconditionally.
+# rustup target add is idempotent; the host-native target is already present.
+# Note: bpfel-unknown-none is NOT a rustup target; it's compiled via -Z build-std=core.
+RUN rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
 
-# Install cross-compilation linker for arm64 when building on amd64
-RUN if [ "$TARGETARCH" = "arm64" ] && [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-      apt-get update && apt-get install -y gcc-aarch64-linux-gnu && rm -rf /var/lib/apt/lists/*; \
-    fi
+# Install cross-compilation linker for arm64 (needed when building on amd64 host)
+RUN apt-get update && apt-get install -y gcc-aarch64-linux-gnu && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install bpf-linker
 


### PR DESCRIPTION
## Summary
- Add both `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu` rustup targets unconditionally instead of using a `case` statement on `$TARGETARCH`
- Install `gcc-aarch64-linux-gnu` unconditionally to simplify build layers

## Context
The v1.3.0 release dataplane Docker build failed with `can't find crate for 'core'` when cross-compiling for arm64. The `case "$TARGETARCH"` shell construct wasn't working reliably in Docker buildx multi-platform builds. Since `rustup target add` is idempotent, adding both targets unconditionally is simpler and more robust.