### PR TITLE
fix: add input validation for NodeName, MeshCA CSR, and ACME storage paths

### DIFF
--- a/internal/acme/storage.go
+++ b/internal/acme/storage.go
@@ -352,14 +352,12 @@ func validateDomain(domain string) error {
 }
 
 // certPath returns the storage path for a certificate.
-// The returned path is guaranteed to be within the basePath directory.
+// The returned path is constructed under the basePath directory.
+// Callers must validate the domain via validateDomain before calling this.
 func (s *FileStorage) certPath(domain string) string {
 	// Replace dots with underscores for filesystem safety
 	safeName := strings.ReplaceAll(domain, ".", "_")
 	// Replace wildcards
 	safeName = strings.ReplaceAll(safeName, "*", "wildcard")
-	result := filepath.Join(s.basePath, "certs", safeName)
-	// Clean the path to resolve any remaining traversal sequences
-	result = filepath.Clean(result)
-	return result
+	return filepath.Join(s.basePath, "certs", safeName)
 }

--- a/internal/acme/storage_test.go
+++ b/internal/acme/storage_test.go
@@ -18,6 +18,7 @@ package acme
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -393,4 +394,34 @@ func TestConcurrentSaveCertificate(t *testing.T) {
 	certs, err := storage.ListCertificates(context.Background())
 	assert.NoError(t, err)
 	assert.Len(t, certs, 3)
+}
+
+func TestValidateDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		domain  string
+		wantErr bool
+	}{
+		{name: "valid domain", domain: "example.com", wantErr: false},
+		{name: "valid wildcard", domain: "*.example.com", wantErr: false},
+		{name: "path traversal dotdot", domain: "../evil.com", wantErr: true},
+		{name: "path traversal embedded dotdot", domain: "a..b.com", wantErr: true},
+		{name: "forward slash", domain: "a/b.com", wantErr: true},
+		{name: "backslash", domain: `a\b.com`, wantErr: true},
+		{name: "bare dotdot", domain: "..", wantErr: true},
+		{name: "null byte", domain: "evil.com\x00.txt", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDomain(tt.domain)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, errInvalidDomainPathTraversal),
+					"expected errInvalidDomainPathTraversal, got: %v", err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/controller/meshca/ca.go
+++ b/internal/controller/meshca/ca.go
@@ -194,8 +194,8 @@ func (ca *MeshCA) SignCSR(csrPEM []byte, nodeName string) ([]byte, error) {
 	}
 
 	// Validate that the nodeName matches the identity in the CSR.
-	// The CSR must contain a SPIFFE URI SAN matching the expected agent identity,
-	// or the Subject CN must match the nodeName.
+	// The CSR should contain a SPIFFE URI SAN matching the expected agent identity.
+	// If no SPIFFE URI SANs are present, the Subject CN must match the nodeName.
 	if err := validateCSRIdentity(csr, nodeName, ca.trustDomain); err != nil {
 		return nil, err
 	}

--- a/internal/controller/meshca/ca_test.go
+++ b/internal/controller/meshca/ca_test.go
@@ -24,7 +24,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"strings"
+	"errors"
 	"testing"
 	"time"
 
@@ -292,7 +292,7 @@ func TestMeshCASignCSRIdentityMismatch(t *testing.T) {
 		t.Fatal("expected SignCSR to reject mismatched node name, but it succeeded")
 	}
 
-	if !strings.Contains(err.Error(), "does not match requested node") {
-		t.Errorf("unexpected error message: %v", err)
+	if !errors.Is(err, errCSRCNMismatch) {
+		t.Errorf("expected errCSRCNMismatch, got: %v", err)
 	}
 }

--- a/internal/controller/snapshot/server.go
+++ b/internal/controller/snapshot/server.go
@@ -164,19 +164,24 @@ func validatePeerNodeName(ctx context.Context, requestedNode string) error {
 	peerCert := tlsInfo.State.PeerCertificates[0]
 
 	// Check SPIFFE URI SANs first (preferred identity format).
+	// Scan ALL SPIFFE URI SANs before rejecting — a cert may contain multiple.
+	foundSPIFFEAgent := false
 	for _, uri := range peerCert.URIs {
 		if uri.Scheme == "spiffe" {
 			// SPIFFE IDs follow the pattern: spiffe://<trust-domain>/agent/<node-name>
 			parts := strings.Split(uri.Path, "/")
 			if len(parts) >= 3 && parts[1] == "agent" {
-				spiffeNode := parts[2]
-				if spiffeNode == requestedNode {
+				foundSPIFFEAgent = true
+				if parts[2] == requestedNode {
 					return nil
 				}
-				return status.Errorf(codes.PermissionDenied,
-					"requested node %q does not match peer SPIFFE identity %q", requestedNode, spiffeNode)
 			}
 		}
+	}
+
+	if foundSPIFFEAgent {
+		return status.Errorf(codes.PermissionDenied,
+			"requested node %q does not match any peer SPIFFE /agent/ identity", requestedNode)
 	}
 
 	// Fall back to CN check.
@@ -188,8 +193,8 @@ func validatePeerNodeName(ctx context.Context, requestedNode string) error {
 			"requested node %q does not match peer certificate CN %q", requestedNode, peerCert.Subject.CommonName)
 	}
 
-	// No recognizable identity in the certificate — allow (best-effort).
-	return nil
+	// No recognizable identity in the certificate — fail closed to avoid identity bypass.
+	return status.Error(codes.PermissionDenied, "client certificate presented but no recognizable identity (SPIFFE /agent/<node> URI SAN or CN) found")
 }
 
 // StreamConfig implements the StreamConfig RPC method
@@ -606,6 +611,11 @@ func (s *Server) SetFederationProvider(provider FederationStateProvider) {
 // RequestMeshCertificate implements the RequestMeshCertificate RPC.
 // Agents call this to obtain a signed mesh workload certificate.
 func (s *Server) RequestMeshCertificate(ctx context.Context, req *pb.MeshCertificateRequest) (*pb.MeshCertificateResponse, error) {
+	// Validate that the requested NodeName matches the peer's TLS identity.
+	if err := validatePeerNodeName(ctx, req.NodeName); err != nil {
+		return nil, err
+	}
+
 	logger := log.FromContext(ctx).WithValues("node", req.NodeName)
 
 	if s.meshCA == nil {

--- a/internal/controller/snapshot/server_validation_test.go
+++ b/internal/controller/snapshot/server_validation_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// newTestCert creates a self-signed certificate with the given URIs and CN.
+func newTestCert(t *testing.T, cn string, uris []*url.URL) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+		URIs:      uris,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	return cert
+}
+
+// ctxWithPeerCert creates a context with the given certificate as peer TLS info.
+func ctxWithPeerCert(t *testing.T, cert *x509.Certificate) context.Context {
+	t.Helper()
+
+	p := &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345},
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{cert},
+			},
+		},
+	}
+
+	return peer.NewContext(context.Background(), p)
+}
+
+func TestValidatePeerNodeName_MatchingSPIFFE(t *testing.T) {
+	spiffeURI, _ := url.Parse("spiffe://cluster.local/agent/worker-1")
+	cert := newTestCert(t, "", []*url.URL{spiffeURI})
+	ctx := ctxWithPeerCert(t, cert)
+
+	err := validatePeerNodeName(ctx, "worker-1")
+	if err != nil {
+		t.Errorf("expected no error for matching SPIFFE, got: %v", err)
+	}
+}
+
+func TestValidatePeerNodeName_MismatchedSPIFFE(t *testing.T) {
+	spiffeURI, _ := url.Parse("spiffe://cluster.local/agent/worker-1")
+	cert := newTestCert(t, "", []*url.URL{spiffeURI})
+	ctx := ctxWithPeerCert(t, cert)
+
+	err := validatePeerNodeName(ctx, "worker-2")
+	if err == nil {
+		t.Fatal("expected PermissionDenied for mismatched SPIFFE, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got: %v", err)
+	}
+}
+
+func TestValidatePeerNodeName_MultipleSPIFFEURIs_SecondMatches(t *testing.T) {
+	uri1, _ := url.Parse("spiffe://cluster.local/agent/worker-1")
+	uri2, _ := url.Parse("spiffe://cluster.local/agent/worker-2")
+	cert := newTestCert(t, "", []*url.URL{uri1, uri2})
+	ctx := ctxWithPeerCert(t, cert)
+
+	// worker-2 is the second URI SAN — should still match.
+	err := validatePeerNodeName(ctx, "worker-2")
+	if err != nil {
+		t.Errorf("expected no error when second SPIFFE URI matches, got: %v", err)
+	}
+}
+
+func TestValidatePeerNodeName_CNFallback(t *testing.T) {
+	cert := newTestCert(t, "worker-1", nil)
+	ctx := ctxWithPeerCert(t, cert)
+
+	err := validatePeerNodeName(ctx, "worker-1")
+	if err != nil {
+		t.Errorf("expected no error for matching CN fallback, got: %v", err)
+	}
+}
+
+func TestValidatePeerNodeName_CNMismatch(t *testing.T) {
+	cert := newTestCert(t, "worker-1", nil)
+	ctx := ctxWithPeerCert(t, cert)
+
+	err := validatePeerNodeName(ctx, "worker-2")
+	if err == nil {
+		t.Fatal("expected PermissionDenied for mismatched CN, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got: %v", err)
+	}
+}
+
+func TestValidatePeerNodeName_CertPresentNoIdentity(t *testing.T) {
+	// Certificate with empty CN and no URI SANs — should fail closed.
+	cert := newTestCert(t, "", nil)
+	ctx := ctxWithPeerCert(t, cert)
+
+	err := validatePeerNodeName(ctx, "worker-1")
+	if err == nil {
+		t.Fatal("expected PermissionDenied when cert has no recognizable identity, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got: %v", err)
+	}
+}
+
+func TestValidatePeerNodeName_NoPeerInfo(t *testing.T) {
+	// No peer info — non-TLS, should allow.
+	err := validatePeerNodeName(context.Background(), "worker-1")
+	if err != nil {
+		t.Errorf("expected no error for non-TLS connection, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- **StreamConfig/ReportStatus NodeName**: Validate that the requested NodeName matches the peer's TLS certificate identity (SPIFFE URI SAN or CN). Prevents a compromised node from requesting another node's config.
- **MeshCA SignCSR**: Validate that the nodeName parameter matches the CSR's identity (URI SANs or Subject CN). Prevents an agent from requesting a certificate for a different node.
- **ACME FileStorage**: Reject domain names containing path traversal characters (`..`, `/`, `\`, null bytes) and apply `filepath.Clean` to all constructed paths. Prevents directory escape via malicious domain names.

## Test plan
- [x] Existing tests updated to use matching CSR CN / nodeName
- [x] New test `TestMeshCASignCSRIdentityMismatch` verifies CSR identity mismatch is rejected
- [x] `go build` passes for all three packages
- [x] `go test` passes for all three packages
- [x] `golangci-lint` passes with zero issues

Fixes #945