### PR TITLE
Upgrade Go to 1.26.1

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Check for outdated dependencies

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,5 +1,5 @@
 # Build the agent binary
-FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1 AS builder
 
 ARG TARGETARCH
 

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,5 +1,5 @@
 # Build the controller binary
-FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1 AS builder
 
 ARG TARGETARCH
 

--- a/Dockerfile.novactl
+++ b/Dockerfile.novactl
@@ -1,5 +1,5 @@
 # Build the novactl binary (includes web UI)
-FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1 AS builder
 
 ARG TARGETARCH
 

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS builder
 
 ARG TARGETARCH
 

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,5 +1,5 @@
 # Build the standalone agent binary
-FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1 AS builder
 
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/azrtydxb/novaedge
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/azrtydxb/novanet v1.8.2-0.20260307101249-8e96b33353d9


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.26.0 to 1.26.1 in go.mod and all Dockerfiles
- Fix govulncheck failures caused by Go stdlib vulnerabilities (GO-2026-4599 through GO-2026-4603)
- Standardize dependency-scan workflow to use go-version-file instead of hardcoded version

Closes #887

## Test plan
- [ ] CI passes with Go 1.26.1
- [ ] govulncheck no longer reports stdlib vulnerabilities