### PR TITLE
fix: set route_localnet via init container for mesh DNAT

### DIFF
--- a/charts/novaedge/templates/agent-daemonset.yaml
+++ b/charts/novaedge/templates/agent-daemonset.yaml
@@ -48,8 +48,22 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.agent.ebpf.enabled }}
+      {{- if or .Values.agent.ebpf.enabled .Values.agent.mesh.enabled }}
       initContainers:
+      {{- if .Values.agent.mesh.enabled }}
+      - name: sysctl-setup
+        image: {{ include "novaedge.agent.image" . }}
+        imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+        command:
+        - sh
+        - -c
+        - |
+          echo 1 > /proc/sys/net/ipv4/conf/all/route_localnet
+          echo "route_localnet enabled for mesh DNAT"
+        securityContext:
+          privileged: true
+      {{- end }}
+      {{- if .Values.agent.ebpf.enabled }}
       - name: mount-bpffs
         image: {{ include "novaedge.agent.image" . }}
         imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
@@ -67,6 +81,7 @@ spec:
         - name: bpffs
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
+      {{- end }}
       {{- end }}
       containers:
       - name: agent

--- a/internal/agent/mesh/tproxy_iptables.go
+++ b/internal/agent/mesh/tproxy_iptables.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -58,9 +57,10 @@ func (b *iptablesBackend) Name() string { return "iptables" }
 // fire before kube-proxy's KUBE-SERVICES chain, preserving the original
 // ClusterIP destination in conntrack for SO_ORIGINAL_DST retrieval.
 func (b *iptablesBackend) Setup() error {
-	// Enable route_localnet so the kernel accepts DNAT to 127.0.0.1 on non-loopback interfaces.
-	if err := os.WriteFile("/proc/sys/net/ipv4/conf/all/route_localnet", []byte("1"), 0o600); err != nil {
-		return fmt.Errorf("failed to set route_localnet: %w", err)
+	// Verify route_localnet is enabled (set by the sysctl-setup init container in k8s,
+	// or written directly in standalone/privileged mode).
+	if err := ensureRouteLocalnet(); err != nil {
+		return err
 	}
 
 	if err := b.ensureChain(); err != nil {

--- a/internal/agent/mesh/tproxy_nftables.go
+++ b/internal/agent/mesh/tproxy_nftables.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
@@ -81,9 +80,10 @@ func (b *nftablesBackend) Name() string { return "nftables" }
 // before kube-proxy's DNAT rules at priority -100, so the original ClusterIP
 // destination is preserved in conntrack for SO_ORIGINAL_DST retrieval.
 func (b *nftablesBackend) Setup() error {
-	// Enable route_localnet so the kernel accepts DNAT to 127.0.0.1 on non-loopback interfaces.
-	if err := os.WriteFile("/proc/sys/net/ipv4/conf/all/route_localnet", []byte("1"), 0o600); err != nil {
-		return fmt.Errorf("failed to set route_localnet: %w", err)
+	// Verify route_localnet is enabled (set by the sysctl-setup init container in k8s,
+	// or written directly in standalone/privileged mode).
+	if err := ensureRouteLocalnet(); err != nil {
+		return err
 	}
 
 	// Delete existing table first to remove any stale chains/rules from

--- a/internal/agent/mesh/tproxy_sysctl.go
+++ b/internal/agent/mesh/tproxy_sysctl.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mesh
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const routeLocalnetPath = "/proc/sys/net/ipv4/conf/all/route_localnet"
+
+// ensureRouteLocalnet verifies that net.ipv4.conf.all.route_localnet is enabled,
+// which is required for DNAT to 127.0.0.1 on non-loopback interfaces.
+//
+// In Kubernetes, the sysctl-setup init container sets this before the agent starts.
+// This function first checks the current value and returns early if already enabled.
+// If not enabled, it attempts to write the value (works in standalone/privileged mode).
+func ensureRouteLocalnet() error {
+	val, err := os.ReadFile(routeLocalnetPath)
+	if err != nil {
+		return fmt.Errorf("failed to read route_localnet: %w", err)
+	}
+	if strings.TrimSpace(string(val)) == "1" {
+		return nil
+	}
+
+	// Not enabled — attempt to set it (works in privileged containers or standalone mode).
+	if err := os.WriteFile(routeLocalnetPath, []byte("1"), 0o600); err != nil {
+		return fmt.Errorf("route_localnet is not enabled and cannot be set (read-only filesystem); "+
+			"ensure the sysctl-setup init container is configured in the Helm chart: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `sysctl-setup` init container to agent DaemonSet when mesh is enabled
- The init container runs privileged to set `net.ipv4.conf.all.route_localnet=1`
- Change Go code to verify the sysctl (read-first) instead of blindly writing
- Falls back to writing for standalone/privileged deployments

Fixes CrashLoopBackOff on v1.7.8 agent pods where `readOnlyRootFilesystem: true` prevents writing to `/proc/sys`.

## Test plan
- [ ] Agent pods start without CrashLoopBackOff
- [ ] Mesh DNAT to 127.0.0.1 works correctly
- [ ] `helm lint` passes
- [ ] `golangci-lint` passes