### PR TITLE
fix: use request context, errors.Is for EOF, bound ReadAll, add HTTP timeouts

### DIFF
--- a/cmd/novactl/cmd/cache.go
+++ b/cmd/novactl/cmd/cache.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,13 @@ var (
 	errCachePurgeFailedStatus = errors.New("cache purge failed (status")
 	errCacheStatsFailedStatus = errors.New("cache stats failed (status")
 )
+
+// cacheHTTPClient has a sensible timeout, replacing http.DefaultClient.
+var cacheHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+const maxCacheResponseBody = 1 << 20 // 1 MiB
 
 func newCacheCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -91,13 +99,13 @@ func runCachePurge(agentAddr, pattern string) error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: URL validated via url.ParseRequestURI above
+	resp, err := cacheHTTPClient.Do(req) //nolint:gosec // URL validated via url.ParseRequestURI above
 	if err != nil {
 		return fmt.Errorf("failed to connect to agent at %s: %w", agentAddr, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxCacheResponseBody))
 	if err != nil {
 		return fmt.Errorf("failed to read response: %w", err)
 	}
@@ -133,13 +141,13 @@ func runCacheStats(agentAddr string) error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: URL validated via url.ParseRequestURI above
+	resp, err := cacheHTTPClient.Do(req) //nolint:gosec // URL validated via url.ParseRequestURI above
 	if err != nil {
 		return fmt.Errorf("failed to connect to agent at %s: %w", agentAddr, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxCacheResponseBody))
 	if err != nil {
 		return fmt.Errorf("failed to read response: %w", err)
 	}

--- a/cmd/novactl/pkg/webui/handlers_write.go
+++ b/cmd/novactl/pkg/webui/handlers_write.go
@@ -358,7 +358,9 @@ func (s *Server) handleConfigImport(w http.ResponseWriter, r *http.Request) {
 
 	dryRun := r.URL.Query().Get("dryRun") == "true"
 
-	data, err := io.ReadAll(r.Body)
+	// Limit request body to 10 MiB to prevent unbounded memory allocation.
+	const maxImportBody = 10 << 20 // 10 MiB
+	data, err := io.ReadAll(io.LimitReader(r.Body, maxImportBody))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "failed to read request body: "+err.Error())
 		return

--- a/cmd/novactl/pkg/webui/server.go
+++ b/cmd/novactl/pkg/webui/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/azrtydxb/novaedge/cmd/novactl/pkg/webui/auth"
 	"github.com/azrtydxb/novaedge/cmd/novactl/pkg/webui/mode"
 	"github.com/azrtydxb/novaedge/internal/acme"
+	"github.com/azrtydxb/novaedge/internal/pkg/httpjson"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -357,19 +358,11 @@ func isSecureRequest(r *http.Request) bool {
 	return r.Header.Get("X-Forwarded-Proto") == "https"
 }
 
-// writeJSON writes a JSON response
-func writeJSON(w http.ResponseWriter, status int, data interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-}
+// writeJSON writes a JSON response using the shared httputil package.
+var writeJSON = httpjson.WriteJSONCompact
 
-// writeError writes an error response
-func writeError(w http.ResponseWriter, status int, message string) {
-	writeJSON(w, status, map[string]string{"error": message})
-}
+// writeError writes an error response using the shared httputil package.
+var writeError = httpjson.WriteError
 
 // parseNamespaceFromQuery extracts namespace from query params
 func parseNamespaceFromQuery(r *http.Request) string {

--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -440,6 +440,7 @@ func applyAgentConfig(ctx context.Context, logger *zap.Logger, comp *agentCompon
 
 	if comp.meshManager != nil {
 		if err := comp.meshManager.ApplyConfig(
+			ctx,
 			snapshot.GetInternalServices(),
 			snapshot.GetMeshAuthzPolicies(),
 		); err != nil {

--- a/internal/acme/dns/provider.go
+++ b/internal/acme/dns/provider.go
@@ -103,6 +103,7 @@ func NewProvider(name string, credentials map[string]string, config *ProviderCon
 type DNS01ChallengeProvider struct {
 	provider Provider
 	logger   *zap.Logger
+	ctx      context.Context //nolint:containedctx // required: lego interface has no context param
 }
 
 // NewDNS01ChallengeProvider creates a new DNS-01 challenge provider wrapping a DNS Provider.
@@ -113,7 +114,16 @@ func NewDNS01ChallengeProvider(provider Provider, logger *zap.Logger) *DNS01Chal
 	return &DNS01ChallengeProvider{
 		provider: provider,
 		logger:   logger,
+		ctx:      context.Background(),
 	}
+}
+
+// WithContext returns a copy of the provider that uses the given context for
+// DNS operations, making Present/CleanUp cancellable.
+func (p *DNS01ChallengeProvider) WithContext(ctx context.Context) *DNS01ChallengeProvider {
+	cp := *p
+	cp.ctx = ctx
+	return &cp
 }
 
 // Present creates the DNS TXT record for the challenge.
@@ -124,14 +134,12 @@ func (p *DNS01ChallengeProvider) Present(domain, _, keyAuth string) error {
 		zap.String("domain", domain),
 		zap.String("fqdn", fqdn))
 
-	ctx := context.Background()
-
-	if err := p.provider.CreateTXTRecord(ctx, fqdn, keyAuth); err != nil {
+	if err := p.provider.CreateTXTRecord(p.ctx, fqdn, keyAuth); err != nil {
 		return fmt.Errorf("failed to create TXT record for %s: %w", domain, err)
 	}
 
 	// Wait for propagation
-	if err := p.provider.WaitForPropagation(ctx, fqdn, keyAuth); err != nil {
+	if err := p.provider.WaitForPropagation(p.ctx, fqdn, keyAuth); err != nil {
 		p.logger.Warn("DNS propagation wait failed, continuing anyway",
 			zap.String("domain", domain),
 			zap.Error(err))
@@ -148,8 +156,7 @@ func (p *DNS01ChallengeProvider) CleanUp(domain, _, keyAuth string) error {
 		zap.String("domain", domain),
 		zap.String("fqdn", fqdn))
 
-	ctx := context.Background()
-	return p.provider.DeleteTXTRecord(ctx, fqdn, keyAuth)
+	return p.provider.DeleteTXTRecord(p.ctx, fqdn, keyAuth)
 }
 
 // waitForDNSPropagation polls DNS until the expected TXT record is visible or the timeout expires.

--- a/internal/agent/mesh/detect.go
+++ b/internal/agent/mesh/detect.go
@@ -18,6 +18,7 @@ package mesh
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"net"
 	"strings"
@@ -68,7 +69,7 @@ func DetectProtocol(conn net.Conn) (Protocol, *PeekConn) {
 
 	pc := &PeekConn{Conn: conn, reader: br}
 
-	if err != nil && (err != io.EOF || len(peeked) == 0) {
+	if err != nil && (!errors.Is(err, io.EOF) || len(peeked) == 0) {
 		return ProtocolOpaque, pc
 	}
 

--- a/internal/agent/mesh/manager.go
+++ b/internal/agent/mesh/manager.go
@@ -303,7 +303,7 @@ func (m *Manager) Start(ctx context.Context) error {
 
 // ApplyConfig updates the mesh routing table, TPROXY interception rules,
 // authorization policies, and eBPF acceleration maps from a config snapshot.
-func (m *Manager) ApplyConfig(services []*pb.InternalService, authzPolicies []*pb.MeshAuthorizationPolicy) error {
+func (m *Manager) ApplyConfig(ctx context.Context, services []*pb.InternalService, authzPolicies []*pb.MeshAuthorizationPolicy) error {
 	if m.tproxy == nil {
 		return errMeshManagerNotStarted
 	}
@@ -339,7 +339,7 @@ func (m *Manager) ApplyConfig(services []*pb.InternalService, authzPolicies []*p
 	// Skip reconciliation if NovaNet is not connected to avoid logging
 	// no-op successes and corrupting tracked state.
 	if m.novanetClient != nil && m.novanetClient.IsConnected() {
-		reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		reconcileCtx, reconcileCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer reconcileCancel()
 		m.reconcileNovaNetMeshRedirects(reconcileCtx, services)
 		m.reconcileNovaNetSockMap(reconcileCtx, services)

--- a/internal/agent/mesh/manager_test.go
+++ b/internal/agent/mesh/manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mesh
 
 import (
+	"context"
 	"testing"
 
 	"go.uber.org/zap"
@@ -200,7 +201,7 @@ func TestManagerApplyConfig(t *testing.T) {
 		},
 	}
 
-	if err := mgr.ApplyConfig(services, nil); err != nil {
+	if err := mgr.ApplyConfig(context.Background(), services, nil); err != nil {
 		t.Fatalf("ApplyConfig failed: %v", err)
 	}
 
@@ -221,7 +222,7 @@ func TestManagerApplyConfigNotStarted(t *testing.T) {
 		serviceTable: NewServiceTable(),
 	}
 
-	err := mgr.ApplyConfig(nil, nil)
+	err := mgr.ApplyConfig(context.Background(), nil, nil)
 	if err == nil {
 		t.Error("Expected error when manager not started")
 	}

--- a/internal/agent/mesh/tunnel_test.go
+++ b/internal/agent/mesh/tunnel_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"net"
 	"net/http"
@@ -38,19 +37,9 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 
+	"github.com/azrtydxb/novaedge/internal/pkg/convert"
 	pb "github.com/azrtydxb/novaedge/internal/proto/gen"
 )
-
-// safeIntToInt32 converts int to int32 with bounds checking.
-func safeIntToInt32(v int) int32 {
-	if v > math.MaxInt32 {
-		return math.MaxInt32
-	}
-	if v < math.MinInt32 {
-		return math.MinInt32
-	}
-	return int32(v)
-}
 
 // tunnelTestPKI holds a self-signed CA and can issue client/server certificates.
 type tunnelTestPKI struct {
@@ -214,7 +203,7 @@ func startTunnelServer(t *testing.T, serverTLS *tls.Config, authorizer *Authoriz
 		t.Fatalf("port %d out of range", port)
 	}
 
-	ts := NewTunnelServer(logger, safeIntToInt32(port), serverTLS, authorizer, nil)
+	ts := NewTunnelServer(logger, convert.SafeIntToInt32(port), serverTLS, authorizer, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -724,7 +713,7 @@ func startTunnelServerWithProvider(t *testing.T, serverTLS *tls.Config, authoriz
 		t.Fatalf("port %d out of range", port)
 	}
 
-	ts := NewTunnelServer(logger, safeIntToInt32(port), serverTLS, authorizer, tlsProvider)
+	ts := NewTunnelServer(logger, convert.SafeIntToInt32(port), serverTLS, authorizer, tlsProvider)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/agent/server/admin.go
+++ b/internal/agent/server/admin.go
@@ -24,7 +24,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -38,6 +37,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/azrtydxb/novaedge/internal/agent/config"
+	"github.com/azrtydxb/novaedge/internal/pkg/httpjson"
 )
 
 // DefaultAdminAddr is the default listen address for the admin API.
@@ -429,15 +429,5 @@ func (a *AdminServer) handleLogging(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// writeJSON serializes v as JSON and writes it to w with the given status code.
-func writeJSON(w http.ResponseWriter, statusCode int, v interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(v); err != nil {
-		// Best effort: the header has already been sent so we can only log.
-		http.Error(w, "failed to encode response", http.StatusInternalServerError)
-	}
-}
+// writeJSON serializes v as indented JSON using the shared httputil package.
+var writeJSON = httpjson.WriteJSON

--- a/internal/controller/federation/server.go
+++ b/internal/controller/federation/server.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/azrtydxb/novaedge/internal/pkg/convert"
 	pb "github.com/azrtydxb/novaedge/internal/proto/gen"
 )
 
@@ -325,7 +325,7 @@ func (s *Server) handleOutgoingMessages(ctx context.Context, stream pb.Federatio
 					Heartbeat: &pb.Heartbeat{
 						VectorClock:    s.vectorClock.ToMap(),
 						Timestamp:      time.Now().UnixNano(),
-						PendingChanges: safeIntToInt32(len(s.pendingChanges)),
+						PendingChanges: convert.SafeIntToInt32(len(s.pendingChanges)),
 						AgentCount:     agentCount,
 					},
 				},
@@ -797,10 +797,10 @@ func (s *Server) RequestFullSync(req *pb.FullSyncRequest, stream pb.FederationSe
 		}
 
 		batch := &pb.ResourceBatch{
-			BatchNumber:    safeIntToInt32(batchNum),
+			BatchNumber:    convert.SafeIntToInt32(batchNum),
 			IsLast:         end == len(resources),
 			Resources:      resources[i:end],
-			TotalResources: safeIntToInt32(totalResources),
+			TotalResources: convert.SafeIntToInt32(totalResources),
 			VectorClock:    s.vectorClock.ToMap(),
 		}
 
@@ -1127,15 +1127,4 @@ func (s *Server) deleteServiceEndpoints(namespace, name, peerName string) {
 // Manager or other components.
 func (s *Server) GetEndpointCache() *RemoteEndpointCache {
 	return s.endpointCache
-}
-
-// safeIntToInt32 safely converts an int to int32, clamping to max int32 value if needed
-func safeIntToInt32(v int) int32 {
-	if v > math.MaxInt32 {
-		return math.MaxInt32
-	}
-	if v < math.MinInt32 {
-		return math.MinInt32
-	}
-	return int32(v) //nolint:gosec // bounds checked above
 }

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -22,6 +22,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/dataplane/client.go
+++ b/internal/dataplane/client.go
@@ -4,6 +4,7 @@ package dataplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -276,7 +277,7 @@ func (c *Client) StreamFlows(ctx context.Context, req *pb.StreamFlowsRequest) (<
 		for {
 			event, recvErr := stream.Recv()
 			if recvErr != nil {
-				if recvErr != io.EOF {
+				if !errors.Is(recvErr, io.EOF) {
 					c.logger.Warn("StreamFlows recv error", zap.Error(recvErr))
 				}
 				return
@@ -307,7 +308,7 @@ func (c *Client) StreamMetrics(ctx context.Context, req *pb.StreamMetricsRequest
 		for {
 			snapshot, recvErr := stream.Recv()
 			if recvErr != nil {
-				if recvErr != io.EOF {
+				if !errors.Is(recvErr, io.EOF) {
 					c.logger.Warn("StreamMetrics recv error", zap.Error(recvErr))
 				}
 				return

--- a/internal/operator/controller/novaedgefederation_controller.go
+++ b/internal/operator/controller/novaedgefederation_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -35,6 +34,7 @@ import (
 
 	novaedgev1alpha1 "github.com/azrtydxb/novaedge/api/v1alpha1"
 	"github.com/azrtydxb/novaedge/internal/controller/federation"
+	"github.com/azrtydxb/novaedge/internal/pkg/convert"
 )
 
 const (
@@ -436,7 +436,7 @@ func (r *NovaEdgeFederationReconciler) syncStatus(ctx context.Context, fed *nova
 	// Update status
 	fed.Status.Phase = crdPhase
 	fed.Status.Members = memberStatuses
-	fed.Status.ConflictsPending = safeIntToInt32(len(conflicts))
+	fed.Status.ConflictsPending = convert.SafeIntToInt32(len(conflicts))
 	fed.Status.LocalVectorClock = vectorClock
 	fed.Status.ObservedGeneration = fed.Generation
 
@@ -555,15 +555,4 @@ func (r *NovaEdgeFederationReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novaedgev1alpha1.NovaEdgeFederation{}).
 		Complete(r)
-}
-
-// safeIntToInt32 safely converts an int to int32, clamping to max int32 value if needed
-func safeIntToInt32(v int) int32 {
-	if v > math.MaxInt32 {
-		return math.MaxInt32
-	}
-	if v < math.MinInt32 {
-		return math.MinInt32
-	}
-	return int32(v) //nolint:gosec // bounds checked above
 }

--- a/internal/pkg/convert/int.go
+++ b/internal/pkg/convert/int.go
@@ -1,0 +1,15 @@
+// Package convert provides shared numeric conversion helpers.
+package convert
+
+import "math"
+
+// SafeIntToInt32 safely converts an int to int32, clamping to the int32 range.
+func SafeIntToInt32(v int) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v) //nolint:gosec // bounds checked above
+}

--- a/internal/pkg/convert/int_test.go
+++ b/internal/pkg/convert/int_test.go
@@ -1,0 +1,27 @@
+package convert
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSafeIntToInt32(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int32
+	}{
+		{"zero", 0, 0},
+		{"positive", 42, 42},
+		{"max int32", math.MaxInt32, math.MaxInt32},
+		{"overflow high", math.MaxInt32 + 1, math.MaxInt32},
+		{"overflow low", math.MinInt32 - 1, math.MinInt32},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SafeIntToInt32(tt.in); got != tt.want {
+				t.Errorf("SafeIntToInt32(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/httpjson/response.go
+++ b/internal/pkg/httpjson/response.go
@@ -1,0 +1,32 @@
+// Package httpjson provides shared HTTP handler helpers.
+package httpjson
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// WriteJSON serializes v as pretty-printed JSON.
+func WriteJSON(w http.ResponseWriter, statusCode int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// WriteJSONCompact serializes v as compact (non-indented) JSON.
+func WriteJSONCompact(w http.ResponseWriter, statusCode int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// WriteError writes a JSON error response.
+func WriteError(w http.ResponseWriter, status int, message string) {
+	WriteJSON(w, status, map[string]string{"error": message})
+}


### PR DESCRIPTION
## Summary

- **context.Background() misuse (#943)**: ACME DNS01ChallengeProvider now stores a context on the struct with `WithContext()` so callers can cancel Present/CleanUp despite the lego interface not accepting context. Mesh `Manager.ApplyConfig` now accepts a `ctx` parameter threaded to NovaNet reconciliation.
- **io.EOF comparison (#943)**: Replaced `!= io.EOF` with `errors.Is(err, io.EOF)` in `dataplane/client.go` (StreamFlows/StreamMetrics) and `mesh/detect.go` (DetectProtocol).
- **Unbounded io.ReadAll (#949)**: Added `io.LimitReader` in `handlers_write.go` (10 MiB) and `cache.go` (1 MiB).
- **http.DefaultClient (#949)**: Replaced with a `cacheHTTPClient` that has a 30-second timeout.
- **safeIntToInt32 dedup (#949)**: Extracted to `internal/pkg/convert.SafeIntToInt32`, removed 3 copies.
- **writeJSON dedup (#949)**: Extracted to `internal/pkg/httpjson`, removed 2 copies.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/... ./cmd/...` passes
- [x] `golangci-lint` passes (pre-commit hook)
- [x] New `internal/pkg/convert` package has unit tests

Fixes #943, #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)