### PR TITLE
fix: remove dead Go forwarding code and Rust Go-only module stubs

### DIFF
--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -50,7 +50,6 @@ import (
 	"github.com/piwi3910/novaedge/internal/agent/ebpf/sockmap"
 	"github.com/piwi3910/novaedge/internal/agent/ebpfmesh"
 	"github.com/piwi3910/novaedge/internal/agent/introspection"
-	"github.com/piwi3910/novaedge/internal/agent/l4"
 	"github.com/piwi3910/novaedge/internal/agent/mesh"
 	"github.com/piwi3910/novaedge/internal/agent/sdwan"
 	"github.com/piwi3910/novaedge/internal/agent/server"
@@ -355,12 +354,6 @@ func main() {
 		logger.Fatal("Failed to create VIP manager", zap.Error(err))
 	}
 
-	// Create HTTP server
-	httpServer := server.NewHTTPServer(logger)
-
-	// Create L4 manager
-	l4Manager := l4.NewManager(logger)
-
 	// Create XDP LB manager — auto-attempted when xdpInterface is set
 	var xdpManager *xdplb.Manager
 	if !forceLegacyLB && xdpInterface != "" {
@@ -371,7 +364,6 @@ func main() {
 				zap.Error(err))
 			xdpManager = nil
 		} else {
-			l4Manager.XDP = xdpManager
 			logger.Info("XDP L4 load balancing active",
 				zap.String("interface", xdpInterface))
 		}
@@ -479,11 +471,6 @@ func main() {
 		logger.Info("eBPF per-IP rate limiter enabled")
 	}
 
-	// Pass eBPF health monitor and rate limiter to the HTTP server so it
-	// can forward them to the Router -> pools/policies on config apply.
-	httpServer.SetEBPFHealthMonitor(ebpfHealthMon)
-	httpServer.SetEBPFRateLimiter(ebpfRL)
-
 	// Create dataplane client and translator for Rust forwarding plane
 	dpClient, dpErr := dpctl.NewClient(dataplaneSocket, logger.Named("dataplane"))
 	if dpErr != nil {
@@ -589,12 +576,6 @@ func main() {
 		})
 	}()
 
-	// Start HTTP server
-	serverChan := make(chan error, 1)
-	go func() {
-		serverChan <- httpServer.Start(ctx)
-	}()
-
 	// Start metrics server
 	metricsChan := make(chan error, 1)
 	go func() {
@@ -620,8 +601,6 @@ func main() {
 	select {
 	case err := <-configChan:
 		logger.Error("Config watcher failed", zap.Error(err))
-	case err := <-serverChan:
-		logger.Error("HTTP server failed", zap.Error(err))
 	case err := <-metricsChan:
 		logger.Error("Metrics server failed", zap.Error(err))
 	case err := <-healthChan:
@@ -716,16 +695,6 @@ func main() {
 		}
 	}
 	// Note: sockMapMgr and ebpfSvcMap are closed by meshManager.Shutdown() above.
-
-	// Shutdown L4 listeners
-	if err := l4Manager.Shutdown(shutdownCtx); err != nil {
-		logger.Error("Error during L4 manager shutdown", zap.Error(err))
-	}
-
-	// Shutdown HTTP server
-	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		logger.Error("Error during HTTP server shutdown", zap.Error(err))
-	}
 
 	// Shutdown metrics server
 	if err := metricsServer.Shutdown(shutdownCtx); err != nil {

--- a/dataplane/novaedge-dataplane/src/main.rs
+++ b/dataplane/novaedge-dataplane/src/main.rs
@@ -1,11 +1,15 @@
 //! NovaEdge dataplane daemon — Rust forwarding plane.
 //!
 //! Receives configuration from the Go agent via gRPC and manages
-//! L4/L7 forwarding, eBPF programs, and VIP operations.
+//! L4/L7 forwarding and eBPF programs.
+//!
+//! VIP management, service mesh, and SD-WAN remain in the Go agent
+//! (kernel netlink / TPROXY / WireGuard operations).
 
-// Modules are scaffolded but not yet fully wired into main().
-// Allow dead code until integration is complete.
-#![allow(dead_code, unused_imports)]
+// Allow dead code for modules not yet wired into the request pipeline
+// (health checking, middleware, upstream pooling, L4 proxy).
+// These will be integrated incrementally.
+#![allow(dead_code)]
 
 use std::sync::Arc;
 
@@ -20,14 +24,11 @@ mod lb;
 mod listener;
 mod loader;
 mod maps;
-mod mesh;
 mod middleware;
 mod proto;
 mod proxy;
-mod sdwan;
 mod server;
 mod upstream;
-mod vip;
 
 /// NovaEdge Rust dataplane daemon.
 #[derive(Parser, Debug)]

--- a/dataplane/novaedge-dataplane/src/server.rs
+++ b/dataplane/novaedge-dataplane/src/server.rs
@@ -513,7 +513,8 @@ impl DataplaneControl for DataplaneService {
                         if filter_protocol > 0 && event.protocol != filter_protocol {
                             continue;
                         }
-                        // TODO: Apply CIDR filters.
+                        // CIDR filters are accepted but not yet applied.
+                        // The Go agent does not currently send CIDR filters.
                         let _ = (&filter_src_cidr, &filter_dst_cidr);
                         yield event;
                     }

--- a/internal/agent/l4/listener.go
+++ b/internal/agent/l4/listener.go
@@ -17,9 +17,9 @@ limitations under the License.
 // Package l4 provides L4 (TCP/UDP) load balancing, proxying, and TLS passthrough
 // capabilities for the NovaEdge data plane agent.
 //
-// DEPRECATED: This package will be removed once --forwarding-plane=rust is
-// validated and the Rust dataplane handles all L4 proxying natively.
-// See docs/plans/forwarding-deprecation.md for the removal timeline.
+// DEPRECATED: The Rust dataplane now handles all L4/L7 forwarding. This package
+// is no longer used by the agent and is retained only for reference during the
+// transition period. It will be removed in a future release.
 package l4
 
 import (


### PR DESCRIPTION
## Summary

Post-merge cleanup from PR #745. Removes dead code that was left behind when the Rust dataplane became the sole forwarding plane.

**Go agent (`cmd/novaedge-agent/main.go`):**
- Remove `httpServer` — was created and started but never received config via `ApplyConfig()` (dead since Rust handles forwarding)
- Remove `l4Manager` — was created but never called in config callback
- Remove `l4` import (now unused)

**Rust dataplane:**
- Remove `mod mesh`, `mod sdwan`, `mod vip` from main.rs — these subsystems stay in Go (per #740, #741, #742) and the Rust implementations were dead code
- Remove scaffold comment and `unused_imports` from `#![allow]` — only `dead_code` remains for not-yet-wired modules (health, middleware, upstream)
- Replace TODO in server.rs flow stream with accurate description

**Other:**
- Update `internal/agent/l4` DEPRECATED comment to reflect current state (no longer references removed `--forwarding-plane` flag)

## Test plan

- [x] `go build ./...` — clean
- [x] `cargo test` — 290 tests pass (90 mesh/sdwan/vip tests removed with modules)
- [x] No unused imports or undefined references