### PR TITLE
fix: bump ArgoCD deployment tags to v1.7.5

### DIFF
--- a/deploy/argocd/application.yaml
+++ b/deploy/argocd/application.yaml
@@ -35,23 +35,23 @@ spec:
         controller:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-controller
-            tag: v1.7.4
+            tag: v1.7.5
         agent:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-agent
-            tag: v1.7.4
+            tag: v1.7.5
         dataplane:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-dataplane
-            tag: v1.7.4
+            tag: v1.7.5
         webui:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novactl
-            tag: v1.7.4
+            tag: v1.7.5
           frontend:
             image:
               repository: ghcr.io/azrtydxb/novaedge/novaedge-webui
-              tag: v1.7.4
+              tag: v1.7.5
   destination:
     server: https://kubernetes.default.svc
     namespace: novaedge-system


### PR DESCRIPTION
Update all image tags in ArgoCD application from v1.7.4 to v1.7.5 (mesh CA namespace fix).