### PR TITLE
fix: suppress dead_code warnings in dataplane crate

### DIFF
--- a/dataplane/novaedge-dataplane/src/main.rs
+++ b/dataplane/novaedge-dataplane/src/main.rs
@@ -3,6 +3,10 @@
 //! Receives configuration from the Go agent via gRPC and manages
 //! L4/L7 forwarding, eBPF programs, and VIP operations.
 
+// Modules are scaffolded but not yet fully wired into main().
+// Allow dead code until integration is complete.
+#![allow(dead_code, unused_imports)]
+
 use std::sync::Arc;
 
 use clap::Parser;


### PR DESCRIPTION
## Summary
- Add `#![allow(dead_code, unused_imports)]` at the crate root to suppress 194 warnings
- Modules are scaffolded but not yet fully wired into main(), so dead_code warnings are expected
- Will be removed once all modules are integrated

## Test plan
- [x] `cargo check` produces 0 warnings
- [x] All 365 tests pass