### PR TITLE
fix: use correct --socket CLI flag for dataplane

### DIFF
--- a/Dockerfile.dataplane
+++ b/Dockerfile.dataplane
@@ -58,4 +58,4 @@ COPY --from=builder /build/out/novaedge-dataplane /usr/local/bin/
 COPY --from=builder /build/dataplane/target/bpfel-unknown-none/release/novaedge-ebpf /opt/novaedge/
 
 ENTRYPOINT ["novaedge-dataplane"]
-CMD ["--socket-path=/run/novaedge/dataplane.sock", "--ebpf-path=/opt/novaedge/novaedge-ebpf"]
+CMD ["--socket=/run/novaedge/dataplane.sock", "--ebpf-path=/opt/novaedge/novaedge-ebpf"]

--- a/charts/novaedge/templates/agent-daemonset.yaml
+++ b/charts/novaedge/templates/agent-daemonset.yaml
@@ -196,7 +196,7 @@ spec:
         image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag }}"
         imagePullPolicy: {{ .Values.dataplane.image.pullPolicy }}
         args:
-        - --socket-path={{ .Values.dataplane.socketPath }}
+        - --socket={{ .Values.dataplane.socketPath }}
         - --ebpf-path={{ .Values.dataplane.ebpfPath }}
         securityContext:
           privileged: true

--- a/config/agent/daemonset.yaml
+++ b/config/agent/daemonset.yaml
@@ -179,7 +179,7 @@ spec:
         image: ghcr.io/piwi3910/novaedge-dataplane:latest
         imagePullPolicy: IfNotPresent
         args:
-        - --socket-path=/run/novaedge/dataplane.sock
+        - --socket=/run/novaedge/dataplane.sock
         - --ebpf-path=/opt/novaedge/novaedge-ebpf
         securityContext:
           privileged: true


### PR DESCRIPTION
## Summary
- Fix `--socket-path` → `--socket` in Dockerfile.dataplane CMD, config/agent/daemonset.yaml, and Helm chart template
- The clap argument is defined as `socket` field, so the CLI flag is `--socket` (not `--socket-path`)
- Using the wrong flag caused CrashLoopBackOff on deployment

## Test plan
- [x] Verified correct flag name from `dataplane/novaedge-dataplane/src/main.rs` clap definition
- [x] Confirmed fix works on live cluster (all 8 nodes running 2/2 with dataplane sidecar)