### PR TITLE
fix: move non-Docker release jobs to ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   # Build multi-arch binaries
   build-binaries:
     name: Build Binaries
-    runs-on: qnap-nas
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -70,7 +70,7 @@ jobs:
   # Build frontend natively (avoids QEMU segfault for arm64)
   build-frontend:
     name: Build Frontend
-    runs-on: qnap-nas
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -101,7 +101,7 @@ jobs:
   # Create GitHub Release with all binaries
   release:
     name: Create Release
-    runs-on: qnap-nas
+    runs-on: ubuntu-latest
     needs: build-binaries
     steps:
       - name: Checkout code
@@ -201,7 +201,7 @@ jobs:
   # Create multi-arch manifests for Go Docker images
   docker-manifest:
     name: "Docker Manifest ${{ matrix.image }}"
-    runs-on: qnap-nas
+    runs-on: ubuntu-latest
     needs: docker
     strategy:
       fail-fast: false
@@ -306,7 +306,7 @@ jobs:
   # Create multi-arch manifest for webui Docker image
   docker-webui-manifest:
     name: "Docker Manifest novaedge-webui"
-    runs-on: qnap-nas
+    runs-on: ubuntu-latest
     needs: docker-webui
     steps:
       - name: Log in to GHCR
@@ -345,7 +345,7 @@ jobs:
   # Generate SBOM for release artifacts
   sbom:
     name: Generate SBOM
-    runs-on: qnap-nas
+    runs-on: ubuntu-latest
     needs: [build-binaries, release]
     steps:
       - name: Checkout code
@@ -373,7 +373,7 @@ jobs:
   # Sign container images with cosign
   sign-images:
     name: Sign Container Images
-    runs-on: qnap-nas
+    runs-on: ubuntu-latest
     needs: [docker-manifest, docker-webui-manifest]
     steps:
       - name: Install cosign


### PR DESCRIPTION
## Summary
- Move build-binaries, build-frontend, release, docker-manifest, docker-webui-manifest, sbom, and sign-images jobs from `qnap-nas` to `ubuntu-latest`
- Docker build jobs remain on `qnap-nas` (amd64) and `ubuntu-24.04-arm` (arm64) via matrix config
- Fixes transient EAGAIN errors on self-hosted runner during pnpm install

## Test plan
- [ ] Tag a new release and verify all jobs succeed on ubuntu-latest