### PR TITLE
fix: remove obsolete service-lb flag and update chart appVersion

### DIFF
--- a/charts/novaedge/Chart.yaml
+++ b/charts/novaedge/Chart.yaml
@@ -3,7 +3,7 @@ name: novaedge
 description: A Helm chart for NovaEdge - Kubernetes-native distributed load balancer, reverse proxy, and VIP controller
 type: application
 version: 0.1.0
-appVersion: "1.0.0"
+appVersion: "1.7.4"
 keywords:
 - load-balancer
 - ingress

--- a/charts/novaedge/templates/controller-deployment.yaml
+++ b/charts/novaedge/templates/controller-deployment.yaml
@@ -64,9 +64,6 @@ spec:
         - --controller-class={{ .Values.controller.controllerClass }}
         {{- end }}
         {{- /* NOTE: ingress class is hardcoded to "novaedge" in the controller binary */}}
-        {{- if .Values.controller.serviceLB.enabled }}
-        - --enable-service-lb
-        {{- end }}
         {{- if .Values.controller.grpc.tls.enabled }}
         - --grpc-tls-cert-file=/etc/novaedge/grpc-tls/tls.crt
         - --grpc-tls-key-file=/etc/novaedge/grpc-tls/tls.key

--- a/charts/novaedge/values.yaml
+++ b/charts/novaedge/values.yaml
@@ -77,7 +77,7 @@ controller:
 
   # Enable ServiceLB controller
   serviceLB:
-    enabled: true
+    enabled: false
 
   # Certificate management
   certificates:


### PR DESCRIPTION
## Summary
- Remove `--enable-service-lb` flag from controller deployment template (flag was removed from the binary when service LB was moved to NovaNet)
- Disable `serviceLB.enabled` default in values.yaml
- Update `Chart.yaml` appVersion from `1.0.0` to `1.7.4` (fixes default image tags)

Follows up on #911 — the controller was crashing with `flag provided but not defined: -enable-service-lb` and the webui's novactl container was trying to pull tag `1.0.0`.