### PR TITLE
fix: add rustup targets to nightly toolchain for dataplane build

### DIFF
--- a/Dockerfile.dataplane
+++ b/Dockerfile.dataplane
@@ -8,17 +8,11 @@ RUN apt-get update && apt-get install -y \
     clang llvm libelf-dev \
     protobuf-compiler \
     pkg-config \
+    gcc-aarch64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup toolchain install nightly --component rust-src
-
-# Add cross-compilation targets for both architectures unconditionally.
-# rustup target add is idempotent; the host-native target is already present.
-# Note: bpfel-unknown-none is NOT a rustup target; it's compiled via -Z build-std=core.
-RUN rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
-
-# Install cross-compilation linker for arm64 (needed when building on amd64 host)
-RUN apt-get update && apt-get install -y gcc-aarch64-linux-gnu && rm -rf /var/lib/apt/lists/*
+RUN rustup toolchain install nightly --component rust-src && \
+    rustup target add --toolchain nightly aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
 
 RUN cargo install bpf-linker
 
@@ -32,8 +26,11 @@ RUN cd dataplane && cargo +nightly build \
     -Z build-std=core \
     --release
 
-# Build dataplane binary for target architecture
-RUN RUST_TARGET="" && \
+# Build dataplane binary for target architecture.
+# Re-run rustup target add to guarantee targets are present regardless of
+# Docker layer caching (rustup target add is idempotent and instant).
+RUN rustup target add --toolchain nightly aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu && \
+    RUST_TARGET="" && \
     LINKER_ENV="" && \
     case "$TARGETARCH" in \
       arm64) RUST_TARGET="aarch64-unknown-linux-gnu" && \


### PR DESCRIPTION
## Summary
- Use `--toolchain nightly` when adding rustup cross-compilation targets
- The root cause: `dataplane/rust-toolchain.toml` specifies `channel = "nightly"`, so `cargo build` in the dataplane directory uses the nightly toolchain. But `rustup target add` was adding targets to the default stable toolchain.
- Also consolidates apt packages and adds redundant `rustup target add` in the cargo build step for cache resilience

## Root Cause
```toml
# dataplane/rust-toolchain.toml
[toolchain]
channel = "nightly"
components = ["rust-src"]
```

When `cargo build` runs in `dataplane/`, it picks up this file and uses nightly. But `rustup target add aarch64-unknown-linux-gnu` without `--toolchain nightly` installs the target for the stable toolchain only, causing `can't find crate for 'core'`.