### PR TITLE
fix: use constant-time comparison and bound session store in WebUI auth

### DIFF
--- a/cmd/novactl/pkg/webui/auth/auth.go
+++ b/cmd/novactl/pkg/webui/auth/auth.go
@@ -32,10 +32,28 @@ const (
 	cookieName = "novaedge_session"
 	// defaultSessionTTL is the default session duration.
 	defaultSessionTTL = 8 * time.Hour
-	// maxSessions is the maximum number of concurrent sessions allowed.
-	// When the limit is reached, the oldest sessions are evicted.
-	maxSessions = 1000
+	// defaultMaxSessions is the default maximum number of concurrent sessions allowed.
+	defaultMaxSessions = 1000
 )
+
+// maxSessions is the maximum number of concurrent sessions allowed.
+// When the limit is reached, sessions with the earliest expiry (soonest to expire) are evicted.
+//
+// This value can be adjusted at runtime using SetMaxSessions. If it is not
+// changed, the default limit of 1000 sessions is used.
+var maxSessions = defaultMaxSessions
+
+// SetMaxSessions sets the global maximum number of concurrent sessions allowed.
+//
+// This should typically be called during application initialization. If limit
+// is less than or equal to zero, the default value of 1000 is used.
+func SetMaxSessions(limit int) {
+	if limit <= 0 {
+		maxSessions = defaultMaxSessions
+		return
+	}
+	maxSessions = limit
+}
 
 // Config holds authentication configuration.
 type Config struct {
@@ -105,7 +123,8 @@ func (m *Manager) Login(user, pass string) (string, error) {
 	return token, nil
 }
 
-// evictExcessSessions removes expired sessions and evicts the oldest when the count exceeds maxSessions.
+// evictExcessSessions removes expired sessions and evicts sessions with the earliest
+// expiry when the count exceeds maxSessions.
 func (m *Manager) evictExcessSessions() {
 	type entry struct {
 		token  string
@@ -116,7 +135,11 @@ func (m *Manager) evictExcessSessions() {
 	now := time.Now()
 
 	m.sessions.Range(func(key, value interface{}) bool {
-		tok, _ := key.(string)
+		tok, ok := key.(string)
+		if !ok {
+			m.sessions.Delete(key)
+			return true
+		}
 		exp, ok := value.(time.Time)
 		if !ok {
 			m.sessions.Delete(key)

--- a/cmd/novactl/pkg/webui/auth/auth_test.go
+++ b/cmd/novactl/pkg/webui/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -215,5 +216,134 @@ func TestMiddlewareAllowsValidSession(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 for authenticated request, got %d", rec.Code)
+	}
+}
+
+func TestSetMaxSessions(t *testing.T) {
+	// Save original and restore after test.
+	orig := maxSessions
+	defer func() { maxSessions = orig }()
+
+	SetMaxSessions(50)
+	if maxSessions != 50 {
+		t.Fatalf("expected maxSessions=50, got %d", maxSessions)
+	}
+
+	// Zero resets to default.
+	SetMaxSessions(0)
+	if maxSessions != defaultMaxSessions {
+		t.Fatalf("expected maxSessions=%d after zero, got %d", defaultMaxSessions, maxSessions)
+	}
+
+	// Negative resets to default.
+	SetMaxSessions(-1)
+	if maxSessions != defaultMaxSessions {
+		t.Fatalf("expected maxSessions=%d after negative, got %d", defaultMaxSessions, maxSessions)
+	}
+}
+
+func TestEvictExpiredSessions(t *testing.T) {
+	m, err := NewManager(Config{
+		BasicUser:  "admin",
+		BasicPass:  "secret",
+		SessionTTL: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Insert sessions that are already expired.
+	past := time.Now().Add(-time.Minute)
+	for i := 0; i < 5; i++ {
+		m.sessions.Store(fmt.Sprintf("expired-%d", i), past)
+	}
+
+	// Insert one valid session.
+	future := time.Now().Add(time.Hour)
+	m.sessions.Store("valid-token", future)
+
+	m.evictExcessSessions()
+
+	// Expired sessions must be gone.
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("expired-%d", i)
+		if _, ok := m.sessions.Load(key); ok {
+			t.Errorf("expected expired session %s to be evicted", key)
+		}
+	}
+
+	// Valid session must remain.
+	if _, ok := m.sessions.Load("valid-token"); !ok {
+		t.Error("expected valid session to remain after eviction")
+	}
+}
+
+func TestEvictExcessSessionsDeterministic(t *testing.T) {
+	// Save original and restore after test.
+	orig := maxSessions
+	defer func() { maxSessions = orig }()
+
+	SetMaxSessions(3)
+
+	m, err := NewManager(Config{
+		BasicUser:  "admin",
+		BasicPass:  "secret",
+		SessionTTL: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Insert 5 sessions with staggered expiries. The 2 with the earliest
+	// expiry should be evicted, leaving 3.
+	now := time.Now()
+	m.sessions.Store("tok-1", now.Add(1*time.Minute)) // earliest — evict
+	m.sessions.Store("tok-2", now.Add(2*time.Minute)) // second earliest — evict
+	m.sessions.Store("tok-3", now.Add(3*time.Minute)) // keep
+	m.sessions.Store("tok-4", now.Add(4*time.Minute)) // keep
+	m.sessions.Store("tok-5", now.Add(5*time.Minute)) // keep
+
+	m.evictExcessSessions()
+
+	// tok-1 and tok-2 should be evicted (soonest to expire).
+	for _, key := range []string{"tok-1", "tok-2"} {
+		if _, ok := m.sessions.Load(key); ok {
+			t.Errorf("expected session %s to be evicted", key)
+		}
+	}
+
+	// tok-3, tok-4, tok-5 should remain.
+	for _, key := range []string{"tok-3", "tok-4", "tok-5"} {
+		if _, ok := m.sessions.Load(key); !ok {
+			t.Errorf("expected session %s to remain", key)
+		}
+	}
+}
+
+func TestEvictNonStringKey(t *testing.T) {
+	m, err := NewManager(Config{
+		BasicUser:  "admin",
+		BasicPass:  "secret",
+		SessionTTL: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Store a non-string key (should be cleaned up by eviction).
+	m.sessions.Store(12345, time.Now().Add(time.Hour))
+	// Also store a valid session.
+	m.sessions.Store("valid", time.Now().Add(time.Hour))
+
+	m.evictExcessSessions()
+
+	// Non-string key must be deleted.
+	if _, ok := m.sessions.Load(12345); ok {
+		t.Error("expected non-string key to be deleted by eviction")
+	}
+
+	// Valid session must remain.
+	if _, ok := m.sessions.Load("valid"); !ok {
+		t.Error("expected valid session to remain")
 	}
 }


### PR DESCRIPTION
## Summary
- Replace timing-unsafe `!=` password/username comparison with `crypto/subtle.ConstantTimeCompare` to prevent timing attacks
- Add maximum session count (1000) with eviction of oldest sessions when the limit is reached
- Clean up expired sessions during eviction pass

Fixes #944

## Test plan
- [x] Existing auth tests pass (`go test ./cmd/novactl/pkg/webui/auth/...`)
- [x] Build succeeds (`go build ./cmd/novactl/...`)
- [x] Pre-commit linting (golangci-lint, cargo clippy, cargo fmt) passes