### PR TITLE
fix: config propagation robustness — content hash, faster fallback, gossip resync (#861)

### DIFF
--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -51,6 +51,7 @@ import (
 	ebpfservice "github.com/piwi3910/novaedge/internal/agent/ebpf/service"
 	"github.com/piwi3910/novaedge/internal/agent/ebpf/sockmap"
 	"github.com/piwi3910/novaedge/internal/agent/ebpfmesh"
+	"github.com/piwi3910/novaedge/internal/agent/gossip"
 	"github.com/piwi3910/novaedge/internal/agent/introspection"
 	"github.com/piwi3910/novaedge/internal/agent/mesh"
 	"github.com/piwi3910/novaedge/internal/agent/sdwan"
@@ -340,6 +341,13 @@ func main() {
 		logger.Warn("WARNING: Config watcher running without TLS (insecure)")
 	}
 
+	// Create config version gossiper for agent-to-agent consensus.
+	// Non-fatal: gossip is defense-in-depth, not critical path.
+	gossiper := gossip.NewConfigGossiper(nodeName, watcher.ForceResync, logger)
+	if err := gossiper.Start(ctx); err != nil {
+		logger.Warn("Failed to start config gossiper", zap.Error(err))
+	}
+
 	// Create VIP manager with selected BGP backend
 	var vipOpts []vip.ManagerOption
 	switch bgpBackend {
@@ -609,6 +617,11 @@ func main() {
 			healthServer.SetReady(true)
 			adminServer.SetSnapshot(snapshot)
 			adminServer.SetReady(true)
+
+			// Update gossiper with the newly applied config version so
+			// peers can detect version divergence.
+			gossiper.UpdateVersion(snapshot.Version)
+
 			return nil
 		})
 	}()

--- a/internal/agent/config/watcher.go
+++ b/internal/agent/config/watcher.go
@@ -37,6 +37,7 @@ var (
 	errTLSConfigurationIsIncomplete                  = errors.New("TLS configuration is incomplete")
 	errTLSConfigurationIsRequiredForRemoteAgents     = errors.New("TLS configuration is required for remote agents")
 	errClusterConfigurationIsRequiredForRemoteAgents = errors.New("cluster configuration is required for remote agents")
+	errForceResyncByGossipQuorum                     = errors.New("force resync requested by gossip quorum")
 )
 
 // Snapshot is a wrapper around the protobuf ConfigSnapshot
@@ -74,6 +75,10 @@ type Watcher struct {
 	// complete new Snapshot then do a single atomic Store; readers use Load
 	// without any lock.
 	currentSnapshot atomic.Pointer[Snapshot]
+
+	// forceResyncCh is used by the gossip layer to trigger an immediate
+	// reconnect to the controller, bypassing version comparison.
+	forceResyncCh chan struct{}
 }
 
 // TLSConfig holds TLS configuration for the watcher
@@ -100,6 +105,7 @@ func NewWatcher(ctx context.Context, nodeName, agentVersion, controllerAddr stri
 		logger:         logger,
 		ctx:            ctx,
 		tlsEnabled:     false,
+		forceResyncCh:  make(chan struct{}, 1),
 	}, nil
 }
 
@@ -119,6 +125,7 @@ func NewWatcherWithTLS(ctx context.Context, nodeName, agentVersion, controllerAd
 		tlsKeyFile:     tlsConfig.KeyFile,
 		tlsCAFile:      tlsConfig.CAFile,
 		tlsEnabled:     true,
+		forceResyncCh:  make(chan struct{}, 1),
 	}, nil
 }
 
@@ -145,7 +152,20 @@ func NewRemoteWatcher(ctx context.Context, nodeName, agentVersion, controllerAdd
 		clusterRegion:  clusterConfig.Region,
 		clusterZone:    clusterConfig.Zone,
 		clusterLabels:  clusterConfig.Labels,
+		forceResyncCh:  make(chan struct{}, 1),
 	}, nil
+}
+
+// ForceResync forces the watcher to close the current stream and reconnect
+// to the controller, fetching a fresh config snapshot. Called by the gossip
+// layer when a quorum of peers have a newer config version.
+func (w *Watcher) ForceResync() {
+	select {
+	case w.forceResyncCh <- struct{}{}:
+		w.logger.Info("Force resync requested by gossip quorum")
+	default:
+		// Already pending
+	}
 }
 
 // Start begins watching for config updates and calls applyFunc when updates arrive
@@ -253,6 +273,13 @@ func (w *Watcher) connectWithRetry() (*grpc.ClientConn, error) {
 	}
 }
 
+// recvResult carries the result of a blocking stream.Recv() call so it can
+// be selected alongside other channels.
+type recvResult struct {
+	snapshot *pb.ConfigSnapshot
+	err      error
+}
+
 // streamConfig streams config snapshots from the controller
 func (w *Watcher) streamConfig(client pb.ConfigServiceClient, applyFunc ApplyFunc) error {
 	// Read the last applied version from the atomic snapshot pointer
@@ -284,22 +311,37 @@ func (w *Watcher) streamConfig(client pb.ConfigServiceClient, applyFunc ApplyFun
 	statusTicker := time.NewTicker(30 * time.Second)
 	defer statusTicker.Stop()
 
+	// Run stream.Recv() in a goroutine so we can select on forceResyncCh.
+	recvCh := make(chan recvResult, 1)
+	go func() {
+		for {
+			snapshot, recvErr := stream.Recv()
+			recvCh <- recvResult{snapshot: snapshot, err: recvErr}
+			if recvErr != nil {
+				return
+			}
+		}
+	}()
+
 	// Receive snapshots
 	for {
 		select {
 		case <-w.ctx.Done():
 			return w.ctx.Err()
 
+		case <-w.forceResyncCh:
+			return errForceResyncByGossipQuorum
+
 		case <-statusTicker.C:
 			// Report status to controller
 			go w.reportStatus(w.ctx, client)
 
-		default:
-			snapshot, err := stream.Recv()
-			if err != nil {
-				return fmt.Errorf("error receiving config snapshot: %w", err)
+		case result := <-recvCh:
+			if result.err != nil {
+				return fmt.Errorf("error receiving config snapshot: %w", result.err)
 			}
 
+			snapshot := result.snapshot
 			w.logger.Info("Received config snapshot",
 				zap.String("version", snapshot.Version),
 				zap.Int64("generation_time", snapshot.GenerationTime),

--- a/internal/agent/gossip/gossip.go
+++ b/internal/agent/gossip/gossip.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package gossip implements agent-to-agent config version gossip using
+// UDP multicast. When a quorum of peers report a different (newer) config
+// version, the lagging agent forces a resync from the controller.
+package gossip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// GossipPort is the UDP multicast port for config version gossip.
+	// Distinct from VIP coordination port (9477).
+	GossipPort = 9478
+
+	// MulticastAddr is the multicast group used for gossip.
+	MulticastAddr = "224.0.0.100"
+
+	// BroadcastInterval is how often to announce our config version.
+	BroadcastInterval = 5 * time.Second
+
+	// QuorumCheckInterval is how often to check if we're behind quorum.
+	QuorumCheckInterval = 5 * time.Second
+
+	// PeerExpiry is how long before a silent peer is removed.
+	// Set to 3× BroadcastInterval.
+	PeerExpiry = 15 * time.Second
+
+	// messagePrefix identifies config gossip messages.
+	messagePrefix = "config_version"
+)
+
+// peerState tracks the last known config version and heartbeat of a peer.
+type peerState struct {
+	version  string
+	lastSeen time.Time
+}
+
+// ConfigGossiper manages UDP multicast gossip for config version consensus.
+type ConfigGossiper struct {
+	nodeName        string
+	multicastAddr   string
+	conn            *net.UDPConn
+	currentVersion  atomic.Value // string
+	peerVersions    sync.Map     // map[string]peerState
+	forceResyncFunc func()
+	logger          *zap.Logger
+	ctx             context.Context
+	cancel          context.CancelFunc
+}
+
+// NewConfigGossiper creates a new config version gossiper.
+// forceResyncFunc is called when quorum detects this agent is behind.
+func NewConfigGossiper(nodeName string, forceResyncFunc func(), logger *zap.Logger) *ConfigGossiper {
+	g := &ConfigGossiper{
+		nodeName:        nodeName,
+		multicastAddr:   fmt.Sprintf("%s:%d", MulticastAddr, GossipPort),
+		forceResyncFunc: forceResyncFunc,
+		logger:          logger.Named("gossip"),
+	}
+	g.currentVersion.Store("")
+	return g
+}
+
+// Start begins the gossip protocol. It launches three goroutines:
+// broadcastLoop, receiveLoop, and quorumCheckLoop.
+func (g *ConfigGossiper) Start(ctx context.Context) error {
+	g.ctx, g.cancel = context.WithCancel(ctx)
+
+	addr, err := net.ResolveUDPAddr("udp4", g.multicastAddr)
+	if err != nil {
+		return fmt.Errorf("failed to resolve multicast address %s: %w", g.multicastAddr, err)
+	}
+
+	conn, err := net.ListenMulticastUDP("udp4", nil, addr)
+	if err != nil {
+		return fmt.Errorf("failed to create multicast socket: %w", err)
+	}
+	g.conn = conn
+
+	go g.broadcastLoop(addr)
+	go g.receiveLoop()
+	go g.quorumCheckLoop()
+
+	g.logger.Info("Config gossip started",
+		zap.String("node", g.nodeName),
+		zap.String("multicast", g.multicastAddr),
+	)
+	return nil
+}
+
+// UpdateVersion updates the current config version. Called by the watcher
+// after successfully applying a new config snapshot.
+func (g *ConfigGossiper) UpdateVersion(version string) {
+	g.currentVersion.Store(version)
+	g.logger.Debug("Gossip version updated", zap.String("version", version))
+}
+
+// broadcastLoop multicasts this node's config version at regular intervals.
+func (g *ConfigGossiper) broadcastLoop(addr *net.UDPAddr) {
+	ticker := time.NewTicker(BroadcastInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-g.ctx.Done():
+			return
+		case <-ticker.C:
+			ver, _ := g.currentVersion.Load().(string)
+			if ver == "" {
+				continue // no config applied yet
+			}
+
+			msg := fmt.Sprintf("%s|%s|%s|%d",
+				messagePrefix, g.nodeName, ver, time.Now().UnixNano())
+
+			if _, err := g.conn.WriteToUDP([]byte(msg), addr); err != nil {
+				g.logger.Debug("Failed to broadcast config version", zap.Error(err))
+			}
+		}
+	}
+}
+
+// receiveLoop listens for peer config version announcements.
+func (g *ConfigGossiper) receiveLoop() {
+	buf := make([]byte, 512)
+
+	for {
+		select {
+		case <-g.ctx.Done():
+			return
+		default:
+		}
+
+		if err := g.conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			g.logger.Debug("Failed to set read deadline", zap.Error(err))
+			continue
+		}
+
+		n, _, err := g.conn.ReadFromUDP(buf)
+		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				continue
+			}
+			// Check if context is done (socket closed during shutdown)
+			select {
+			case <-g.ctx.Done():
+				return
+			default:
+			}
+			g.logger.Debug("Error reading gossip message", zap.Error(err))
+			continue
+		}
+
+		g.handleMessage(string(buf[:n]))
+	}
+}
+
+// handleMessage parses and processes a received gossip message.
+// Format: config_version|<nodeName>|<configVersion>|<timestamp>
+func (g *ConfigGossiper) handleMessage(data string) {
+	parts := strings.SplitN(data, "|", 4)
+	if len(parts) != 4 || parts[0] != messagePrefix {
+		return
+	}
+
+	peerName := parts[1]
+	peerVersion := parts[2]
+
+	// Ignore our own messages
+	if peerName == g.nodeName {
+		return
+	}
+
+	g.peerVersions.Store(peerName, peerState{
+		version:  peerVersion,
+		lastSeen: time.Now(),
+	})
+}
+
+// quorumCheckLoop periodically checks if a quorum of peers have a different
+// config version, indicating this agent is lagging.
+func (g *ConfigGossiper) quorumCheckLoop() {
+	ticker := time.NewTicker(QuorumCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-g.ctx.Done():
+			return
+		case <-ticker.C:
+			g.checkQuorum()
+		}
+	}
+}
+
+// checkQuorum determines if a majority of known peers have a different
+// (presumably newer) config version, and forces a resync if so.
+func (g *ConfigGossiper) checkQuorum() {
+	myVersion, _ := g.currentVersion.Load().(string)
+	if myVersion == "" {
+		return // no config applied yet, nothing to compare
+	}
+
+	total := 0
+	newerCount := 0
+	now := time.Now()
+
+	g.peerVersions.Range(func(key, val any) bool {
+		peer, ok := val.(peerState)
+		if !ok {
+			return true
+		}
+
+		// Expire peers not seen in PeerExpiry
+		if now.Sub(peer.lastSeen) > PeerExpiry {
+			g.peerVersions.Delete(key)
+			return true
+		}
+
+		total++
+		if peer.version != myVersion {
+			newerCount++
+		}
+		return true
+	})
+
+	// Quorum: majority of known peers have a different (newer) version
+	if total > 0 && newerCount > total/2 {
+		g.logger.Warn("Config version behind quorum, forcing resync",
+			zap.String("myVersion", myVersion),
+			zap.Int("peers", total),
+			zap.Int("newerPeers", newerCount),
+		)
+		g.forceResyncFunc()
+	}
+}

--- a/internal/controller/snapshot/builder.go
+++ b/internal/controller/snapshot/builder.go
@@ -1451,65 +1451,33 @@ func (b *Builder) loadWASMBinary(source, defaultNamespace string, bc *buildConte
 	return nil, fmt.Errorf("%w: %s/%s (expected key: plugin.wasm)", errWASMBinaryNotFoundInConfigMap, namespace, name)
 }
 
-// generateVersion generates a version string based on content hash.
-// The hash must include ALL mutable snapshot fields so that downstream
-// consumers (e.g. the agent's HTTPServer.ApplyConfig) detect changes.
+// generateVersion generates a version string by hashing the entire proto
+// snapshot with deterministic marshaling. This ensures ANY field change
+// (route rules, LB policies, weights, headers, etc.) produces a new version,
+// not just changes to resource identifiers.
 func (b *Builder) generateVersion(snapshot *pb.ConfigSnapshot) string {
-	// Create a deterministic string representation
-	parts := make([]string, 0, len(snapshot.Gateways)+len(snapshot.Routes)+len(snapshot.Clusters)+len(snapshot.VipAssignments)+len(snapshot.Policies))
+	// Temporarily zero out self-referential fields to avoid including
+	// the previous version or generation timestamp in the hash.
+	savedVersion := snapshot.Version
+	savedGenTime := snapshot.GenerationTime
+	snapshot.Version = ""
+	snapshot.GenerationTime = 0
 
-	// Add all component counts and names
-	for _, gw := range snapshot.Gateways {
-		parts = append(parts, fmt.Sprintf("gw:%s/%s", gw.Namespace, gw.Name))
-	}
-	for _, r := range snapshot.Routes {
-		parts = append(parts, fmt.Sprintf("route:%s/%s", r.Namespace, r.Name))
-	}
-	for _, c := range snapshot.Clusters {
-		parts = append(parts, fmt.Sprintf("cluster:%s/%s", c.Namespace, c.Name))
-	}
-	// Include endpoint addresses and ports so that pod IP changes
-	// (e.g. after a scale-down/up) produce a different version hash.
-	for clusterName, epList := range snapshot.Endpoints {
-		for _, ep := range epList.Endpoints {
-			parts = append(parts, fmt.Sprintf("ep:%s:%s:%d:%v", clusterName, ep.Address, ep.Port, ep.Ready))
-		}
-	}
-	for _, vip := range snapshot.VipAssignments {
-		part := fmt.Sprintf("vip:%s:%s", vip.VipName, vip.Address)
-		if vip.BgpConfig != nil {
-			part += fmt.Sprintf(":bgp:%d:%s:%d", vip.BgpConfig.LocalAs, vip.BgpConfig.RouterId, len(vip.BgpConfig.Peers))
-		}
-		if vip.OspfConfig != nil {
-			part += fmt.Sprintf(":ospf:%s", vip.OspfConfig.RouterId)
-		}
-		parts = append(parts, part)
-	}
-	for _, p := range snapshot.Policies {
-		parts = append(parts, fmt.Sprintf("policy:%s/%s", p.Namespace, p.Name))
-	}
-	for _, l := range snapshot.L4Listeners {
-		parts = append(parts, fmt.Sprintf("l4:%s:%d", l.Name, l.Port))
-	}
-	for _, wl := range snapshot.WanLinks {
-		parts = append(parts, fmt.Sprintf("wanlink:%s/%s", wl.Namespace, wl.Name))
-	}
-	for _, wp := range snapshot.WanPolicies {
-		parts = append(parts, fmt.Sprintf("wanpolicy:%s/%s", wp.Namespace, wp.Name))
+	data, err := proto.MarshalOptions{Deterministic: true}.Marshal(snapshot)
+
+	// Restore fields immediately.
+	snapshot.Version = savedVersion
+	snapshot.GenerationTime = savedGenTime
+
+	if err != nil {
+		// Proto marshal should never fail for a well-formed snapshot,
+		// but return a unique error version so the caller still detects
+		// a change and pushes the snapshot.
+		return fmt.Sprintf("err-%d", time.Now().UnixNano())
 	}
 
-	// Sort for determinism
-	sort.Strings(parts)
-
-	// Hash the concatenated parts
-	h := sha256.New()
-	for _, part := range parts {
-		h.Write([]byte(part))
-	}
-	hash := hex.EncodeToString(h.Sum(nil))
-
-	// Return content hash only for deterministic version comparison
-	return hash[:16]
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:8])
 }
 
 // buildMeshAuthorizationPolicies converts ProxyPolicy resources of type

--- a/internal/controller/snapshot/server.go
+++ b/internal/controller/snapshot/server.go
@@ -203,11 +203,11 @@ func (s *Server) StreamConfig(req *pb.StreamConfigRequest, stream pb.ConfigServi
 	defer s.cache.Unsubscribe(req.NodeName, updateCh)
 
 	// Listen for updates.
-	// The periodic ticker is a 5-minute fallback safety net. Actual changes
+	// The periodic ticker is a 30-second fallback safety net. Actual changes
 	// are delivered through updateCh (triggered by watch handlers). The
 	// periodic rebuild only fires when the dirty flag is set, avoiding
 	// unnecessary List() calls when nothing has changed.
-	ticker := time.NewTicker(5 * time.Minute)
+	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
## Summary

- **Root cause fix**: Replace identifier-only version hashing in `generateVersion()` with `proto.MarshalOptions{Deterministic: true}` — now ANY proto field change (route rules, LB policies, weights, headers, etc.) produces a new version hash
- **Faster fallback**: Reduce periodic rebuild interval from 5 minutes to 30 seconds (only fires when dirty flag is set, so no unnecessary API load)
- **Defense-in-depth**: Add agent-to-agent UDP multicast gossip (`internal/agent/gossip/`) that detects config version divergence via quorum consensus and forces a controller resync through the watcher's new `ForceResync()` method

## Files Changed

| File | Change |
|------|--------|
| `internal/controller/snapshot/builder.go` | Replace `generateVersion()` with proto-based content hashing |
| `internal/controller/snapshot/server.go` | Periodic interval 5min → 30s |
| `internal/agent/gossip/gossip.go` | **New** — config version gossip (broadcast, receive, quorum check) |
| `internal/agent/config/watcher.go` | Add `ForceResync()` method, `forceResyncCh`, restructure `streamConfig()` |
| `cmd/novaedge-agent/main.go` | Wire gossiper to watcher |

## Test Plan

- [x] `make build-all` — all 5 binaries compile clean
- [x] `make test` — all packages pass
- [x] `make lint` (new issues only) — 0 new lint issues
- [ ] Deploy to k3s cluster (8 agent pods):
  - [ ] Modify existing ProxyBackend LB policy → confirm ALL agents receive new config without restart
  - [ ] Modify existing ProxyRoute rules → same
  - [ ] Verify no-op reconciles do NOT trigger unnecessary pushes
  - [ ] Kill controller → modify CRD → bring controller back → confirm gossip forces resync
  - [ ] Check agent logs for gossip quorum messages