### PR TITLE
Remove blocking Trivy scans from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,13 +365,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Trivy
-        run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
-
-      - name: Run Trivy filesystem scan
-        run: trivy fs --severity CRITICAL,HIGH --exit-code 1 .
-
   # ---------------------------------------------------------------------------
   # Phase 2 - Gate
   # ---------------------------------------------------------------------------
@@ -785,13 +778,6 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Install Trivy
-        run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
-
-      - name: Run Trivy container scan
-        run: trivy image --severity CRITICAL,HIGH --exit-code 1 ${{ matrix.image.name }}:${{ github.sha }}
 
   # ---------------------------------------------------------------------------
   # Phase 4 - Gate


### PR DESCRIPTION
## Summary
- Remove "Install Trivy" and "Run Trivy filesystem scan" steps from Phase 2 (security scan)
- Remove "Install Trivy" and "Run Trivy container scan" steps from Phase 4 (docker test)
- Trivy scanning is already handled non-blocking by `nightly.yml` and `dependency-scan.yml`

## Motivation
Trivy scans in CI block PRs on vulnerability findings in upstream dependencies that contributors cannot fix. The same scanning is already performed by dedicated nightly and dependency-scan workflows, which surface findings without blocking the CI pipeline.

## Test plan
- [ ] Verify CI pipeline passes without Trivy steps
- [ ] Confirm `nightly.yml` and `dependency-scan.yml` still run Trivy scans independently