### PR TITLE
docs: fix 33 documentation discrepancies from code audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Critical Rules
 
-- **DATAPLANE ARCHITECTURE: ALL traffic (HTTP/HTTPS/HTTP3/TCP/UDP/WebSocket/gRPC) flows through the Rust dataplane + eBPF.** The Go agent is a CONFIG AGENT ONLY — it handles Kubernetes API interaction, config translation, VIP management, iptables/nftables, and eBPF program lifecycle. It does NOT serve user traffic. The Rust dataplane (`dataplane/`) is the sole traffic handler. Legacy Go traffic-handling code (`internal/agent/router/`, `lb/`, `upstream/`, `policy/`, `health/`, and traffic-serving files from `server/`) has been removed. Do NOT reintroduce Go-based traffic handling.
+- **DATAPLANE ARCHITECTURE: ALL traffic (HTTP/HTTPS/HTTP3/TCP/UDP/WebSocket/gRPC) flows through the Rust dataplane + eBPF.** The Go agent is a CONFIG AGENT ONLY — it handles Kubernetes API interaction, config translation, VIP management, iptables/nftables, and eBPF program lifecycle. It does NOT serve user traffic. The Rust dataplane (`dataplane/`) is the sole traffic handler. Legacy Go traffic-handling code (`internal/agent/router/`, `lb/`, `upstream/`, `policy/`, `health/`) has been removed. The Go `internal/agent/server/` directory still exists but only provides health probes, Prometheus metrics, admin API, and eBPF rate-limit management — it does NOT serve user traffic. Do NOT reintroduce Go-based traffic handling.
 - **NEVER create version tags (`git tag`) or push tags after merging PRs unless the user explicitly asks for a new release/version.** Tagging triggers the release workflow which builds and publishes Docker images and GitHub releases. Only tag when specifically instructed.
 - **ALWAYS file GitHub issues for pre-existing problems discovered during work.** When you encounter bugs, lint failures, broken tests, or other issues unrelated to the current task, create a `gh issue` for each one instead of ignoring them.
 - **ALWAYS use git worktrees for all code changes.** Never commit directly to `main`. The workflow is:
@@ -82,14 +82,14 @@ novaedge/
 │   ├── standalone/                   # Standalone mode config
 │   └── proto/                        # Protobuf definitions
 ├── api/                              # CRD API definitions
-│   └── v1alpha1/                     # API version (10 CRD types)
+│   └── v1alpha1/                     # API version (12 CRD types)
 ├── charts/                           # Helm charts
 │   ├── novaedge/                     # Main chart
 │   ├── novaedge-agent/               # Agent chart
 │   └── novaedge-operator/            # Operator chart
 ├── config/                           # Kubernetes manifests
-│   ├── crd/                          # CRD definitions (10 CRDs)
-│   ├── samples/                      # Example resources (51 samples)
+│   ├── crd/                          # CRD definitions (12 CRDs)
+│   ├── samples/                      # Example resources (58 samples)
 │   ├── rbac/                         # RBAC manifests
 │   ├── controller/                   # Controller deployment
 │   ├── agent/                        # Agent DaemonSet
@@ -102,17 +102,17 @@ novaedge/
 │           ├── lb/                   # Load balancing algorithms (12 types)
 │           ├── upstream/             # Connection pool, circuit breaker, outlier detection
 │           ├── health/               # Active health checking
-│           ├── listener/             # Dynamic listener management
+│           ├── listener.rs           # Dynamic listener management
 │           ├── l4/                   # L4 TCP/UDP proxying
 │           ├── vip/                  # VIP management (dataplane side)
 │           ├── mesh/                 # Service mesh support
 │           ├── sdwan/                # SD-WAN support
-│           ├── maps/                 # eBPF map management
-│           ├── loader/               # eBPF program loader
-│           ├── flows/                # Flow event streaming
-│           ├── config/               # Runtime config store
-│           ├── server/               # gRPC server (receives config from Go agent)
-│           └── proto/                # Protobuf definitions
+│           ├── maps.rs               # eBPF map management
+│           ├── loader.rs             # eBPF program loader
+│           ├── flows.rs              # Flow event streaming
+│           ├── config.rs             # Runtime config store
+│           ├── server.rs             # gRPC server (receives config from Go agent)
+│           └── proto.rs              # Protobuf definitions
 ├── docs/                             # Documentation site
 ├── test/                             # Integration tests
 └── Makefile                          # Build automation
@@ -135,7 +135,7 @@ make build-novactl
 # Build web UI frontend (requires Node.js)
 make build-webui
 
-# Build Docker images (all 6: controller, agent, novactl, standalone, operator, webui)
+# Build Docker images (all 7: controller, agent, novactl, standalone, operator, webui, dataplane)
 make docker-build
 
 # Generate CRDs
@@ -443,13 +443,10 @@ Key Go libraries used:
 - `go.uber.org/zap`: Structured logging
 - `github.com/prometheus/client_golang`: Metrics
 - `go.opentelemetry.io/otel`: Tracing
-- `github.com/quic-go/quic-go`: HTTP/3 QUIC support
 - `github.com/tetratelabs/wazero`: WASM plugin runtime
-- `github.com/corazawaf/coraza/v3`: WAF engine
 - `github.com/go-acme/lego/v4`: ACME protocol (Let's Encrypt)
-- `github.com/redis/go-redis/v9`: Distributed rate limiting
-- `github.com/coreos/go-oidc/v3`: OAuth2/OIDC authentication
 - `github.com/golang-jwt/jwt/v5`: JWT parsing and validation
 - `github.com/gorilla/websocket`: WebSocket support
-- `github.com/andybalholm/brotli`: Brotli compression
 - `github.com/spf13/cobra`: CLI framework
+
+Note: HTTP/3 (QUIC), WAF (Coraza), Redis-backed distributed rate limiting, OIDC, and Brotli compression are handled by the Rust dataplane, not the Go codebase.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 
 ---
 
-NovaEdge is a unified replacement for Envoy + MetalLB + NGINX Ingress + Cisco SD-WAN, written in Go. It combines L4/L7 load balancing, VIP management, service mesh, and SD-WAN into a single Kubernetes-native binary.
+NovaEdge is a unified replacement for Envoy + MetalLB + NGINX Ingress + Cisco SD-WAN, written in Go and Rust. It combines L4/L7 load balancing, VIP management, service mesh, and SD-WAN into a Kubernetes-native platform with a Go control plane and Rust data plane.
 
 ## Features
 
 ### L7 Load Balancing & Reverse Proxy
 - **Protocol support**: HTTP/1.1, HTTP/2 (h2/h2c), HTTP/3 (QUIC), WebSockets, gRPC, Server-Sent Events
-- **12 load balancing algorithms**: RoundRobin, LeastConn, P2C, EWMA, RingHash, Maglev, Sticky (cookie-based), Locality-aware, Priority failover, Panic mode, Slow-start, Resource-adaptive
+- **8 CRD-selectable load balancing policies** (RoundRobin, LeastConn, P2C, EWMA, RingHash, Maglev, SourceHash, Sticky) plus composable wrappers in the Rust dataplane (Locality-aware, Priority failover, Panic mode, Slow-start, Resource-adaptive)
 - **Advanced routing**: hostname, path, header, method matching with boolean routing expressions
 - **Traffic management**: canary/weighted splitting, traffic mirroring, request retry with configurable policies
 - **Response processing**: HTTP caching, gzip/Brotli compression, buffering, custom error pages
@@ -114,12 +114,13 @@ NovaEdge is a unified replacement for Envoy + MetalLB + NGINX Ingress + Cisco SD
 
 ## Architecture
 
-NovaEdge consists of four major components:
+NovaEdge consists of five major components:
 
 1. **Operator**: Manages NovaEdge lifecycle via `NovaEdgeCluster` CRD
 2. **Controller (Control-Plane)**: Runs as a Deployment, watches CRDs and Kubernetes resources, builds routing configuration, and pushes ConfigSnapshots to node agents via gRPC
-3. **Node Agent (Data Plane)**: Runs as a DaemonSet with hostNetwork, handles L4/L7 load balancing, VIP management, and executes routing/filtering/policy logic
-4. **CRDs**: 12 Custom Resource Definitions:
+3. **Node Agent (Config Agent)**: Runs as a DaemonSet with hostNetwork, receives configuration from the controller, manages VIP binding (ARP/BGP/OSPF/BFD), iptables/nftables rules, eBPF program lifecycle, and pushes config to the Rust dataplane via gRPC. Does NOT handle user traffic.
+4. **Rust Dataplane (Traffic Handler)**: Runs as a DaemonSet sidecar alongside the Go agent, binds ports 80/443, handles ALL L4/L7 traffic (HTTP/HTTPS/HTTP3/TCP/UDP/WebSocket/gRPC), executes routing, middleware, policies, load balancing, and connection pooling. Optionally accelerated by eBPF XDP.
+5. **CRDs**: 12 Custom Resource Definitions:
    - Core: `ProxyGateway`, `ProxyRoute`, `ProxyBackend`, `ProxyPolicy`, `ProxyVIP`
    - Certificate & IP: `ProxyCertificate`, `ProxyIPPool`
    - SD-WAN: `ProxyWANLink`, `ProxyWANPolicy`
@@ -131,7 +132,7 @@ See the [documentation site](docs/index.md) for detailed architecture and specif
 
 ### Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - Kubernetes cluster (1.29+)
 - kubectl configured
 - make
@@ -265,7 +266,7 @@ kubectl get proxyippools
 ## Testing & Quality
 
 ### Test Suite
-- **1500+ test functions** across unit, integration, and controller tests
+- **1345+ test functions** across unit, integration, and controller tests
 - **85%+ unit coverage** for critical components (router, health, VIP, load balancing, mesh, policies)
 
 ### Running Tests

--- a/charts/novaedge/README.md
+++ b/charts/novaedge/README.md
@@ -42,7 +42,11 @@ helm uninstall novaedge --namespace nova-system
 
 # CRDs are preserved by default, to remove them:
 kubectl delete crds proxybackends.novaedge.io proxygateways.novaedge.io \
-  proxypolicies.novaedge.io proxyroutes.novaedge.io proxyvips.novaedge.io
+  proxypolicies.novaedge.io proxyroutes.novaedge.io proxyvips.novaedge.io \
+  proxycertificates.novaedge.io proxyippools.novaedge.io \
+  proxywanlinks.novaedge.io proxywanpolicies.novaedge.io \
+  novaedgeclusters.novaedge.io novaedgefederations.novaedge.io \
+  novaedgeremoteclusters.novaedge.io
 ```
 
 ## Configuration

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -170,25 +170,66 @@ classDiagram
 
 ```yaml
 # Controller command-line flags
---grpc-port=9090        # gRPC server port
+--grpc-port=9090        # gRPC server port (CRD default: 9090, Helm chart default: 8082)
 --metrics-port=8080     # Prometheus metrics port
 --health-port=8081      # Health probe port
 --log-level=info        # Log level
 --leader-election=true  # Enable leader election
 ```
 
-## Agent
+## Agent (Config Agent)
 
-The Agent is the data plane component that handles all traffic routing and VIP management on each node.
+The Go Agent is a **config-only agent** that manages VIPs, receives configuration from the controller, and pushes it to the Rust Dataplane. It does NOT handle user traffic.
 
 ### Internal Architecture
 
 ```mermaid
 flowchart TB
-    subgraph Agent["Agent"]
+    subgraph Agent["Go Agent (Config Agent)"]
         subgraph Config["Configuration"]
-            GC["gRPC Client"]
+            GC["gRPC Client<br/>(from controller)"]
             CM["Config Manager"]
+            TRANSLATOR["Config Translator"]
+        end
+
+        subgraph VIPMgmt["VIP Management"]
+            VIP["VIP Manager<br/>(L2/BGP/OSPF/BFD)"]
+        end
+
+        subgraph eBPFMgmt["eBPF Program Lifecycle"]
+            EBPF["eBPF Loader"]
+        end
+
+        subgraph DataplanePush["Dataplane Communication"]
+            GRPC_PUSH["gRPC Push to Rust Dataplane"]
+        end
+
+        subgraph Observability["Observability"]
+            MET["Metrics"]
+            HEALTH["Health Probes"]
+            ADMIN["Admin API"]
+        end
+    end
+
+    GC --> CM
+    CM --> TRANSLATOR
+    TRANSLATOR --> GRPC_PUSH
+    CM --> VIP
+    CM --> EBPF
+```
+
+## Rust Dataplane (Traffic Handler)
+
+The Rust Dataplane is the **actual data plane** that handles all L4/L7 traffic. It runs as a DaemonSet sidecar alongside the Go Agent.
+
+### Internal Architecture
+
+```mermaid
+flowchart TB
+    subgraph Dataplane["Rust Dataplane (Traffic Handler)"]
+        subgraph ConfigRecv["Configuration"]
+            GRPC_RECV["gRPC Server<br/>(from Go Agent)"]
+            CFG["Config Store"]
         end
 
         subgraph eBPFAccel["eBPF/XDP Acceleration"]
@@ -198,7 +239,6 @@ flowchart TB
         end
 
         subgraph Traffic["Traffic Handling"]
-            VIP["VIP Manager"]
             RT["Router"]
             POL["Policy Engine"]
             LB["Load Balancer"]
@@ -209,30 +249,22 @@ flowchart TB
             POOL["Connection Pool"]
             CB["Circuit Breaker"]
         end
-
-        subgraph Observability["Observability"]
-            MET["Metrics"]
-            TRC["Tracing"]
-            LOG["Logging"]
-        end
     end
 
-    GC --> CM
-    CM --> VIP & RT & POL & LB & HC & XDP & AFXDP & SKLOOKUP
+    GRPC_RECV --> CFG
+    CFG --> RT & POL & LB & HC & XDP & AFXDP & SKLOOKUP
 
     eBPFAccel --> Traffic
     Traffic --> Backend
-    Traffic --> Observability
-    Backend --> Observability
 
     style eBPFAccel fill:#fff4e6
 ```
 
 ### Subcomponents
 
-#### VIP Manager
+#### VIP Manager (Go Agent)
 
-Manages virtual IP addresses on the node:
+Manages virtual IP addresses on the node (part of the Go config agent):
 
 ```mermaid
 flowchart LR
@@ -255,9 +287,9 @@ flowchart LR
 | BGP | Announce VIP via GoBGP |
 | OSPF | Advertise via OSPF LSAs |
 
-#### Router
+#### Router (Rust Dataplane)
 
-Matches incoming requests to routes:
+Matches incoming requests to routes (part of the Rust dataplane):
 
 ```mermaid
 flowchart LR
@@ -274,9 +306,9 @@ Matching order:
 3. Method
 4. Headers
 
-#### Policy Engine
+#### Policy Engine (Rust Dataplane)
 
-Applies policies to requests:
+Applies policies to requests (part of the Rust dataplane):
 
 ```mermaid
 flowchart LR
@@ -294,9 +326,9 @@ flowchart LR
 | CORS | Handle preflight, set headers |
 | IP Filter | Allow/deny by CIDR |
 
-#### Load Balancer
+#### Load Balancer (Rust Dataplane)
 
-Selects backend endpoints:
+Selects backend endpoints (part of the Rust dataplane):
 
 ```mermaid
 flowchart TB
@@ -320,9 +352,9 @@ flowchart TB
 | Ring Hash | Session affinity |
 | Maglev | High-performance consistent hashing |
 
-#### Health Checker
+#### Health Checker (Rust Dataplane)
 
-Monitors backend health:
+Monitors backend health (part of the Rust dataplane):
 
 ```mermaid
 sequenceDiagram
@@ -348,9 +380,9 @@ Supports:
 - gRPC health protocol
 - Passive failure detection
 
-#### Connection Pool
+#### Connection Pool (Rust Dataplane)
 
-Manages backend connections:
+Manages backend connections (part of the Rust dataplane):
 
 ```mermaid
 flowchart TB
@@ -400,9 +432,9 @@ flowchart TB
 | STUN Discoverer | Discovers public endpoints for NAT traversal in tunnel establishment |
 | DSCP Marker | Applies DSCP markings for QoS enforcement on outbound traffic |
 
-#### eBPF/XDP Acceleration
+#### eBPF/XDP Acceleration (Rust Dataplane + Go Agent)
 
-The agent uses eBPF/XDP by default for data plane acceleration. All features are auto-detected at runtime and fall back to legacy paths if the kernel does not support them.
+The Rust dataplane uses eBPF/XDP by default for data plane acceleration, with the Go agent managing eBPF program lifecycle. All features are auto-detected at runtime and fall back to legacy paths if the kernel does not support them.
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -57,7 +57,8 @@ flowchart TB
 |-----------|------|---------|
 | **Operator** | Deployment | Manages NovaEdge lifecycle via `NovaEdgeCluster` CRD |
 | **Controller** | Deployment | Watches CRDs, builds config snapshots, distributes via gRPC |
-| **Agent** | DaemonSet | Handles L4/L7 routing, VIP management, policy enforcement, eBPF/XDP acceleration |
+| **Agent** | DaemonSet | Config agent: receives config from controller, manages VIPs, pushes config to Rust dataplane |
+| **Rust Dataplane** | DaemonSet sidecar | Traffic handler: binds ports 80/443, handles all L4/L7 traffic, routing, policies, load balancing |
 
 ## Request Flow
 
@@ -65,15 +66,15 @@ flowchart TB
 sequenceDiagram
     participant C as Client
     participant V as VIP
-    participant A as Agent
+    participant DP as Rust Dataplane
     participant R as Router
     participant P as Policies
     participant LB as Load Balancer
     participant B as Backend
 
     C->>V: HTTP Request
-    V->>A: Route to node
-    A->>R: Match route
+    V->>DP: Route to node (port 80/443)
+    DP->>R: Match route
     R->>P: Apply policies
     Note over P: Rate limit, JWT, CORS
     P->>LB: Select backend
@@ -81,9 +82,11 @@ sequenceDiagram
     LB->>B: Forward request
     B-->>LB: Response
     LB-->>P: Apply response policies
-    P-->>A: Return response
-    A-->>C: HTTP Response
+    P-->>DP: Return response
+    DP-->>C: HTTP Response
 ```
+
+Note: The Go Agent does not appear in the request flow. It runs alongside the Rust Dataplane as a config agent, managing VIPs and pushing configuration updates via gRPC.
 
 ## Configuration Distribution
 
@@ -172,15 +175,20 @@ flowchart TB
 
 ### Agent
 
-Each Agent runs as a DaemonSet pod with `hostNetwork: true`:
+Each node runs two DaemonSet pods: the Go Agent (config agent) and the Rust Dataplane (traffic handler), both with `hostNetwork: true`:
 
 ```mermaid
 flowchart TB
-    subgraph Agent["Agent Pod"]
-        GC["gRPC Client"]
+    subgraph GoAgent["Go Agent (Config Agent)"]
+        GC["gRPC Client<br/>(receives config from controller)"]
+        VIP["VIP Manager<br/>(L2/BGP/OSPF/BFD)"]
+        TRANSLATOR["Config Translator"]
+        GRPC_PUSH["gRPC Push to Dataplane"]
+    end
+
+    subgraph RustDP["Rust Dataplane (Traffic Handler)"]
         RT["Router"]
         LB["Load Balancer"]
-        VIP["VIP Manager"]
         HC["Health Checker"]
         POL["Policy Engine"]
         POOL["Connection Pool"]
@@ -192,15 +200,14 @@ flowchart TB
         end
     end
 
-    GC -->|"config"| RT
-    GC -->|"config"| LB
-    GC -->|"config"| VIP
-    GC -->|"config"| POL
+    GC --> TRANSLATOR
+    TRANSLATOR --> GRPC_PUSH
+    GRPC_PUSH -->|"config"| RT & LB & POL & HC
+    GC -->|"VIP config"| VIP
 
     Traffic((Traffic)) --> XDP
     XDP -->|"L4 match"| AFXDP
-    XDP -->|"no match"| VIP
-    VIP --> RT
+    XDP -->|"no match"| RT
     RT --> POL
     POL --> LB
     LB --> HC
@@ -208,18 +215,27 @@ flowchart TB
     POOL --> Backend((Backend))
 
     style eBPF fill:#fff4e6
+    style GoAgent fill:#e6f3ff
+    style RustDP fill:#90EE90
 ```
 
-**Responsibilities:**
+**Agent Responsibilities (Config Agent):**
 
-1. Receive config via gRPC streaming
-2. Bind/unbind VIPs on node interface
-3. Route incoming requests
-4. Apply policies (rate limit, JWT, CORS)
-5. Load balance across healthy backends
-6. Manage connection pools
-7. Perform health checks
-8. Accelerate L4 traffic via eBPF/XDP (auto-detected)
+1. Receive config from controller via gRPC streaming
+2. Bind/unbind VIPs on node interface (L2 ARP/BGP/OSPF/BFD)
+3. Translate config and push to Rust dataplane via gRPC
+4. Manage iptables/nftables rules
+5. Manage eBPF program lifecycle
+
+**Rust Dataplane Responsibilities (Traffic Handler):**
+
+1. Bind ports 80/443 and accept all inbound traffic
+2. Route incoming requests (hostname, path, header matching)
+3. Apply policies (rate limit, JWT, CORS, WAF)
+4. Load balance across healthy backends
+5. Manage connection pools and circuit breakers
+6. Perform active and passive health checks
+7. Accelerate L4 traffic via eBPF/XDP (auto-detected)
 
 ## VIP Modes
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -75,8 +75,7 @@ metadata:
   name: my-vip
 spec:
   address: 192.168.1.100/32
-  mode: L2
-  interface: eth0
+  mode: L2ARP
 ```
 
 ### 3.2 Create a Gateway
@@ -159,8 +158,7 @@ metadata:
   name: my-vip
 spec:
   address: 192.168.1.100/32
-  mode: L2
-  interface: eth0
+  mode: L2ARP
 ---
 apiVersion: novaedge.io/v1alpha1
 kind: ProxyGateway

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -21,11 +21,11 @@ novactl version
 
 ```
 --kubeconfig string   Path to kubeconfig file (default: $KUBECONFIG or ~/.kube/config)
---context string      Kubernetes context to use
 --namespace string    Kubernetes namespace (default: "default")
--o, --output string   Output format: table, json, yaml (default: "table")
 -h, --help           Help for any command
 ```
+
+Note: The `-o, --output` flag is available on per-command basis (e.g., `get`, `sdwan links`) rather than as a global flag.
 
 ## Commands
 
@@ -53,20 +53,21 @@ novactl get <resource-type> [name] [flags]
 ```
 
 **Resource Types:**
-- `clusters` or `cluster` or `cl` (NovaEdgeCluster)
 - `gateways` or `gateway` or `gw`
 - `routes` or `route` or `rt`
 - `backends` or `backend` or `be`
 - `vips` or `vip`
 - `policies` or `policy` or `pol`
+- `tcproutes` or `tcproute`
+- `tlsroutes` or `tlsroute`
+- `grpcroutes` or `grpcroute`
+- `ippools` or `ippool`
+- `wasmplugins` or `wasmplugin` or `wasm` (shown via policies with type WASMPlugin)
+- `certificates` or `certificate` or `cert`
 
 **Examples:**
 
 ```bash
-# List all NovaEdge clusters
-novactl get clusters
-novactl get clusters -A
-
 # List all gateways in current namespace
 novactl get gateways
 
@@ -87,7 +88,6 @@ novactl get gateways -o json
 novactl get gateways -o yaml
 
 # List all resource types
-novactl get clusters
 novactl get routes
 novactl get backends
 novactl get vips
@@ -95,12 +95,6 @@ novactl get policies
 ```
 
 **Table Output Format:**
-
-NovaEdgeClusters:
-```
-NAMESPACE        NAME       VERSION   PHASE     CONTROLLER   AGENTS   AGE
-nova-system  novaedge   v0.1.0    Running   1/1          3/3      5d
-```
 
 Gateways:
 ```
@@ -207,34 +201,6 @@ Status:
 Events:  <none>
 ```
 
-### novactl create
-
-Create resources from file or stdin.
-
-**Syntax:**
-```bash
-novactl create -f <file> [flags]
-```
-
-**Examples:**
-
-```bash
-# Create from file
-novactl create -f gateway.yaml
-
-# Create from multiple files
-novactl create -f gateway.yaml -f route.yaml
-
-# Create from directory
-novactl create -f ./manifests/
-
-# Create from stdin
-cat gateway.yaml | novactl create -f -
-
-# Create in specific namespace
-novactl create -f gateway.yaml -n production
-```
-
 ### novactl apply
 
 Apply configuration from file (create or update).
@@ -289,56 +255,6 @@ novactl delete gateway main-gateway -n production
 novactl delete gateway main-gateway --force --grace-period=0
 ```
 
-### novactl edit
-
-Edit a resource using default editor.
-
-**Syntax:**
-```bash
-novactl edit <resource-type> <name> [flags]
-```
-
-**Examples:**
-
-```bash
-# Edit gateway
-novactl edit gateway main-gateway
-
-# Edit in specific namespace
-novactl edit gateway main-gateway -n production
-
-# Use specific editor
-EDITOR=vim novactl edit gateway main-gateway
-```
-
-### novactl patch
-
-Update fields of a resource.
-
-**Syntax:**
-```bash
-novactl patch <resource-type> <name> -p <patch> [flags]
-```
-
-**Examples:**
-
-```bash
-# Patch with JSON
-novactl patch gateway main-gateway -p '{"spec":{"vipRef":"new-vip"}}'
-
-# Patch with YAML
-novactl patch gateway main-gateway --type=merge -p '
-spec:
-  vipRef: new-vip
-'
-
-# Strategic merge patch (default)
-novactl patch gateway main-gateway --type=strategic -p '{"spec":{"listeners":[{"name":"http","port":8080}]}}'
-
-# JSON patch
-novactl patch gateway main-gateway --type=json -p '[{"op":"replace","path":"/spec/vipRef","value":"new-vip"}]'
-```
-
 ### novactl logs
 
 View logs from NovaEdge components.
@@ -351,6 +267,7 @@ novactl logs <component> [flags]
 **Components:**
 - `controller`
 - `agent`
+- `access` (access logs)
 
 **Examples:**
 
@@ -375,113 +292,6 @@ novactl logs controller --since=1h
 
 # Show timestamps
 novactl logs controller --timestamps
-```
-
-### novactl status
-
-Show overall status of NovaEdge deployment.
-
-**Syntax:**
-```bash
-novactl status [flags]
-```
-
-**Example:**
-
-```bash
-novactl status
-```
-
-**Output:**
-
-```
-NovaEdge Status Report
-
-Operator:
-  Installed:   Yes
-  Version:     v0.1.0
-
-Cluster:
-  Name:        novaedge
-  Namespace:   nova-system
-  Phase:       Running
-  Version:     v0.1.0
-
-Controller:
-  Replicas:    1/1 Ready
-  Version:     v1.0.0
-  Status:      Running
-  Last Sync:   2024-11-15T10:30:00Z
-
-Agents:
-  Total Nodes: 3
-  Ready:       3
-  Version:     v1.0.0
-
-  Node            Status    VIPs    Active Connections
-  ----            ------    ----    ------------------
-  control-plane   Ready     1       145
-  worker-1        Ready     0       203
-  worker-2        Ready     0       198
-
-Web UI:
-  Enabled:     Yes
-  Replicas:    1/1 Ready
-  URL:         http://novaedge-webui.nova-system:9080
-
-Resources:
-  NovaEdgeClusters:  1
-  ProxyGateways:     5
-  ProxyRoutes:       12
-  ProxyBackends:     8
-  ProxyVIPs:         2
-  ProxyPolicies:     6
-
-Health:
-  Operator:    ✓ Healthy
-  Controller:  ✓ Healthy
-  Agents:      ✓ All Ready
-  VIPs:        ✓ All Active
-  Backends:    ⚠ 1 Degraded
-```
-
-### novactl validate
-
-Validate resource definitions without applying them.
-
-**Syntax:**
-```bash
-novactl validate -f <file> [flags]
-```
-
-**Examples:**
-
-```bash
-# Validate single file
-novactl validate -f gateway.yaml
-
-# Validate multiple files
-novactl validate -f gateway.yaml -f route.yaml
-
-# Validate directory
-novactl validate -f ./manifests/
-
-# Validate from stdin
-cat gateway.yaml | novactl validate -f -
-```
-
-**Output:**
-
-```
-✓ gateway.yaml: Valid ProxyGateway (main-gateway)
-✗ route.yaml: Invalid ProxyRoute (test-route)
-  - spec.rules[0].backendRef.name: Required field missing
-  - spec.hostnames: At least one hostname required
-
-Validation Summary:
-  Total: 2
-  Valid: 1
-  Invalid: 1
 ```
 
 ### novactl trace
@@ -615,53 +425,6 @@ Services (3):
   database-service
 ```
 
-### novactl config
-
-View and modify novactl configuration.
-
-**Syntax:**
-```bash
-novactl config <subcommand> [flags]
-```
-
-**Subcommands:**
-- `view` - Display current configuration
-- `set-context` - Set current context
-- `use-context` - Switch context
-
-**Examples:**
-
-```bash
-# View current configuration
-novactl config view
-
-# Set context
-novactl config use-context production
-
-# View contexts
-novactl config get-contexts
-```
-
-## Configuration File
-
-novactl uses `~/.novactl/config` for configuration:
-
-```yaml
-currentContext: default
-contexts:
-- name: default
-  cluster: default
-  namespace: default
-- name: production
-  cluster: production-cluster
-  namespace: prod
-clusters:
-- name: default
-  kubeconfig: ~/.kube/config
-- name: production-cluster
-  kubeconfig: ~/.kube/prod-config
-```
-
 ## Environment Variables
 
 - `KUBECONFIG` - Path to kubeconfig file
@@ -720,11 +483,8 @@ curl -H "Host: myapp.example.com" http://<vip-address>/
 ### Updating Configuration
 
 ```bash
-# Edit route
-novactl edit route myapp-route
-
-# Or patch specific field
-novactl patch route myapp-route -p '{"spec":{"hostnames":["new.example.com"]}}'
+# Update route via apply
+novactl apply -f myapp-route-updated.yaml
 
 # Verify changes
 novactl get route myapp-route -o yaml
@@ -733,9 +493,6 @@ novactl get route myapp-route -o yaml
 ### Troubleshooting
 
 ```bash
-# Check overall status
-novactl status
-
 # View controller logs
 novactl logs controller --tail=100
 
@@ -746,7 +503,11 @@ novactl logs agent --node=worker-1
 novactl describe backend myapp-backend
 
 # Check all resources
-novactl get clusters,gateways,routes,backends,vips,policies
+novactl get gateways
+novactl get routes
+novactl get backends
+novactl get vips
+novactl get policies
 ```
 
 ### Cleaning Up
@@ -774,8 +535,8 @@ novactl is designed to work alongside kubectl:
 | List gateways | `kubectl get proxygateways` | `novactl get gateways` |
 | Describe gateway | `kubectl describe proxygateway main-gateway` | `novactl describe gateway main-gateway` |
 | View logs | `kubectl logs -n nova-system -l app=controller` | `novactl logs controller` |
-| Overall status | Manual inspection | `novactl status` |
-| Validate | `kubectl apply --dry-run=client` | `novactl validate` |
+| Apply config | `kubectl apply -f gateway.yaml` | `novactl apply -f gateway.yaml` |
+| Delete resource | `kubectl delete proxygateway main-gateway` | `novactl delete gateway main-gateway` |
 
 You can use both tools interchangeably. `novactl` provides convenience shortcuts and NovaEdge-specific features, while `kubectl` offers full Kubernetes API access.
 
@@ -802,12 +563,7 @@ You can use both tools interchangeably. `novactl` provides convenience shortcuts
    novactl get routes -o yaml | grep -A1 hostnames
    ```
 
-4. **Validate before applying:**
-   ```bash
-   novactl validate -f config.yaml && novactl apply -f config.yaml
-   ```
-
-5. **Watch logs during deployment:**
+4. **Watch logs during deployment:**
    ```bash
    novactl logs controller -f &
    novactl apply -f new-gateway.yaml

--- a/docs/reference/crd-reference.md
+++ b/docs/reference/crd-reference.md
@@ -1641,11 +1641,13 @@ spec:
     protocol: HTTPS
     port: 443
     tls:
-      mode: Terminate
-      certificateRefs:
-      - kind: Secret
+      secretRef:
         name: tls-secret
+        namespace: default
+      minVersion: "TLS1.2"
 ```
+
+Note: The `tls` field uses the NovaEdge `TLSConfig` struct with fields: `secretRef`, `certificateRef`, `acme`, `selfSigned`, `vaultCertRef`, `minVersion`, and `cipherSuites`. This differs from the Gateway API `mode`/`certificateRefs` pattern.
 
 **Status Conditions:**
 

--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -2,10 +2,11 @@
 
 Complete reference for all configurable values in the NovaEdge Helm charts.
 
-NovaEdge provides two Helm charts:
+NovaEdge provides three Helm charts:
 
 1. **novaedge-operator** - Deploys the NovaEdge Operator which manages the lifecycle of NovaEdge components (recommended)
 2. **novaedge** - Directly deploys NovaEdge components without the operator
+3. **novaedge-agent** - Deploys agents in remote/edge clusters that connect back to a hub controller
 
 ---
 
@@ -361,6 +362,42 @@ tolerations:
 |-----------|-------------|---------|
 | `agent.podDisruptionBudget.enabled` | Enable PDB | `true` |
 | `agent.podDisruptionBudget.maxUnavailable` | Maximum unavailable pods | `1` |
+
+---
+
+## Dataplane
+
+The Rust dataplane handles all L4/L7 traffic and runs as a sidecar alongside the Go agent.
+
+### Basic Settings
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `dataplane.enabled` | Deploy the Rust dataplane sidecar | `true` |
+
+### Image
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `dataplane.image.repository` | Dataplane image repository | `ghcr.io/piwi3910/novaedge/novaedge-dataplane` |
+| `dataplane.image.tag` | Dataplane image tag | `latest` |
+| `dataplane.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+
+### Resources
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `dataplane.resources.limits.cpu` | CPU limit | `1` |
+| `dataplane.resources.limits.memory` | Memory limit | `512Mi` |
+| `dataplane.resources.requests.cpu` | CPU request | `100m` |
+| `dataplane.resources.requests.memory` | Memory request | `128Mi` |
+
+### Communication
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `dataplane.socketPath` | Unix socket for agent-dataplane communication | `/run/novaedge/dataplane.sock` |
+| `dataplane.ebpfPath` | Path to eBPF programs | `/opt/novaedge/novaedge-ebpf` |
 
 ---
 

--- a/docs/user-guide/load-balancing.md
+++ b/docs/user-guide/load-balancing.md
@@ -4,7 +4,7 @@ Configure how NovaEdge distributes traffic across backend endpoints.
 
 ## Algorithms
 
-NovaEdge supports 12 load balancing algorithms plus composable wrappers:
+NovaEdge supports 8 CRD-selectable load balancing policies (RoundRobin, P2C, EWMA, RingHash, Maglev, LeastConn, SourceHash, Sticky) plus composable wrappers in the Rust dataplane:
 
 ```mermaid
 flowchart TB
@@ -38,6 +38,7 @@ flowchart TB
 | LeastConn | Connection-aware distribution | No |
 | RingHash | Stateful applications | Yes |
 | Maglev | High-performance consistent hashing | Yes |
+| SourceHash | Source IP-based consistent routing | Yes |
 
 ### Composable Wrappers
 

--- a/docs/user-guide/middleware-pipelines.md
+++ b/docs/user-guide/middleware-pipelines.md
@@ -10,16 +10,11 @@ A middleware pipeline is an ordered list of middleware entries that execute in p
 - **Short-circuit** the chain (e.g., return 401 for auth failures)
 - **Communicate** with other middleware via pipeline state
 
-## Pipeline Phases
+## Pipeline Execution Model
 
-Middleware can execute at different phases:
+Middleware entries use `Type` (either `builtin` or `wasm`) and `Priority` (integer) to determine execution order. Lower priority numbers execute first.
 
-| Phase | Description |
-|-------|-------------|
-| `pre-route` | Before route matching |
-| `post-route` | After route matching, before backend |
-| `pre-backend` | Just before sending to backend |
-| `post-backend` | After backend response |
+For WASM plugins specifically, the `Phase` field (with values `request`, `response`, or `both`) controls when the plugin executes in the request lifecycle. Built-in middleware does not use phases.
 
 ## Configuration
 

--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -49,10 +49,9 @@ spec:
       hostnames:
         - "*.example.com"
       tls:
-        mode: Terminate
-        certificateRefs:
-          - name: example-tls
-            namespace: default
+        secretRef:
+          name: example-tls
+          namespace: default
 ```
 
 ### Multiple Certificates (SNI)
@@ -68,12 +67,16 @@ spec:
     - name: https
       port: 443
       protocol: HTTPS
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - name: api-tls        # For api.example.com
-          - name: web-tls        # For www.example.com
-          - name: admin-tls      # For admin.example.com
+  tlsCertificates:
+    api.example.com:
+      secretRef:
+        name: api-tls
+    www.example.com:
+      secretRef:
+        name: web-tls
+    admin.example.com:
+      secretRef:
+        name: admin-tls
 ```
 
 NovaEdge automatically selects the correct certificate based on SNI.
@@ -92,26 +95,28 @@ spec:
       port: 443
       protocol: HTTPS
       tls:
-        mode: Terminate
+        secretRef:
+          name: example-tls
         minVersion: "TLS1.2"  # Minimum TLS version
-        maxVersion: "TLS1.3"  # Maximum TLS version
         cipherSuites:
           - TLS_AES_128_GCM_SHA256
           - TLS_AES_256_GCM_SHA384
           - TLS_CHACHA20_POLY1305_SHA256
-        certificateRefs:
-          - name: example-tls
 ```
 
 ### TLS Options
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `mode` | Terminate | TLS mode (Terminate, Passthrough) |
+| `secretRef` | - | Reference to a Kubernetes TLS Secret |
+| `certificateRef` | - | Reference to a ProxyCertificate resource |
+| `acme` | - | Inline ACME certificate provisioning config |
+| `selfSigned` | - | Generate a self-signed certificate |
+| `vaultCertRef` | - | Reference to a Vault PKI certificate |
 | `minVersion` | TLS1.2 | Minimum TLS version |
-| `maxVersion` | TLS1.3 | Maximum TLS version |
 | `cipherSuites` | [] | Allowed cipher suites |
-| `certificateRefs` | [] | Certificate secrets |
+
+One of `secretRef`, `certificateRef`, `acme`, `selfSigned`, or `vaultCertRef` must be specified.
 
 ## TLS Passthrough
 
@@ -293,13 +298,12 @@ spec:
       port: 443
       protocol: HTTPS
       tls:
-        mode: Terminate
-        certificateRefs:
-          - name: server-tls
-        clientValidation:
-          mode: Require  # Require, Request, or Optional
-          caSecretRef:
-            name: client-ca
+        secretRef:
+          name: server-tls
+      clientAuth:
+        mode: require  # none, optional, or require
+        caCertRef:
+          name: client-ca
 ```
 
 ### Client Validation Modes
@@ -326,17 +330,14 @@ spec:
       port: 443
       protocol: HTTPS
       tls:
-        mode: Terminate
-        certificateRefs:
-          - name: server-tls
-        clientValidation:
-          mode: Require
-          caSecretRef:
-            name: client-ca
-          forwardClientCertificate:
-            enabled: true
-            header: X-Client-Certificate
-            sanitize: true
+        secretRef:
+          name: server-tls
+      clientAuth:
+        mode: require
+        caCertRef:
+          name: client-ca
+        requiredCNPatterns:
+          - "^.*$"
 ```
 
 ## Certificate Management
@@ -402,9 +403,8 @@ spec:
       port: 443
       protocol: HTTPS
       tls:
-        mode: Terminate
-        certificateRefs:
-          - name: example-tls
+        secretRef:
+          name: example-tls
 ---
 apiVersion: novaedge.io/v1alpha1
 kind: ProxyRoute


### PR DESCRIPTION
## Summary
- Fixed architecture docs describing Go agent as traffic handler (now correctly describes Rust dataplane)
- Removed 6 non-existent CLI commands from reference (create, edit, patch, status, validate, config)
- Fixed all TLS YAML examples to use actual CRD fields (secretRef/certificateRef instead of mode/certificateRefs)
- Added Rust dataplane documentation to architecture docs and Helm values reference
- Fixed component/algorithm/CRD/test counts throughout
- Updated CLAUDE.md with accurate directory structure and dependencies
- Fixed ProxyVIP YAML examples (L2ARP not L2, no interface field)
- Fixed middleware pipeline docs to match actual schema (Type + Priority, not phases)
- Added missing CRDs to Helm chart uninstall cleanup command
- Fixed chart count from two to three in Helm values reference

### Files changed (12)
- CLAUDE.md (6 fixes)
- README.md (6 fixes)
- docs/architecture/overview.md (4 fixes)
- docs/architecture/components.md (3 fixes)
- docs/reference/cli-reference.md (5 fixes)
- docs/reference/crd-reference.md (1 fix)
- docs/getting-started/quickstart.md (1 fix)
- docs/user-guide/tls.md (1 fix - all YAML examples)
- docs/user-guide/load-balancing.md (1 fix)
- docs/user-guide/middleware-pipelines.md (1 fix)
- docs/reference/helm-values.md (3 fixes)
- charts/novaedge/README.md (1 fix)

## Test plan
- [ ] Verify YAML examples validate against CRD schemas
- [ ] Cross-reference CLI commands with actual cobra registrations
- [ ] Verify Helm values match actual values.yaml
- [ ] Run `mkdocs build --strict` to verify no broken links