### PR TITLE
fix: bump appVersion and ArgoCD tags to v1.7.6

### DIFF
--- a/charts/novaedge/Chart.yaml
+++ b/charts/novaedge/Chart.yaml
@@ -3,7 +3,7 @@ name: novaedge
 description: A Helm chart for NovaEdge - Kubernetes-native distributed load balancer, reverse proxy, and VIP controller
 type: application
 version: 0.1.0
-appVersion: "v1.7.4"
+appVersion: "v1.7.6"
 keywords:
 - load-balancer
 - ingress

--- a/deploy/argocd/application.yaml
+++ b/deploy/argocd/application.yaml
@@ -35,23 +35,23 @@ spec:
         controller:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-controller
-            tag: v1.7.5
+            tag: v1.7.6
         agent:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-agent
-            tag: v1.7.5
+            tag: v1.7.6
         dataplane:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-dataplane
-            tag: v1.7.5
+            tag: v1.7.6
         webui:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novactl
-            tag: v1.7.5
+            tag: v1.7.6
           frontend:
             image:
               repository: ghcr.io/azrtydxb/novaedge/novaedge-webui
-              tag: v1.7.5
+              tag: v1.7.6
   destination:
     server: https://kubernetes.default.svc
     namespace: novaedge-system


### PR DESCRIPTION
## Summary
- Bump Chart.yaml appVersion to v1.7.6
- Bump all ArgoCD application image tags to v1.7.6

Follows PR #915 which fixed the controller gRPC port binding bug.