### PR TITLE
fix: remove eBPF references from agent and dataplane Dockerfiles

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -5,13 +5,6 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 
-# Install BPF compilation tools for go generate (eBPF/XDP programs).
-# These are only needed at build time; the runtime image is separate.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang llvm libbpf-dev linux-libc-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -sf /usr/include/$(gcc -dumpmachine)/asm /usr/include/asm
-
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -22,16 +15,10 @@ COPY go.sum go.sum
 ENV GOTOOLCHAIN=auto
 RUN go mod download
 
-# Copy the go source and BPF C programs
+# Copy the go source
 COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
-COPY bpf/ bpf/
-
-# Generate BPF Go bindings from C sources (produces *_bpfel.go and *.o files).
-# Required — the generated loadMeshRedirect/loadAfxdpRedirect
-# functions are called at runtime and have no placeholder fallback.
-RUN go generate ./internal/agent/ebpfmesh/... ./internal/agent/afxdp/...
 
 # Build args for version injection
 ARG VERSION=dev
@@ -44,10 +31,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
     -o novaedge-agent cmd/novaedge-agent/main.go
 
 # Agent requires nftables (preferred) or iptables for TPROXY mesh interception,
-# root for privileged network operations (VIP binding, BGP port 179, ARP/NDP),
-# and libbpf for eBPF program loading at runtime.
+# and root for privileged network operations (VIP binding, BGP port 179, ARP/NDP).
 FROM alpine:3.23
-RUN apk add --no-cache nftables iptables ip6tables iproute2 libbpf
+RUN apk add --no-cache nftables iptables ip6tables iproute2
 WORKDIR /
 COPY --from=builder /workspace/novaedge-agent .
 

--- a/Dockerfile.dataplane
+++ b/Dockerfile.dataplane
@@ -1,4 +1,4 @@
-# Build stage: compile eBPF programs and Rust dataplane binary.
+# Build stage: compile Rust dataplane binary.
 # Uses TARGETARCH for multi-arch builds via docker buildx.
 FROM --platform=$BUILDPLATFORM rust:bookworm AS builder
 
@@ -11,26 +11,13 @@ RUN apt-get update && apt-get install -y \
     gcc-aarch64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup toolchain install nightly --component rust-src && \
-    rustup target add --toolchain nightly aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
-
-RUN cargo install bpf-linker
+RUN rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
 
 WORKDIR /build
 COPY . .
 
-# Build eBPF programs (BPF bytecode is architecture-independent)
-RUN cd dataplane && cargo +nightly build \
-    --package novaedge-ebpf \
-    --target bpfel-unknown-none \
-    -Z build-std=core \
-    --release
-
 # Build dataplane binary for target architecture.
-# Re-run rustup target add to guarantee targets are present regardless of
-# Docker layer caching (rustup target add is idempotent and instant).
-RUN rustup target add --toolchain nightly aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu && \
-    RUST_TARGET="" && \
+RUN RUST_TARGET="" && \
     LINKER_ENV="" && \
     case "$TARGETARCH" in \
       arm64) RUST_TARGET="aarch64-unknown-linux-gnu" && \
@@ -55,7 +42,6 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/out/novaedge-dataplane /usr/local/bin/
-COPY --from=builder /build/dataplane/target/bpfel-unknown-none/release/novaedge-ebpf /opt/novaedge/
 
 ENTRYPOINT ["novaedge-dataplane"]
-CMD ["--socket=/run/novaedge/dataplane.sock", "--ebpf-path=/opt/novaedge/novaedge-ebpf"]
+CMD ["--socket=/run/novaedge/dataplane.sock"]


### PR DESCRIPTION
## Summary
- Remove eBPF build toolchain (clang, llvm, libbpf-dev, bpf-linker) from agent and dataplane Dockerfiles
- Remove `bpf/` directory COPY and `go generate` for deleted eBPF packages from agent Dockerfile
- Remove nightly toolchain, eBPF build step, and eBPF object COPY from dataplane Dockerfile
- Remove `libbpf` from agent runtime image (no longer needed)

These references were left behind when eBPF code was migrated to NovaNet in PR #905.

## Test plan
- [ ] Verify agent Docker image builds for amd64 and arm64
- [ ] Verify dataplane Docker image builds for amd64 and arm64