### PR TITLE
Migrate IPAM to NovaNet shared gRPC service

### DIFF
--- a/cmd/novaedge-controller/main.go
+++ b/cmd/novaedge-controller/main.go
@@ -52,6 +52,7 @@ import (
 	vaultpkg "github.com/azrtydxb/novaedge/internal/controller/vault"
 	"github.com/azrtydxb/novaedge/internal/pkg/grpclimits"
 	"github.com/azrtydxb/novaedge/internal/pkg/tlsutil"
+	novanetv1alpha1 "github.com/azrtydxb/novanet/api/v1alpha1"
 )
 
 // Build-time variables set via ldflags.
@@ -69,6 +70,7 @@ var (
 func setupScheme() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(novaedgev1alpha1.AddToScheme(scheme))
+	utilruntime.Must(novanetv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(gatewayv1.Install(scheme))
 }
 
@@ -92,6 +94,7 @@ type controllerFlags struct {
 	federationID          string
 	federationLocalMember string
 	enableLeaderElection  bool
+	ipamSocket            string
 }
 
 func parseControllerFlags() controllerFlags {
@@ -119,6 +122,8 @@ func parseControllerFlags() controllerFlags {
 	flag.BoolVar(&f.enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&f.ipamSocket, "ipam-socket", "/run/novanet/ipam.sock",
+		"Path to NovaNet IPAM gRPC Unix socket. Falls back to local allocator if unavailable.")
 	return f
 }
 
@@ -131,7 +136,7 @@ func registerReconciler(mgr ctrl.Manager, name string, setupFn func(ctrl.Manager
 }
 
 // registerReconcilers registers all CRD and Gateway API reconcilers with the manager.
-func registerReconcilers(mgr ctrl.Manager, f controllerFlags, allocator *ipam.Allocator) *controller.ProxyGatewayReconciler {
+func registerReconcilers(mgr ctrl.Manager, f controllerFlags, allocator ipam.Client) *controller.ProxyGatewayReconciler {
 	registerReconciler(mgr, "ProxyVIP", func(m ctrl.Manager) error {
 		return (&controller.ProxyVIPReconciler{
 			Client: m.GetClient(), Scheme: m.GetScheme(), Allocator: allocator,
@@ -378,7 +383,18 @@ func main() {
 	}
 
 	ipamLogger, _ := uberzap.NewProduction()
-	allocator := ipam.NewAllocator(ipamLogger)
+	var allocator ipam.Client
+
+	// Try to connect to NovaNet IPAM gRPC service; fall back to local allocator.
+	grpcAllocator, grpcErr := ipam.NewGRPCAllocator(f.ipamSocket, ipamLogger)
+	if grpcErr != nil {
+		setupLog.Info("NovaNet IPAM socket unavailable, using local allocator",
+			"socket", f.ipamSocket, "error", grpcErr.Error())
+		allocator = ipam.NewAllocator(ipamLogger)
+	} else {
+		setupLog.Info("Connected to NovaNet IPAM service", "socket", f.ipamSocket)
+		allocator = grpcAllocator
+	}
 
 	proxyGatewayReconciler := registerReconcilers(mgr, f, allocator)
 
@@ -403,4 +419,11 @@ func main() {
 
 	// Graceful shutdown of gRPC server
 	grpcServer.GracefulStop()
+
+	// Close IPAM gRPC connection if applicable.
+	if grpcAllocator != nil {
+		if closeErr := grpcAllocator.Close(); closeErr != nil {
+			setupLog.Error(closeErr, "Failed to close IPAM gRPC connection")
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/azrtydxb/novaedge
 
-go 1.25.7
+go 1.26.0
 
 require (
+	github.com/azrtydxb/novanet v0.0.0-00010101000000-000000000000
 	github.com/cilium/ebpf v0.20.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-acme/lego/v4 v4.29.0
@@ -128,3 +129,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
+
+replace github.com/azrtydxb/novanet => ../novanet

--- a/internal/controller/ipam/allocator.go
+++ b/internal/controller/ipam/allocator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ipam
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -28,7 +29,11 @@ var (
 	errPool = errors.New("pool")
 )
 
-// Allocator manages IP address allocation across multiple pools
+// Verify that Allocator implements Client.
+var _ Client = (*Allocator)(nil)
+
+// Allocator manages IP address allocation across multiple pools.
+// It implements Client for use as a local/standalone IPAM backend.
 type Allocator struct {
 	mu     sync.RWMutex
 	logger *zap.Logger
@@ -99,8 +104,9 @@ func (a *Allocator) RemovePool(name string) {
 	}
 }
 
-// Allocate allocates an IP from the specified pool for a VIP
-func (a *Allocator) Allocate(poolName, vipName string) (string, error) {
+// Allocate allocates an IP from the specified pool for a resource.
+// The context parameter is accepted for interface compatibility but ignored locally.
+func (a *Allocator) Allocate(_ context.Context, poolName, resource string) (string, error) {
 	a.mu.RLock()
 	pool, ok := a.pools[poolName]
 	a.mu.RUnlock()
@@ -109,40 +115,44 @@ func (a *Allocator) Allocate(poolName, vipName string) (string, error) {
 		return "", fmt.Errorf("%w: %s not found", errPool, poolName)
 	}
 
-	addr, err := pool.Allocate(vipName)
+	addr, err := pool.Allocate(resource)
 	if err != nil {
 		return "", err
 	}
 
 	a.logger.Info("IP allocated",
 		zap.String("pool", poolName),
-		zap.String("vip", vipName),
+		zap.String("resource", resource),
 		zap.String("address", addr),
 	)
 
 	return addr, nil
 }
 
-// Release releases an IP allocation for a VIP from the specified pool
-func (a *Allocator) Release(poolName, vipName string) {
+// Release releases an IP allocation for a resource from the specified pool.
+// The context parameter is accepted for interface compatibility but ignored locally.
+func (a *Allocator) Release(_ context.Context, poolName, resource string) error {
 	a.mu.RLock()
 	pool, ok := a.pools[poolName]
 	a.mu.RUnlock()
 
 	if !ok {
-		return
+		return nil
 	}
 
-	pool.Release(vipName)
+	pool.Release(resource)
 
 	a.logger.Info("IP released",
 		zap.String("pool", poolName),
-		zap.String("vip", vipName),
+		zap.String("resource", resource),
 	)
+
+	return nil
 }
 
-// GetPoolStats returns allocation statistics for a pool
-func (a *Allocator) GetPoolStats(poolName string) (allocated, available int, err error) {
+// GetPoolStats returns allocation statistics for a pool.
+// The context parameter is accepted for interface compatibility but ignored locally.
+func (a *Allocator) GetPoolStats(_ context.Context, poolName string) (allocated, available int, err error) {
 	a.mu.RLock()
 	pool, ok := a.pools[poolName]
 	a.mu.RUnlock()
@@ -154,8 +164,9 @@ func (a *Allocator) GetPoolStats(poolName string) (allocated, available int, err
 	return pool.GetAllocatedCount(), pool.GetAvailableCount(), nil
 }
 
-// GetPoolAllocations returns all allocations for a pool
-func (a *Allocator) GetPoolAllocations(poolName string) (map[string]string, error) {
+// GetPoolAllocations returns all allocations for a pool.
+// The context parameter is accepted for interface compatibility but ignored locally.
+func (a *Allocator) GetPoolAllocations(_ context.Context, poolName string) (map[string]string, error) {
 	a.mu.RLock()
 	pool, ok := a.pools[poolName]
 	a.mu.RUnlock()
@@ -167,8 +178,9 @@ func (a *Allocator) GetPoolAllocations(poolName string) (map[string]string, erro
 	return pool.GetAllocations(), nil
 }
 
-// IsAddressConflict checks if an address is already allocated in any pool
-func (a *Allocator) IsAddressConflict(address string) (string, bool) {
+// IsAddressConflict checks if an address is already allocated in any pool.
+// The context parameter is accepted for interface compatibility but ignored locally.
+func (a *Allocator) IsAddressConflict(_ context.Context, address string) (string, bool) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
@@ -181,8 +193,9 @@ func (a *Allocator) IsAddressConflict(address string) (string, bool) {
 	return "", false
 }
 
-// GetPoolNames returns the names of all registered pools
-func (a *Allocator) GetPoolNames() []string {
+// GetPoolNames returns the names of all registered pools.
+// The context parameter is accepted for interface compatibility but ignored locally.
+func (a *Allocator) GetPoolNames(_ context.Context) []string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 

--- a/internal/controller/ipam/allocator_test.go
+++ b/internal/controller/ipam/allocator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ipam
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -101,6 +102,7 @@ func TestAllocator_AddPool(t *testing.T) {
 func TestAllocator_AddPool_Migration(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Create initial pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -109,7 +111,7 @@ func TestAllocator_AddPool_Migration(t *testing.T) {
 	}
 
 	// Allocate an IP
-	addr, err := a.Allocate("test-pool", "test-vip")
+	addr, err := a.Allocate(ctx, "test-pool", "test-vip")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
@@ -124,7 +126,7 @@ func TestAllocator_AddPool_Migration(t *testing.T) {
 	}
 
 	// Verify allocation was migrated
-	allocations, _ := a.GetPoolAllocations("test-pool")
+	allocations, _ := a.GetPoolAllocations(ctx, "test-pool")
 	if allocations[ipStr] != "test-vip" {
 		t.Errorf("allocation not migrated, got allocations: %v", allocations)
 	}
@@ -151,6 +153,7 @@ func TestAllocator_RemovePool(t *testing.T) {
 func TestAllocator_RemovePool_WithAllocations(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -159,7 +162,7 @@ func TestAllocator_RemovePool_WithAllocations(t *testing.T) {
 	}
 
 	// Allocate an IP
-	_, err = a.Allocate("test-pool", "test-vip")
+	_, err = a.Allocate(ctx, "test-pool", "test-vip")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
@@ -183,6 +186,7 @@ func TestAllocator_RemovePool_NonExistent(_ *testing.T) {
 func TestAllocator_Allocate(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -191,7 +195,7 @@ func TestAllocator_Allocate(t *testing.T) {
 	}
 
 	// Allocate an IP
-	addr, err := a.Allocate("test-pool", "test-vip")
+	addr, err := a.Allocate(ctx, "test-pool", "test-vip")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
@@ -204,8 +208,9 @@ func TestAllocator_Allocate(t *testing.T) {
 func TestAllocator_Allocate_PoolNotFound(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
-	_, err := a.Allocate("non-existent", "test-vip")
+	_, err := a.Allocate(ctx, "non-existent", "test-vip")
 	if err == nil {
 		t.Error("Allocate() should return error for non-existent pool")
 	}
@@ -214,6 +219,7 @@ func TestAllocator_Allocate_PoolNotFound(t *testing.T) {
 func TestAllocator_Release(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -222,7 +228,7 @@ func TestAllocator_Release(t *testing.T) {
 	}
 
 	// Allocate an IP
-	addr, err := a.Allocate("test-pool", "test-vip")
+	addr, err := a.Allocate(ctx, "test-pool", "test-vip")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
@@ -237,7 +243,9 @@ func TestAllocator_Release(t *testing.T) {
 	}
 
 	// Release by VIP name
-	a.Release("test-pool", "test-vip")
+	if err := a.Release(ctx, "test-pool", "test-vip"); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
 
 	// Verify it was released
 	if pool.IsAllocated(ipStr) {
@@ -245,17 +253,22 @@ func TestAllocator_Release(t *testing.T) {
 	}
 }
 
-func TestAllocator_Release_PoolNotFound(_ *testing.T) {
+func TestAllocator_Release_PoolNotFound(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
-	// Should not panic
-	a.Release("non-existent", "test-vip")
+	// Should not return error for non-existent pool
+	err := a.Release(ctx, "non-existent", "test-vip")
+	if err != nil {
+		t.Errorf("Release() should not return error for non-existent pool, got %v", err)
+	}
 }
 
 func TestAllocator_GetPoolAllocations(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -264,12 +277,12 @@ func TestAllocator_GetPoolAllocations(t *testing.T) {
 	}
 
 	// Allocate some IPs
-	addr1, err := a.Allocate("test-pool", "vip-1")
+	addr1, err := a.Allocate(ctx, "test-pool", "vip-1")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
 
-	addr2, err := a.Allocate("test-pool", "vip-2")
+	addr2, err := a.Allocate(ctx, "test-pool", "vip-2")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
@@ -279,7 +292,7 @@ func TestAllocator_GetPoolAllocations(t *testing.T) {
 	ip2 := strings.TrimSuffix(addr2, "/32")
 
 	// Get allocations
-	allocations, err := a.GetPoolAllocations("test-pool")
+	allocations, err := a.GetPoolAllocations(ctx, "test-pool")
 	if err != nil {
 		t.Fatalf("GetPoolAllocations() error = %v", err)
 	}
@@ -305,8 +318,9 @@ func TestAllocator_GetPoolAllocations(t *testing.T) {
 func TestAllocator_GetPoolAllocations_PoolNotFound(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
-	allocations, err := a.GetPoolAllocations("non-existent")
+	allocations, err := a.GetPoolAllocations(ctx, "non-existent")
 	if err == nil {
 		t.Error("GetPoolAllocations() should return error for non-existent pool")
 	}
@@ -318,6 +332,7 @@ func TestAllocator_GetPoolAllocations_PoolNotFound(t *testing.T) {
 func TestAllocator_GetPoolStats(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -326,13 +341,13 @@ func TestAllocator_GetPoolStats(t *testing.T) {
 	}
 
 	// Allocate an IP
-	_, err = a.Allocate("test-pool", "vip-1")
+	_, err = a.Allocate(ctx, "test-pool", "vip-1")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
 
 	// Get stats
-	allocated, available, err := a.GetPoolStats("test-pool")
+	allocated, available, err := a.GetPoolStats(ctx, "test-pool")
 	if err != nil {
 		t.Fatalf("GetPoolStats() error = %v", err)
 	}
@@ -349,8 +364,9 @@ func TestAllocator_GetPoolStats(t *testing.T) {
 func TestAllocator_GetPoolStats_PoolNotFound(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
-	_, _, err := a.GetPoolStats("non-existent")
+	_, _, err := a.GetPoolStats(ctx, "non-existent")
 	if err == nil {
 		t.Error("GetPoolStats() should return error for non-existent pool")
 	}
@@ -359,6 +375,7 @@ func TestAllocator_GetPoolStats_PoolNotFound(t *testing.T) {
 func TestAllocator_IsAddressConflict(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -367,7 +384,7 @@ func TestAllocator_IsAddressConflict(t *testing.T) {
 	}
 
 	// Allocate an IP
-	addr, err := a.Allocate("test-pool", "test-vip")
+	addr, err := a.Allocate(ctx, "test-pool", "test-vip")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
@@ -376,7 +393,7 @@ func TestAllocator_IsAddressConflict(t *testing.T) {
 	ipStr := strings.TrimSuffix(addr, "/32")
 
 	// Check conflict
-	poolName, isConflict := a.IsAddressConflict(ipStr)
+	poolName, isConflict := a.IsAddressConflict(ctx, ipStr)
 	if !isConflict {
 		t.Error("IsAddressConflict() should return true for allocated address")
 	}
@@ -385,7 +402,7 @@ func TestAllocator_IsAddressConflict(t *testing.T) {
 	}
 
 	// Check non-conflict
-	_, isConflict = a.IsAddressConflict("192.168.1.250")
+	_, isConflict = a.IsAddressConflict(ctx, "192.168.1.250")
 	if isConflict {
 		t.Error("IsAddressConflict() should return false for unallocated address")
 	}
@@ -394,9 +411,10 @@ func TestAllocator_IsAddressConflict(t *testing.T) {
 func TestAllocator_GetPoolNames(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Initially empty
-	names := a.GetPoolNames()
+	names := a.GetPoolNames(ctx)
 	if len(names) != 0 {
 		t.Errorf("expected 0 pool names, got %d", len(names))
 	}
@@ -405,7 +423,7 @@ func TestAllocator_GetPoolNames(t *testing.T) {
 	_ = a.AddPool("pool-1", []string{"192.168.1.0/29"}, nil)
 	_ = a.AddPool("pool-2", []string{"10.0.0.0/29"}, nil)
 
-	names = a.GetPoolNames()
+	names = a.GetPoolNames(ctx)
 	if len(names) != 2 {
 		t.Errorf("expected 2 pool names, got %d", len(names))
 	}
@@ -424,6 +442,7 @@ func TestAllocator_GetPoolNames(t *testing.T) {
 func TestAllocator_MultiplePools(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add multiple pools
 	err := a.AddPool("pool-1", []string{"192.168.1.0/29"}, nil)
@@ -437,12 +456,12 @@ func TestAllocator_MultiplePools(t *testing.T) {
 	}
 
 	// Allocate from different pools
-	addr1, err := a.Allocate("pool-1", "vip-1")
+	addr1, err := a.Allocate(ctx, "pool-1", "vip-1")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
 
-	addr2, err := a.Allocate("pool-2", "vip-2")
+	addr2, err := a.Allocate(ctx, "pool-2", "vip-2")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
@@ -452,8 +471,8 @@ func TestAllocator_MultiplePools(t *testing.T) {
 	ip2 := strings.TrimSuffix(addr2, "/32")
 
 	// Verify allocations are independent
-	alloc1, _ := a.GetPoolAllocations("pool-1")
-	alloc2, _ := a.GetPoolAllocations("pool-2")
+	alloc1, _ := a.GetPoolAllocations(ctx, "pool-1")
+	alloc2, _ := a.GetPoolAllocations(ctx, "pool-2")
 
 	if len(alloc1) != 1 {
 		t.Errorf("pool-1 should have 1 allocation, got %d", len(alloc1))
@@ -476,6 +495,7 @@ func TestAllocator_MultiplePools(t *testing.T) {
 func TestAllocator_ConcurrentAccess(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool with enough addresses
 	err := a.AddPool("test-pool", []string{"192.168.0.0/16"}, nil)
@@ -490,7 +510,7 @@ func TestAllocator_ConcurrentAccess(t *testing.T) {
 		go func(id int) {
 			for j := 0; j < 10; j++ {
 				vipName := fmt.Sprintf("vip-%d-%d", id, j)
-				_, _ = a.Allocate("test-pool", vipName)
+				_, _ = a.Allocate(ctx, "test-pool", vipName)
 			}
 			done <- true
 		}(i)
@@ -499,10 +519,10 @@ func TestAllocator_ConcurrentAccess(t *testing.T) {
 	// Concurrent releases
 	go func() {
 		for i := 0; i < 10; i++ {
-			allocs, _ := a.GetPoolAllocations("test-pool")
+			allocs, _ := a.GetPoolAllocations(ctx, "test-pool")
 			for ip, vipName := range allocs {
 				// Release by VIP name, not IP
-				a.Release("test-pool", vipName)
+				_ = a.Release(ctx, "test-pool", vipName)
 				_ = ip // Just to avoid unused variable warning
 				break  // Release one and continue
 			}
@@ -519,6 +539,7 @@ func TestAllocator_ConcurrentAccess(t *testing.T) {
 func TestAllocator_ExhaustPool(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a very small pool (only 6 usable addresses in /29)
 	err := a.AddPool("small-pool", []string{"192.168.1.0/29"}, nil)
@@ -529,7 +550,7 @@ func TestAllocator_ExhaustPool(t *testing.T) {
 	// Allocate until exhausted
 	allocated := []string{}
 	for i := 0; i < 10; i++ {
-		addr, err := a.Allocate("small-pool", string(rune('A'+i)))
+		addr, err := a.Allocate(ctx, "small-pool", string(rune('A'+i)))
 		if err != nil {
 			break
 		}
@@ -542,7 +563,7 @@ func TestAllocator_ExhaustPool(t *testing.T) {
 	}
 
 	// Pool should be exhausted (next allocation should fail)
-	_, err = a.Allocate("small-pool", "should-fail")
+	_, err = a.Allocate(ctx, "small-pool", "should-fail")
 	if err == nil {
 		t.Error("expected error when pool is exhausted")
 	}
@@ -551,6 +572,7 @@ func TestAllocator_ExhaustPool(t *testing.T) {
 func TestAllocator_ReleaseByVIPName(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -559,28 +581,30 @@ func TestAllocator_ReleaseByVIPName(t *testing.T) {
 	}
 
 	// Allocate an IP for a specific VIP
-	addr, err := a.Allocate("test-pool", "my-app-vip")
+	addr, err := a.Allocate(ctx, "test-pool", "my-app-vip")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
 
 	// Verify allocation exists
-	allocations, _ := a.GetPoolAllocations("test-pool")
+	allocations, _ := a.GetPoolAllocations(ctx, "test-pool")
 	if len(allocations) != 1 {
 		t.Errorf("expected 1 allocation, got %d", len(allocations))
 	}
 
 	// Release by VIP name (not IP address)
-	a.Release("test-pool", "my-app-vip")
+	if err := a.Release(ctx, "test-pool", "my-app-vip"); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
 
 	// Verify allocation was removed
-	allocations, _ = a.GetPoolAllocations("test-pool")
+	allocations, _ = a.GetPoolAllocations(ctx, "test-pool")
 	if len(allocations) != 0 {
 		t.Errorf("expected 0 allocations after release, got %d", len(allocations))
 	}
 
 	// The IP should now be available for reallocation
-	addr2, err := a.Allocate("test-pool", "another-vip")
+	addr2, err := a.Allocate(ctx, "test-pool", "another-vip")
 	if err != nil {
 		t.Fatalf("Allocate() after release error = %v", err)
 	}
@@ -594,6 +618,7 @@ func TestAllocator_ReleaseByVIPName(t *testing.T) {
 func TestAllocator_AllocateIdempotent(t *testing.T) {
 	logger := zap.NewNop()
 	a := NewAllocator(logger)
+	ctx := context.Background()
 
 	// Add a pool
 	err := a.AddPool("test-pool", []string{"192.168.1.0/29"}, nil)
@@ -602,12 +627,12 @@ func TestAllocator_AllocateIdempotent(t *testing.T) {
 	}
 
 	// Allocate for same VIP twice
-	addr1, err := a.Allocate("test-pool", "same-vip")
+	addr1, err := a.Allocate(ctx, "test-pool", "same-vip")
 	if err != nil {
 		t.Fatalf("Allocate() error = %v", err)
 	}
 
-	addr2, err := a.Allocate("test-pool", "same-vip")
+	addr2, err := a.Allocate(ctx, "test-pool", "same-vip")
 	if err != nil {
 		t.Fatalf("Second Allocate() error = %v", err)
 	}
@@ -618,8 +643,15 @@ func TestAllocator_AllocateIdempotent(t *testing.T) {
 	}
 
 	// Should only have one allocation
-	allocations, _ := a.GetPoolAllocations("test-pool")
+	allocations, _ := a.GetPoolAllocations(ctx, "test-pool")
 	if len(allocations) != 1 {
 		t.Errorf("expected 1 allocation, got %d", len(allocations))
 	}
+}
+
+// TestAllocator_ImplementsClient verifies interface compliance at test time.
+func TestAllocator_ImplementsClient(_ *testing.T) {
+	// Compile-time interface check (also enforced by var _ Client = (*Allocator)(nil) in allocator.go).
+	logger := zap.NewNop()
+	var _ Client = NewAllocator(logger)
 }

--- a/internal/controller/ipam/client.go
+++ b/internal/controller/ipam/client.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import "context"
+
+// Client defines the interface for IP address management operations.
+// It is implemented by the local Allocator (for standalone/test use) and
+// GRPCAllocator (for production use via NovaNet's IPAM gRPC service).
+//
+// Pool lifecycle (AddPool/RemovePool) is NOT part of this interface because
+// in the gRPC path pools are managed as NovaNet IPPool CRDs by the
+// ProxyIPPoolReconciler.
+type Client interface {
+	// Allocate allocates an IP from the specified pool for the given resource.
+	// The resource string identifies the requesting entity (e.g. "proxyvip/my-vip").
+	// Returns the allocated address in CIDR notation (e.g. "10.0.0.1/32").
+	// Allocation is idempotent: repeated calls for the same resource return the same IP.
+	Allocate(ctx context.Context, poolName, resource string) (string, error)
+
+	// Release releases an IP allocation for the given resource from the specified pool.
+	Release(ctx context.Context, poolName, resource string) error
+
+	// GetPoolStats returns allocation statistics for a pool.
+	GetPoolStats(ctx context.Context, poolName string) (allocated, available int, err error)
+
+	// GetPoolAllocations returns all allocations for a pool as a map of IP -> resource name.
+	GetPoolAllocations(ctx context.Context, poolName string) (map[string]string, error)
+
+	// GetPoolNames returns the names of all registered pools.
+	GetPoolNames(ctx context.Context) []string
+
+	// IsAddressConflict checks if an address is already allocated in any pool.
+	// Returns the pool name and true if conflicted.
+	IsAddressConflict(ctx context.Context, address string) (string, bool)
+}

--- a/internal/controller/ipam/grpc_client.go
+++ b/internal/controller/ipam/grpc_client.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	ipampb "github.com/azrtydxb/novanet/api/v1"
+)
+
+const (
+	// ownerNovaEdge is the owner identifier used for all NovaEdge IPAM allocations.
+	ownerNovaEdge = "novaedge"
+)
+
+// Verify that GRPCAllocator implements Client.
+var _ Client = (*GRPCAllocator)(nil)
+
+// GRPCAllocator implements Client by delegating to NovaNet's IPAM gRPC service.
+// It bridges semantic differences between NovaEdge's IPAM model (resource-based,
+// CIDR return format) and NovaNet's gRPC API (owner+resource, bare IP).
+type GRPCAllocator struct {
+	conn   *grpc.ClientConn
+	client ipampb.IPAMServiceClient
+	logger *zap.Logger
+}
+
+// NewGRPCAllocator creates a GRPCAllocator connected to the given Unix socket path.
+func NewGRPCAllocator(socketPath string, logger *zap.Logger) (*GRPCAllocator, error) {
+	conn, err := grpc.NewClient(
+		"unix://"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to IPAM socket %s: %w", socketPath, err)
+	}
+
+	return &GRPCAllocator{
+		conn:   conn,
+		client: ipampb.NewIPAMServiceClient(conn),
+		logger: logger.Named("ipam-grpc"),
+	}, nil
+}
+
+// Close closes the underlying gRPC connection.
+func (g *GRPCAllocator) Close() error {
+	return g.conn.Close()
+}
+
+// Allocate allocates an IP from the specified pool for the given resource.
+// It provides idempotency by checking for an existing allocation before requesting a new one.
+// Returns the allocated address in CIDR notation (e.g. "10.0.0.1/32" or "2001:db8::1/128").
+func (g *GRPCAllocator) Allocate(ctx context.Context, poolName, resource string) (string, error) {
+	// Check for existing allocation (idempotency).
+	existing, err := g.findAllocationByResource(ctx, poolName, resource)
+	if err != nil {
+		return "", fmt.Errorf("failed to check existing allocation: %w", err)
+	}
+	if existing != "" {
+		g.logger.Debug("Returning existing allocation",
+			zap.String("pool", poolName),
+			zap.String("resource", resource),
+			zap.String("ip", existing),
+		)
+		return ipToCIDR(existing), nil
+	}
+
+	// Request new allocation.
+	resp, err := g.client.Allocate(ctx, &ipampb.AllocateRequest{
+		PoolName: poolName,
+		Owner:    ownerNovaEdge,
+		Resource: resource,
+	})
+	if err != nil {
+		return "", fmt.Errorf("IPAM allocate failed for pool %s resource %s: %w", poolName, resource, err)
+	}
+
+	g.logger.Info("IP allocated via gRPC",
+		zap.String("pool", poolName),
+		zap.String("resource", resource),
+		zap.String("address", resp.GetIp()),
+	)
+
+	return ipToCIDR(resp.GetIp()), nil
+}
+
+// Release releases an IP allocation for the given resource from the specified pool.
+// It looks up the IP by resource identifier, then releases it.
+func (g *GRPCAllocator) Release(ctx context.Context, poolName, resource string) error {
+	// Find the IP allocated for this resource.
+	ip, err := g.findAllocationByResource(ctx, poolName, resource)
+	if err != nil {
+		return fmt.Errorf("failed to find allocation for release: %w", err)
+	}
+	if ip == "" {
+		// No allocation found — nothing to release.
+		return nil
+	}
+
+	// Release the IP.
+	_, err = g.client.Release(ctx, &ipampb.ReleaseRequest{
+		PoolName: poolName,
+		Ip:       ip,
+	})
+	if err != nil {
+		return fmt.Errorf("IPAM release failed for pool %s ip %s: %w", poolName, ip, err)
+	}
+
+	g.logger.Info("IP released via gRPC",
+		zap.String("pool", poolName),
+		zap.String("resource", resource),
+		zap.String("ip", ip),
+	)
+
+	return nil
+}
+
+// GetPoolStats returns allocation statistics for a pool.
+func (g *GRPCAllocator) GetPoolStats(ctx context.Context, poolName string) (allocated, available int, err error) {
+	resp, err := g.client.GetPool(ctx, &ipampb.GetPoolRequest{
+		Name: poolName,
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("IPAM GetPool failed for %s: %w", poolName, err)
+	}
+
+	return int(resp.GetAllocated()), int(resp.GetAvailable()), nil
+}
+
+// GetPoolAllocations returns all allocations for a pool as a map of IP -> resource name.
+func (g *GRPCAllocator) GetPoolAllocations(ctx context.Context, poolName string) (map[string]string, error) {
+	resp, err := g.client.ListIPAllocations(ctx, &ipampb.ListIPAllocationsRequest{
+		PoolFilter: poolName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("IPAM ListIPAllocations failed for pool %s: %w", poolName, err)
+	}
+
+	result := make(map[string]string, len(resp.GetAllocations()))
+	for _, alloc := range resp.GetAllocations() {
+		result[alloc.GetIp()] = alloc.GetResource()
+	}
+
+	return result, nil
+}
+
+// GetPoolNames returns the names of all registered pools.
+func (g *GRPCAllocator) GetPoolNames(ctx context.Context) []string {
+	resp, err := g.client.ListIPPools(ctx, &ipampb.ListIPPoolsRequest{})
+	if err != nil {
+		g.logger.Error("Failed to list IP pools via gRPC", zap.Error(err))
+		return nil
+	}
+
+	names := make([]string, 0, len(resp.GetPools()))
+	for _, pool := range resp.GetPools() {
+		names = append(names, pool.GetName())
+	}
+	return names
+}
+
+// IsAddressConflict checks if an address is already allocated in any pool.
+func (g *GRPCAllocator) IsAddressConflict(ctx context.Context, address string) (string, bool) {
+	resp, err := g.client.ListIPPools(ctx, &ipampb.ListIPPoolsRequest{})
+	if err != nil {
+		g.logger.Error("Failed to list IP pools for conflict check", zap.Error(err))
+		return "", false
+	}
+
+	for _, pool := range resp.GetPools() {
+		allocResp, allocErr := g.client.ListIPAllocations(ctx, &ipampb.ListIPAllocationsRequest{
+			PoolFilter: pool.GetName(),
+		})
+		if allocErr != nil {
+			continue
+		}
+		for _, alloc := range allocResp.GetAllocations() {
+			if alloc.GetIp() == address {
+				return pool.GetName(), true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// findAllocationByResource looks up an existing allocation by owner and resource in a pool.
+func (g *GRPCAllocator) findAllocationByResource(ctx context.Context, poolName, resource string) (string, error) {
+	resp, err := g.client.ListIPAllocations(ctx, &ipampb.ListIPAllocationsRequest{
+		PoolFilter:  poolName,
+		OwnerFilter: ownerNovaEdge,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	for _, alloc := range resp.GetAllocations() {
+		if alloc.GetResource() == resource {
+			return alloc.GetIp(), nil
+		}
+	}
+
+	return "", nil
+}
+
+// ipToCIDR appends /32 (IPv4) or /128 (IPv6) to a bare IP address.
+func ipToCIDR(ip string) string {
+	if strings.Contains(ip, "/") {
+		return ip // already in CIDR notation
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return ip + "/32" // fallback
+	}
+	if parsed.To4() != nil {
+		return ip + "/32"
+	}
+	return ip + "/128"
+}

--- a/internal/controller/ipam/grpc_client_test.go
+++ b/internal/controller/ipam/grpc_client_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"testing"
+)
+
+func TestIPToCIDR(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"10.0.0.1", "10.0.0.1/32"},
+		{"192.168.1.100", "192.168.1.100/32"},
+		{"2001:db8::1", "2001:db8::1/128"},
+		{"::1", "::1/128"},
+		{"10.0.0.1/32", "10.0.0.1/32"},         // already CIDR
+		{"2001:db8::1/128", "2001:db8::1/128"}, // already CIDR
+		{"10.0.0.1/24", "10.0.0.1/24"},         // non-host CIDR preserved
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ipToCIDR(tt.input)
+			if result != tt.expected {
+				t.Errorf("ipToCIDR(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGRPCAllocator_ImplementsClient(t *testing.T) {
+	// Compile-time check (via var _ above), but also verify at test time.
+	var _ Client = (*GRPCAllocator)(nil)
+}

--- a/internal/controller/ipam/pool_test.go
+++ b/internal/controller/ipam/pool_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ipam
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -203,6 +204,7 @@ func TestPool_IsAllocated(t *testing.T) {
 func TestAllocator_MultiplePool(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	allocator := NewAllocator(logger)
+	ctx := context.Background()
 
 	err := allocator.AddPool("pool-a", []string{"10.200.0.0/30"}, nil)
 	if err != nil {
@@ -215,7 +217,7 @@ func TestAllocator_MultiplePool(t *testing.T) {
 	}
 
 	t.Run("allocate from pool-a", func(t *testing.T) {
-		addr, err := allocator.Allocate("pool-a", "vip-1")
+		addr, err := allocator.Allocate(ctx, "pool-a", "vip-1")
 		if err != nil {
 			t.Fatalf("Failed to allocate: %v", err)
 		}
@@ -225,7 +227,7 @@ func TestAllocator_MultiplePool(t *testing.T) {
 	})
 
 	t.Run("allocate from pool-b", func(t *testing.T) {
-		addr, err := allocator.Allocate("pool-b", "vip-2")
+		addr, err := allocator.Allocate(ctx, "pool-b", "vip-2")
 		if err != nil {
 			t.Fatalf("Failed to allocate: %v", err)
 		}
@@ -235,14 +237,14 @@ func TestAllocator_MultiplePool(t *testing.T) {
 	})
 
 	t.Run("allocate from non-existent pool", func(t *testing.T) {
-		_, err := allocator.Allocate("pool-c", "vip-3")
+		_, err := allocator.Allocate(ctx, "pool-c", "vip-3")
 		if err == nil {
 			t.Error("Expected error for non-existent pool")
 		}
 	})
 
 	t.Run("conflict detection", func(t *testing.T) {
-		poolName, conflict := allocator.IsAddressConflict("10.200.0.1")
+		poolName, conflict := allocator.IsAddressConflict(ctx, "10.200.0.1")
 		if !conflict {
 			t.Error("Expected conflict for allocated address")
 		}
@@ -252,7 +254,7 @@ func TestAllocator_MultiplePool(t *testing.T) {
 	})
 
 	t.Run("pool stats", func(t *testing.T) {
-		allocated, available, err := allocator.GetPoolStats("pool-a")
+		allocated, available, err := allocator.GetPoolStats(ctx, "pool-a")
 		if err != nil {
 			t.Fatalf("Failed to get stats: %v", err)
 		}
@@ -266,7 +268,7 @@ func TestAllocator_MultiplePool(t *testing.T) {
 
 	t.Run("remove pool", func(t *testing.T) {
 		allocator.RemovePool("pool-a")
-		names := allocator.GetPoolNames()
+		names := allocator.GetPoolNames(ctx)
 		if len(names) != 1 {
 			t.Errorf("Expected 1 pool remaining, got %d", len(names))
 		}

--- a/internal/controller/proxyippool_controller.go
+++ b/internal/controller/proxyippool_controller.go
@@ -23,26 +23,36 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	novaedgev1alpha1 "github.com/azrtydxb/novaedge/api/v1alpha1"
 	"github.com/azrtydxb/novaedge/internal/controller/ipam"
+	novanetv1alpha1 "github.com/azrtydxb/novanet/api/v1alpha1"
+)
+
+const (
+	// proxyIPPoolFinalizer is the finalizer added to ProxyIPPool resources
+	// to ensure cleanup of the corresponding NovaNet IPPool CRD on deletion.
+	proxyIPPoolFinalizer = "novaedge.io/ippool-cleanup"
 )
 
 // ProxyIPPoolReconciler reconciles a ProxyIPPool object
 type ProxyIPPoolReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
-	Allocator *ipam.Allocator
+	Allocator ipam.Client
 }
 
 // +kubebuilder:rbac:groups=novaedge.io,resources=proxyippools,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=novaedge.io,resources=proxyippools/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=novaedge.io,resources=proxyippools/finalizers,verbs=update
+// +kubebuilder:rbac:groups=novanet.io,resources=ippools,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile handles ProxyIPPool reconciliation
 func (r *ProxyIPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -52,14 +62,45 @@ func (r *ProxyIPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	err := r.Get(ctx, req.NamespacedName, pool)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			logger.Info("ProxyIPPool resource not found, removing from allocator")
-			if r.Allocator != nil {
-				r.Allocator.RemovePool(req.Name)
+			logger.Info("ProxyIPPool resource not found, cleaning up NovaNet IPPool")
+			// Delete the corresponding NovaNet IPPool if it exists.
+			novanetPool := &novanetv1alpha1.IPPool{}
+			novanetPool.Name = req.Name
+			if delErr := r.Delete(ctx, novanetPool); delErr != nil && !errors.IsNotFound(delErr) {
+				logger.Error(delErr, "Failed to delete NovaNet IPPool")
 			}
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get ProxyIPPool")
 		return ctrl.Result{}, err
+	}
+
+	// Handle deletion with finalizer.
+	if !pool.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(pool, proxyIPPoolFinalizer) {
+			// Delete the corresponding NovaNet IPPool.
+			novanetPool := &novanetv1alpha1.IPPool{}
+			novanetPool.Name = pool.Name
+			if delErr := r.Delete(ctx, novanetPool); delErr != nil && !errors.IsNotFound(delErr) {
+				logger.Error(delErr, "Failed to delete NovaNet IPPool during finalization")
+				return ctrl.Result{}, delErr
+			}
+
+			// Remove the finalizer.
+			controllerutil.RemoveFinalizer(pool, proxyIPPoolFinalizer)
+			if err := r.Update(ctx, pool); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Add finalizer if not present.
+	if !controllerutil.ContainsFinalizer(pool, proxyIPPoolFinalizer) {
+		controllerutil.AddFinalizer(pool, proxyIPPoolFinalizer)
+		if err := r.Update(ctx, pool); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	logger.Info("Reconciling ProxyIPPool",
@@ -69,55 +110,32 @@ func (r *ProxyIPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		"autoAssign", pool.Spec.AutoAssign,
 	)
 
-	// Register/update pool in allocator
-	if r.Allocator != nil {
-		if err := r.Allocator.AddPool(pool.Name, pool.Spec.CIDRs, pool.Spec.Addresses); err != nil {
-			logger.Error(err, "Failed to register IP pool")
+	// Sync ProxyIPPool spec to a NovaNet IPPool CRD.
+	if err := r.syncNovanetIPPool(ctx, pool); err != nil {
+		logger.Error(err, "Failed to sync NovaNet IPPool")
 
-			// Update status with error condition
-			condition := metav1.Condition{
-				Type:               "Ready",
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: pool.Generation,
-				LastTransitionTime: metav1.Now(),
-				Reason:             "PoolConfigError",
-				Message:            err.Error(),
-			}
-			setCondition(&pool.Status.Conditions, condition)
-			if statusErr := r.Status().Update(ctx, pool); statusErr != nil {
-				logger.Error(statusErr, "Failed to update pool status")
-			}
-
-			return ctrl.Result{}, err
+		condition := metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: pool.Generation,
+			LastTransitionTime: metav1.Now(),
+			Reason:             "IPPoolSyncError",
+			Message:            err.Error(),
+		}
+		setCondition(&pool.Status.Conditions, condition)
+		if statusErr := r.Status().Update(ctx, pool); statusErr != nil {
+			logger.Error(statusErr, "Failed to update pool status")
 		}
 
-		// Get pool stats
-		allocated, available, statsErr := r.Allocator.GetPoolStats(pool.Name)
-		if statsErr == nil {
-			if allocated > math.MaxInt32 {
-				allocated = math.MaxInt32
-			}
-			if available > math.MaxInt32 {
-				available = math.MaxInt32
-			}
-			pool.Status.Allocated = int32(allocated) //nolint:gosec // bounds-checked above
-			pool.Status.Available = int32(available) //nolint:gosec // bounds-checked above
-		}
-
-		// Get allocations
-		allocations, allocErr := r.Allocator.GetPoolAllocations(pool.Name)
-		if allocErr == nil {
-			pool.Status.Allocations = make([]novaedgev1alpha1.IPAllocation, 0, len(allocations))
-			for addr, vipName := range allocations {
-				pool.Status.Allocations = append(pool.Status.Allocations, novaedgev1alpha1.IPAllocation{
-					Address: addr,
-					VIPRef:  vipName,
-				})
-			}
-		}
+		return ctrl.Result{}, err
 	}
 
-	// Update status
+	// Query stats from IPAM service.
+	if r.Allocator != nil {
+		r.updatePoolStatus(ctx, pool)
+	}
+
+	// Update status.
 	pool.Status.ObservedGeneration = pool.Generation
 	condition := metav1.Condition{
 		Type:               "Ready",
@@ -135,6 +153,71 @@ func (r *ProxyIPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// updatePoolStatus queries the IPAM service for pool stats and allocations,
+// then updates the ProxyIPPool status fields.
+func (r *ProxyIPPoolReconciler) updatePoolStatus(ctx context.Context, pool *novaedgev1alpha1.ProxyIPPool) {
+	allocated, available, statsErr := r.Allocator.GetPoolStats(ctx, pool.Name)
+	if statsErr == nil {
+		if allocated > math.MaxInt32 {
+			allocated = math.MaxInt32
+		}
+		if available > math.MaxInt32 {
+			available = math.MaxInt32
+		}
+		pool.Status.Allocated = int32(allocated) //nolint:gosec // bounds-checked above
+		pool.Status.Available = int32(available) //nolint:gosec // bounds-checked above
+	}
+
+	allocations, allocErr := r.Allocator.GetPoolAllocations(ctx, pool.Name)
+	if allocErr == nil {
+		pool.Status.Allocations = make([]novaedgev1alpha1.IPAllocation, 0, len(allocations))
+		for addr, resource := range allocations {
+			pool.Status.Allocations = append(pool.Status.Allocations, novaedgev1alpha1.IPAllocation{
+				Address: addr,
+				VIPRef:  resource,
+			})
+		}
+	}
+}
+
+// syncNovanetIPPool creates or updates the corresponding NovaNet IPPool CRD
+// from a ProxyIPPool spec. This ensures NovaNet's IPAM service knows about the pool.
+func (r *ProxyIPPoolReconciler) syncNovanetIPPool(ctx context.Context, pool *novaedgev1alpha1.ProxyIPPool) error {
+	novanetPool := &novanetv1alpha1.IPPool{}
+	err := r.Get(ctx, types.NamespacedName{Name: pool.Name}, novanetPool)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+
+		// Create new NovaNet IPPool.
+		novanetPool = &novanetv1alpha1.IPPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pool.Name,
+				Labels: map[string]string{
+					"novaedge.io/managed-by": "proxyippool",
+				},
+			},
+			Spec: novanetv1alpha1.IPPoolSpec{
+				Type:       novanetv1alpha1.IPPoolTypeLoadBalancerVIP,
+				CIDRs:      pool.Spec.CIDRs,
+				Addresses:  pool.Spec.Addresses,
+				AutoAssign: pool.Spec.AutoAssign,
+				Owner:      "novaedge",
+			},
+		}
+
+		return r.Create(ctx, novanetPool)
+	}
+
+	// Update existing NovaNet IPPool if spec changed.
+	novanetPool.Spec.CIDRs = pool.Spec.CIDRs
+	novanetPool.Spec.Addresses = pool.Spec.Addresses
+	novanetPool.Spec.AutoAssign = pool.Spec.AutoAssign
+
+	return r.Update(ctx, novanetPool)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/proxyvip_controller.go
+++ b/internal/controller/proxyvip_controller.go
@@ -48,7 +48,7 @@ import (
 type ProxyVIPReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
-	Allocator *ipam.Allocator
+	Allocator ipam.Client
 }
 
 // +kubebuilder:rbac:groups=novaedge.io,resources=proxyvips,verbs=get;list;watch;create;update;patch;delete
@@ -144,36 +144,25 @@ func (r *ProxyVIPReconciler) reconcileIPAM(ctx context.Context, vip *novaedgev1a
 
 	// Handle IPAM allocation if poolRef is set and no address allocated yet
 	if vip.Spec.PoolRef != nil && vip.Status.AllocatedAddress == "" && r.Allocator != nil {
-		pool := &novaedgev1alpha1.ProxyIPPool{}
-		if err := r.Get(ctx, client.ObjectKey{Name: vip.Spec.PoolRef.Name}, pool); err != nil {
-			if !errors.IsNotFound(err) {
-				logger.Error(err, "Failed to get ProxyIPPool", "pool", vip.Spec.PoolRef.Name)
-				return err
-			}
-			logger.Info("Referenced ProxyIPPool not found", "pool", vip.Spec.PoolRef.Name)
-		} else {
-			cidrs := append([]string{}, pool.Spec.CIDRs...)
-			addresses := append([]string{}, pool.Spec.Addresses...)
-			if err := r.Allocator.AddPool(pool.Name, cidrs, addresses); err != nil {
-				logger.Error(err, "Failed to register IP pool", "pool", pool.Name)
-				return err
-			}
+		poolName := vip.Spec.PoolRef.Name
+		resource := "proxyvip/" + vip.Name
 
-			allocated, err := r.Allocator.Allocate(pool.Name, vip.Name)
-			if err != nil {
-				logger.Error(err, "Failed to allocate IP from pool", "pool", pool.Name)
-				return err
-			}
-
-			vip.Status.AllocatedAddress = allocated
-			if err := r.Status().Update(ctx, vip); err != nil {
-				logger.Error(err, "Failed to update VIP status with allocated address")
-				r.Allocator.Release(pool.Name, vip.Name)
-				return err
-			}
-
-			logger.Info("Allocated IP from pool", "pool", pool.Name, "address", allocated, "vip", vip.Name)
+		allocated, err := r.Allocator.Allocate(ctx, poolName, resource)
+		if err != nil {
+			logger.Error(err, "Failed to allocate IP from pool", "pool", poolName)
+			return err
 		}
+
+		vip.Status.AllocatedAddress = allocated
+		if err := r.Status().Update(ctx, vip); err != nil {
+			logger.Error(err, "Failed to update VIP status with allocated address")
+			if releaseErr := r.Allocator.Release(ctx, poolName, resource); releaseErr != nil {
+				logger.Error(releaseErr, "Failed to release IP after status update failure")
+			}
+			return err
+		}
+
+		logger.Info("Allocated IP from pool", "pool", poolName, "address", allocated, "vip", vip.Name)
 	}
 
 	// Handle IPAM release if VIP had allocation but poolRef was removed

--- a/internal/controller/service_controller.go
+++ b/internal/controller/service_controller.go
@@ -70,7 +70,7 @@ const (
 type ServiceReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
-	Allocator       *ipam.Allocator
+	Allocator       ipam.Client
 	Recorder        record.EventRecorder
 	EnableServiceLB bool
 }
@@ -96,7 +96,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if apierrors.IsNotFound(err) {
 			// Service deleted — IPAM release is handled below when ProxyVIP is not found
 			logger.Info("Service resource not found, cleaning up IPAM allocation if any")
-			r.releaseIPAMForService(req.Name, req.Namespace)
+			r.releaseIPAMForService(ctx, req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get Service")
@@ -139,7 +139,8 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	vipName := vipNamePrefix + svc.Name
 
 	// Allocate IP from IPAM pool
-	address, err := r.Allocator.Allocate(poolName, vipName)
+	ipamResource := "service/" + svc.Namespace + "/" + svc.Name
+	address, err := r.Allocator.Allocate(ctx, poolName, ipamResource)
 	if err != nil {
 		r.recordEvent(svc, corev1.EventTypeWarning, "IPAllocationFailed",
 			fmt.Sprintf("Failed to allocate IP from pool %q: %v", poolName, err))
@@ -154,7 +155,9 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			fmt.Sprintf("Failed to parse annotations: %v", err))
 		logger.Error(err, "Failed to build VIP spec from annotations")
 		// Release the allocated IP since we can't create the VIP
-		r.Allocator.Release(poolName, vipName)
+		if releaseErr := r.Allocator.Release(ctx, poolName, ipamResource); releaseErr != nil {
+			logger.Error(releaseErr, "Failed to release IP after annotation parse failure")
+		}
 		return ctrl.Result{}, nil // Do not requeue for invalid annotations
 	}
 
@@ -184,7 +187,9 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					fmt.Sprintf("Failed to create ProxyVIP: %v", createErr))
 				logger.Error(createErr, "Failed to create ProxyVIP", "vipName", vipName)
 				// Release the allocated IP since VIP creation failed
-				r.Allocator.Release(poolName, vipName)
+				if releaseErr := r.Allocator.Release(ctx, poolName, ipamResource); releaseErr != nil {
+					logger.Error(releaseErr, "Failed to release IP after VIP creation failure")
+				}
 				return ctrl.Result{}, createErr
 			}
 
@@ -222,16 +227,15 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 // releaseIPAMForService releases the IPAM allocation for a deleted Service.
-func (r *ServiceReconciler) releaseIPAMForService(serviceName, namespace string) {
+func (r *ServiceReconciler) releaseIPAMForService(ctx context.Context, serviceName, namespace string) {
 	if r.Allocator == nil {
 		return
 	}
-	vipName := vipNamePrefix + serviceName
+	ipamResource := "service/" + namespace + "/" + serviceName
 	// Try to release from all known pools since we don't track which pool was used
-	for _, poolName := range r.Allocator.GetPoolNames() {
-		r.Allocator.Release(poolName, vipName)
+	for _, poolName := range r.Allocator.GetPoolNames(ctx) {
+		_ = r.Allocator.Release(ctx, poolName, ipamResource)
 	}
-	_ = namespace // namespace used for logging context if needed
 }
 
 // parseVIPMode validates and converts a string annotation value to a VIPMode.

--- a/internal/controller/service_controller_test.go
+++ b/internal/controller/service_controller_test.go
@@ -409,7 +409,7 @@ func TestServiceDeletionTriggersIPAMRelease(t *testing.T) {
 	}
 
 	// Verify IP was allocated
-	allocated1, _, err := env.allocator.GetPoolStats(defaultPoolName)
+	allocated1, _, err := env.allocator.GetPoolStats(ctx, defaultPoolName)
 	if err != nil {
 		t.Fatalf("failed to get pool stats: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestServiceDeletionTriggersIPAMRelease(t *testing.T) {
 	}
 
 	// Verify IP was released
-	allocated2, _, err := env.allocator.GetPoolStats(defaultPoolName)
+	allocated2, _, err := env.allocator.GetPoolStats(ctx, defaultPoolName)
 	if err != nil {
 		t.Fatalf("failed to get pool stats after release: %v", err)
 	}
@@ -822,7 +822,7 @@ func TestIdempotentReconciliation(t *testing.T) {
 	}
 
 	// Verify only one allocation exists
-	allocated, _, err := env.allocator.GetPoolStats(defaultPoolName)
+	allocated, _, err := env.allocator.GetPoolStats(ctx, defaultPoolName)
 	if err != nil {
 		t.Fatalf("failed to get pool stats: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Replace NovaEdge's local in-process IPAM with a gRPC client to NovaNet's shared IPAM service (`/run/novanet/ipam.sock`), making NovaNet the single source of truth for IP allocations
- Define `ipam.Client` interface with `GRPCAllocator` (production) and local `Allocator` (fallback) implementations, bridging semantic differences between the two APIs
- Update ProxyIPPoolReconciler to sync NovaNet IPPool CRDs with finalizer-based cleanup, and wire everything in main.go with `--ipam-socket` flag

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/controller/...` — all 7 packages pass
- [x] `golangci-lint run` — 0 issues
- [ ] Deploy with NovaNet IPAM service running and verify IP allocation/release
- [ ] Deploy without NovaNet socket and verify local fallback works