### PR TITLE
fix: use project-prefixed GHCR image paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/novaedge
 
 jobs:
   # Build multi-arch binaries

--- a/charts/novaedge/values.yaml
+++ b/charts/novaedge/values.yaml
@@ -14,7 +14,7 @@ controller:
   replicaCount: 3
 
   image:
-    repository: ghcr.io/azrtydxb/novaedge-controller
+    repository: ghcr.io/azrtydxb/novaedge/novaedge-controller
     tag: ""  # Defaults to Chart.appVersion
     pullPolicy: IfNotPresent
 
@@ -189,7 +189,7 @@ agent:
   enabled: true
 
   image:
-    repository: ghcr.io/azrtydxb/novaedge-agent
+    repository: ghcr.io/azrtydxb/novaedge/novaedge-agent
     tag: ""  # Defaults to Chart.appVersion
     pullPolicy: IfNotPresent
 
@@ -337,7 +337,7 @@ agent:
 dataplane:
   enabled: true
   image:
-    repository: ghcr.io/azrtydxb/novaedge-dataplane
+    repository: ghcr.io/azrtydxb/novaedge/novaedge-dataplane
     tag: ""  # Defaults to Chart.appVersion
     pullPolicy: IfNotPresent
   resources:
@@ -358,7 +358,7 @@ webui:
   # Frontend container (nginx serving React SPA)
   frontend:
     image:
-      repository: ghcr.io/azrtydxb/novaedge-webui
+      repository: ghcr.io/azrtydxb/novaedge/novaedge-webui
       tag: ""  # Defaults to Chart.appVersion
       pullPolicy: IfNotPresent
     resources:
@@ -371,7 +371,7 @@ webui:
 
   # API backend container (novactl)
   image:
-    repository: ghcr.io/azrtydxb/novaedge-novactl
+    repository: ghcr.io/azrtydxb/novaedge/novactl
     tag: ""  # Defaults to Chart.appVersion
     pullPolicy: IfNotPresent
 

--- a/deploy/argocd/application.yaml
+++ b/deploy/argocd/application.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd-image-updater.argoproj.io/image-list: >-
-      controller=ghcr.io/azrtydxb/novaedge-controller,
-      agent=ghcr.io/azrtydxb/novaedge-agent,
-      dataplane=ghcr.io/azrtydxb/novaedge-dataplane,
-      webui=ghcr.io/azrtydxb/novaedge-webui
+      controller=ghcr.io/azrtydxb/novaedge/novaedge-controller,
+      agent=ghcr.io/azrtydxb/novaedge/novaedge-agent,
+      dataplane=ghcr.io/azrtydxb/novaedge/novaedge-dataplane,
+      webui=ghcr.io/azrtydxb/novaedge/novaedge-webui
     argocd-image-updater.argoproj.io/controller.update-strategy: semver
     argocd-image-updater.argoproj.io/agent.update-strategy: semver
     argocd-image-updater.argoproj.io/dataplane.update-strategy: semver
@@ -34,21 +34,21 @@ spec:
       valuesObject:
         controller:
           image:
-            repository: ghcr.io/azrtydxb/novaedge-controller
-            tag: v1.7.3
+            repository: ghcr.io/azrtydxb/novaedge/novaedge-controller
+            tag: v1.7.4
         agent:
           image:
-            repository: ghcr.io/azrtydxb/novaedge-agent
-            tag: v1.7.3
+            repository: ghcr.io/azrtydxb/novaedge/novaedge-agent
+            tag: v1.7.4
         dataplane:
           image:
-            repository: ghcr.io/azrtydxb/novaedge-dataplane
-            tag: v1.7.3
+            repository: ghcr.io/azrtydxb/novaedge/novaedge-dataplane
+            tag: v1.7.4
         webui:
           frontend:
             image:
-              repository: ghcr.io/azrtydxb/novaedge-webui
-              tag: v1.7.3
+              repository: ghcr.io/azrtydxb/novaedge/novaedge-webui
+              tag: v1.7.4
   destination:
     server: https://kubernetes.default.svc
     namespace: novaedge-system


### PR DESCRIPTION
## Summary
- Fix `IMAGE_PREFIX` in release workflow to include `/novaedge` project prefix
- All images now publish to `ghcr.io/azrtydxb/novaedge/<image-name>` matching NovaNet/NovaStor convention
- Fix all image repository paths in `values.yaml` and ArgoCD `application.yaml`
- Bump ArgoCD deployment tags to v1.7.4

## Affected paths
| Image | Old (wrong) | New (correct) |
|-------|------------|---------------|
| controller | `ghcr.io/azrtydxb/novaedge-controller` | `ghcr.io/azrtydxb/novaedge/novaedge-controller` |
| agent | `ghcr.io/azrtydxb/novaedge-agent` | `ghcr.io/azrtydxb/novaedge/novaedge-agent` |
| dataplane | `ghcr.io/azrtydxb/novaedge-dataplane` | `ghcr.io/azrtydxb/novaedge/novaedge-dataplane` |
| webui | `ghcr.io/azrtydxb/novaedge-webui` | `ghcr.io/azrtydxb/novaedge/novaedge-webui` |
| novactl | `ghcr.io/azrtydxb/novaedge-novactl` | `ghcr.io/azrtydxb/novaedge/novactl` |