### PR TITLE
fix: bump appVersion and ArgoCD tags to v1.7.7, enable mesh CA

### DIFF
--- a/charts/novaedge/Chart.yaml
+++ b/charts/novaedge/Chart.yaml
@@ -3,7 +3,7 @@ name: novaedge
 description: A Helm chart for NovaEdge - Kubernetes-native distributed load balancer, reverse proxy, and VIP controller
 type: application
 version: 0.1.0
-appVersion: "v1.7.6"
+appVersion: "v1.7.7"
 keywords:
 - load-balancer
 - ingress

--- a/deploy/argocd/application.yaml
+++ b/deploy/argocd/application.yaml
@@ -35,23 +35,25 @@ spec:
         controller:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-controller
-            tag: v1.7.6
+            tag: v1.7.7
+          meshCA:
+            enabled: true
         agent:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-agent
-            tag: v1.7.6
+            tag: v1.7.7
         dataplane:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novaedge-dataplane
-            tag: v1.7.6
+            tag: v1.7.7
         webui:
           image:
             repository: ghcr.io/azrtydxb/novaedge/novactl
-            tag: v1.7.6
+            tag: v1.7.7
           frontend:
             image:
               repository: ghcr.io/azrtydxb/novaedge/novaedge-webui
-              tag: v1.7.6
+              tag: v1.7.7
   destination:
     server: https://kubernetes.default.svc
     namespace: novaedge-system


### PR DESCRIPTION
## Summary
- Bump appVersion to v1.7.7
- Update ArgoCD application image tags to v1.7.7
- Enable mesh CA in ArgoCD values (`controller.meshCA.enabled: true`)

## Test plan
- [ ] CI passes
- [ ] After merge + tag, release workflow builds images
- [ ] ArgoCD syncs with new images and mesh CA enabled