### PR TITLE
fix: disable provenance/sbom attestations in release Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,8 @@ jobs:
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
 
   # Create multi-arch manifests for Go Docker images
   docker-manifest:
@@ -298,6 +300,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
 
   # Create multi-arch manifest for webui Docker image
   docker-webui-manifest:


### PR DESCRIPTION
## Summary
- Add `provenance: false` and `sbom: false` to Docker build-push-action steps in release workflow
- Docker Buildx v0.10+ creates OCI image index (manifest list) even for single-platform builds when attestations are enabled
- This breaks `docker manifest create --amend` which expects plain single-arch images

## Test plan
- [ ] Tag a new release and verify all Docker Manifest jobs succeed