### PR TITLE
fix: standardize controller patterns and minor code quality (#974, #976)

### DIFF
--- a/cmd/novactl/cmd/cache.go
+++ b/cmd/novactl/cmd/cache.go
@@ -114,7 +114,7 @@ func runCachePurge(agentAddr, pattern string) error {
 		return fmt.Errorf("%w: %d): %s", errCachePurgeFailedStatus, resp.StatusCode, string(body))
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(body, &result); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
@@ -156,7 +156,7 @@ func runCacheStats(agentAddr string) error {
 		return fmt.Errorf("%w: %d): %s", errCacheStatsFailedStatus, resp.StatusCode, string(body))
 	}
 
-	var stats map[string]interface{}
+	var stats map[string]any
 	if err := json.Unmarshal(body, &stats); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}

--- a/cmd/novactl/cmd/conformance.go
+++ b/cmd/novactl/cmd/conformance.go
@@ -47,7 +47,7 @@ func checkGatewayClasses(ctx context.Context, dynamicClient dynamic.Interface) {
 	found := false
 	for _, gc := range gcList.Items {
 		controllerName := ""
-		if spec, ok := gc.Object["spec"].(map[string]interface{}); ok {
+		if spec, ok := gc.Object["spec"].(map[string]any); ok {
 			controllerName, _ = spec["controllerName"].(string)
 		}
 		if controllerName != "novaedge.io/gateway-controller" {
@@ -67,17 +67,17 @@ func checkGatewayClasses(ctx context.Context, dynamicClient dynamic.Interface) {
 }
 
 // printStatusConditions prints conditions from a resource's status.
-func printStatusConditions(obj map[string]interface{}) {
-	status, ok := obj["status"].(map[string]interface{})
+func printStatusConditions(obj map[string]any) {
+	status, ok := obj["status"].(map[string]any)
 	if !ok {
 		return
 	}
-	conditions, ok := status["conditions"].([]interface{})
+	conditions, ok := status["conditions"].([]any)
 	if !ok {
 		return
 	}
 	for _, c := range conditions {
-		if cond, ok := c.(map[string]interface{}); ok {
+		if cond, ok := c.(map[string]any); ok {
 			condType, _ := cond["type"].(string)
 			condStatus, _ := cond["status"].(string)
 			condReason, _ := cond["reason"].(string)
@@ -87,9 +87,9 @@ func printStatusConditions(obj map[string]interface{}) {
 }
 
 // extractConditionStatus extracts condition values from a conditions list.
-func extractConditionStatus(conditions []interface{}, targets map[string]*string) {
+func extractConditionStatus(conditions []any, targets map[string]*string) {
 	for _, c := range conditions {
-		if cond, ok := c.(map[string]interface{}); ok {
+		if cond, ok := c.(map[string]any); ok {
 			condType, _ := cond["type"].(string)
 			condStatus, _ := cond["status"].(string)
 			if ptr, exists := targets[condType]; exists {
@@ -117,12 +117,12 @@ func checkGateways(ctx context.Context, dynamicClient dynamic.Interface) {
 		_, _ = fmt.Fprintln(w, "  NAME\tNAMESPACE\tCLASS\tACCEPTED\tPROGRAMMED")
 		for _, gw := range gwList.Items {
 			className := ""
-			if spec, ok := gw.Object["spec"].(map[string]interface{}); ok {
+			if spec, ok := gw.Object["spec"].(map[string]any); ok {
 				className, _ = spec["gatewayClassName"].(string)
 			}
 			accepted, programmed := "-", "-"
-			if status, ok := gw.Object["status"].(map[string]interface{}); ok {
-				if conditions, ok := status["conditions"].([]interface{}); ok {
+			if status, ok := gw.Object["status"].(map[string]any); ok {
+				if conditions, ok := status["conditions"].([]any); ok {
 					extractConditionStatus(conditions, map[string]*string{
 						"Accepted": &accepted, "Programmed": &programmed,
 					})
@@ -154,10 +154,10 @@ func checkHTTPRoutes(ctx context.Context, dynamicClient dynamic.Interface) {
 		_, _ = fmt.Fprintln(w, "  NAME\tNAMESPACE\tACCEPTED\tRESOLVED_REFS")
 		for _, hr := range hrList.Items {
 			accepted, resolvedRefs := "-", "-"
-			if status, ok := hr.Object["status"].(map[string]interface{}); ok {
-				if parents, ok := status["parents"].([]interface{}); ok && len(parents) > 0 {
-					if parent, ok := parents[0].(map[string]interface{}); ok {
-						if conditions, ok := parent["conditions"].([]interface{}); ok {
+			if status, ok := hr.Object["status"].(map[string]any); ok {
+				if parents, ok := status["parents"].([]any); ok && len(parents) > 0 {
+					if parent, ok := parents[0].(map[string]any); ok {
+						if conditions, ok := parent["conditions"].([]any); ok {
 							extractConditionStatus(conditions, map[string]*string{
 								"Accepted": &accepted, "ResolvedRefs": &resolvedRefs,
 							})

--- a/cmd/novactl/cmd/debug.go
+++ b/cmd/novactl/cmd/debug.go
@@ -103,7 +103,7 @@ func runDebugRoutes(_ *cobra.Command, args []string) error {
 		if len(matches) > 0 {
 			fmt.Printf("Matches:\n")
 			for _, match := range matches {
-				m, ok := match.(map[string]interface{})
+				m, ok := match.(map[string]any)
 				if !ok {
 					continue
 				}
@@ -122,7 +122,7 @@ func runDebugRoutes(_ *cobra.Command, args []string) error {
 		if len(backends) > 0 {
 			fmt.Printf("Backends:\n")
 			for _, backend := range backends {
-				b, ok := backend.(map[string]interface{})
+				b, ok := backend.(map[string]any)
 				if !ok {
 					continue
 				}
@@ -205,7 +205,7 @@ func runDebugBackends(_ *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintln(w, "ADDRESS\tPORT\tHEALTHY\tLAST CHECK")
 
 		for _, ep := range endpoints {
-			epMap, ok := ep.(map[string]interface{})
+			epMap, ok := ep.(map[string]any)
 			if !ok {
 				continue
 			}

--- a/cmd/novactl/cmd/gateway_api.go
+++ b/cmd/novactl/cmd/gateway_api.go
@@ -116,17 +116,17 @@ func runGetGatewayClasses(_ *cobra.Command, _ []string) error {
 		name := item.GetName()
 
 		controllerName := ""
-		if spec, ok := item.Object["spec"].(map[string]interface{}); ok {
+		if spec, ok := item.Object["spec"].(map[string]any); ok {
 			if cn, ok := spec["controllerName"].(string); ok {
 				controllerName = cn
 			}
 		}
 
 		accepted := statusUnknown
-		if status, ok := item.Object["status"].(map[string]interface{}); ok {
-			if conditions, ok := status["conditions"].([]interface{}); ok {
+		if status, ok := item.Object["status"].(map[string]any); ok {
+			if conditions, ok := status["conditions"].([]any); ok {
 				for _, c := range conditions {
-					if cond, ok := c.(map[string]interface{}); ok {
+					if cond, ok := c.(map[string]any); ok {
 						condType, _ := cond["type"].(string)
 						condStatus, _ := cond["status"].(string)
 						if condType == conditionAccepted {
@@ -177,21 +177,21 @@ func runGetGatewayAPIGateways(_ *cobra.Command, _ []string) error {
 
 		className := ""
 		listenerCount := 0
-		if spec, ok := item.Object["spec"].(map[string]interface{}); ok {
+		if spec, ok := item.Object["spec"].(map[string]any); ok {
 			if cn, ok := spec["gatewayClassName"].(string); ok {
 				className = cn
 			}
-			if listeners, ok := spec["listeners"].([]interface{}); ok {
+			if listeners, ok := spec["listeners"].([]any); ok {
 				listenerCount = len(listeners)
 			}
 		}
 
 		accepted := statusUnknown
 		programmed := statusUnknown
-		if status, ok := item.Object["status"].(map[string]interface{}); ok {
-			if conditions, ok := status["conditions"].([]interface{}); ok {
+		if status, ok := item.Object["status"].(map[string]any); ok {
+			if conditions, ok := status["conditions"].([]any); ok {
 				for _, c := range conditions {
-					if cond, ok := c.(map[string]interface{}); ok {
+					if cond, ok := c.(map[string]any); ok {
 						condType, _ := cond["type"].(string)
 						condStatus, _ := cond["status"].(string)
 						switch condType {
@@ -248,8 +248,8 @@ func runGetHTTPRoutes(_ *cobra.Command, _ []string) error {
 
 		hostnames := "*"
 		parentCount := 0
-		if spec, ok := item.Object["spec"].(map[string]interface{}); ok {
-			if hn, ok := spec["hostnames"].([]interface{}); ok && len(hn) > 0 {
+		if spec, ok := item.Object["spec"].(map[string]any); ok {
+			if hn, ok := spec["hostnames"].([]any); ok && len(hn) > 0 {
 				hostnames = ""
 				for i, h := range hn {
 					if i > 0 {
@@ -260,7 +260,7 @@ func runGetHTTPRoutes(_ *cobra.Command, _ []string) error {
 					}
 				}
 			}
-			if parents, ok := spec["parentRefs"].([]interface{}); ok {
+			if parents, ok := spec["parentRefs"].([]any); ok {
 				parentCount = len(parents)
 			}
 		}
@@ -276,25 +276,25 @@ func runGetHTTPRoutes(_ *cobra.Command, _ []string) error {
 
 // httpRouteAcceptedStatus extracts the accepted status from the first parent
 // in an unstructured HTTPRoute object.
-func httpRouteAcceptedStatus(obj map[string]interface{}) string {
-	status, ok := obj["status"].(map[string]interface{})
+func httpRouteAcceptedStatus(obj map[string]any) string {
+	status, ok := obj["status"].(map[string]any)
 	if !ok {
 		return statusUnknown
 	}
-	parents, ok := status["parents"].([]interface{})
+	parents, ok := status["parents"].([]any)
 	if !ok || len(parents) == 0 {
 		return statusUnknown
 	}
-	parent, ok := parents[0].(map[string]interface{})
+	parent, ok := parents[0].(map[string]any)
 	if !ok {
 		return statusUnknown
 	}
-	conditions, ok := parent["conditions"].([]interface{})
+	conditions, ok := parent["conditions"].([]any)
 	if !ok {
 		return statusUnknown
 	}
 	for _, c := range conditions {
-		cond, ok := c.(map[string]interface{})
+		cond, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -311,7 +311,7 @@ func httpRouteAcceptedStatus(obj map[string]interface{}) string {
 }
 
 // getUnstructuredString returns a string value from an unstructured map.
-func getUnstructuredString(m map[string]interface{}, key string) string {
+func getUnstructuredString(m map[string]any, key string) string {
 	if v, ok := m[key].(string); ok {
 		return v
 	}
@@ -320,7 +320,7 @@ func getUnstructuredString(m map[string]interface{}, key string) string {
 
 // getUnstructuredInt64 returns an int64 value from an unstructured map,
 // handling both float64 and int64 representations.
-func getUnstructuredInt64(m map[string]interface{}, key string) int64 {
+func getUnstructuredInt64(m map[string]any, key string) int64 {
 	if v, ok := m[key].(float64); ok {
 		return int64(v)
 	}
@@ -331,18 +331,18 @@ func getUnstructuredInt64(m map[string]interface{}, key string) int64 {
 }
 
 // printGatewaySpec prints the spec section of a Gateway.
-func printGatewaySpec(spec map[string]interface{}) {
+func printGatewaySpec(spec map[string]any) {
 	if cn, ok := spec["gatewayClassName"].(string); ok {
 		fmt.Printf("GatewayClass: %s\n", cn)
 	}
 
-	listeners, ok := spec["listeners"].([]interface{})
+	listeners, ok := spec["listeners"].([]any)
 	if !ok {
 		return
 	}
 	fmt.Printf("\nListeners (%d):\n", len(listeners))
 	for _, l := range listeners {
-		if listener, ok := l.(map[string]interface{}); ok {
+		if listener, ok := l.(map[string]any); ok {
 			fmt.Printf("  - Name: %s, Port: %d, Protocol: %s\n",
 				getUnstructuredString(listener, "name"),
 				getUnstructuredInt64(listener, "port"),
@@ -352,11 +352,11 @@ func printGatewaySpec(spec map[string]interface{}) {
 }
 
 // printGatewayStatus prints the status section of a Gateway.
-func printGatewayStatus(status map[string]interface{}) {
-	if conditions, ok := status["conditions"].([]interface{}); ok && len(conditions) > 0 {
+func printGatewayStatus(status map[string]any) {
+	if conditions, ok := status["conditions"].([]any); ok && len(conditions) > 0 {
 		fmt.Printf("\nConditions:\n")
 		for _, c := range conditions {
-			if cond, ok := c.(map[string]interface{}); ok {
+			if cond, ok := c.(map[string]any); ok {
 				fmt.Printf("  Type:    %s\n", getUnstructuredString(cond, "type"))
 				fmt.Printf("  Status:  %s\n", getUnstructuredString(cond, "status"))
 				fmt.Printf("  Reason:  %s\n", getUnstructuredString(cond, "reason"))
@@ -366,19 +366,19 @@ func printGatewayStatus(status map[string]interface{}) {
 		}
 	}
 
-	listeners, ok := status["listeners"].([]interface{})
+	listeners, ok := status["listeners"].([]any)
 	if !ok || len(listeners) == 0 {
 		return
 	}
 	fmt.Printf("Listener Status:\n")
 	for _, l := range listeners {
-		if listener, ok := l.(map[string]interface{}); ok {
+		if listener, ok := l.(map[string]any); ok {
 			fmt.Printf("  - Name: %s, AttachedRoutes: %d\n",
 				getUnstructuredString(listener, "name"),
 				getUnstructuredInt64(listener, "attachedRoutes"))
-			if conditions, ok := listener["conditions"].([]interface{}); ok {
+			if conditions, ok := listener["conditions"].([]any); ok {
 				for _, c := range conditions {
-					if cond, ok := c.(map[string]interface{}); ok {
+					if cond, ok := c.(map[string]any); ok {
 						fmt.Printf("    %s: %s\n",
 							getUnstructuredString(cond, "type"),
 							getUnstructuredString(cond, "status"))
@@ -407,11 +407,11 @@ func runDescribeGatewayAPIGateway(_ *cobra.Command, args []string) error {
 	fmt.Printf("Namespace:    %s\n", gw.GetNamespace())
 	fmt.Printf("Age:          %s\n", formatResourceAge(gw.GetCreationTimestamp().Time))
 
-	if spec, ok := gw.Object["spec"].(map[string]interface{}); ok {
+	if spec, ok := gw.Object["spec"].(map[string]any); ok {
 		printGatewaySpec(spec)
 	}
 
-	if status, ok := gw.Object["status"].(map[string]interface{}); ok {
+	if status, ok := gw.Object["status"].(map[string]any); ok {
 		printGatewayStatus(status)
 	}
 

--- a/cmd/novactl/cmd/generate.go
+++ b/cmd/novactl/cmd/generate.go
@@ -236,8 +236,8 @@ redirected to a file (e.g., /etc/kubernetes/manifests/novaedge-cpvip.yaml).`,
 
 	addBGPFlags(cmd, &vipMode, &bgpLocalAS, &bgpRouterID, &bgpPeers, &bfdEnabled, &bfdDetectMult, &bfdTxInterval, &bfdRxInterval)
 
-	_ = cmd.MarkFlagRequired("vip-address")
-	_ = cmd.MarkFlagRequired("image")
+	cobra.CheckErr(cmd.MarkFlagRequired("vip-address"))
+	cobra.CheckErr(cmd.MarkFlagRequired("image"))
 
 	return cmd
 }
@@ -295,7 +295,7 @@ VIP mode. The unit file is written to stdout so it can be redirected to a file
 
 	addBGPFlags(cmd, &vipMode, &bgpLocalAS, &bgpRouterID, &bgpPeers, &bfdEnabled, &bfdDetectMult, &bfdTxInterval, &bfdRxInterval)
 
-	_ = cmd.MarkFlagRequired("vip-address")
+	cobra.CheckErr(cmd.MarkFlagRequired("vip-address"))
 
 	return cmd
 }
@@ -362,7 +362,7 @@ func runGenerateSystemdUnit(vipAddress, binaryPath, iface string, apiPort int, h
 	return renderTemplate(systemdUnitTemplate, "systemd-unit", data)
 }
 
-func renderTemplate(tmplText, name string, data interface{}) error {
+func renderTemplate(tmplText, name string, data any) error {
 	tmpl, err := template.New(name).Parse(tmplText)
 	if err != nil {
 		return fmt.Errorf("failed to parse template: %w", err)

--- a/cmd/novactl/cmd/metrics.go
+++ b/cmd/novactl/cmd/metrics.go
@@ -106,7 +106,7 @@ func runMetricsBackends(_ *cobra.Command, _ []string) error {
 
 		healthy := 0
 		for _, ep := range endpoints {
-			epMap, ok := ep.(map[string]interface{})
+			epMap, ok := ep.(map[string]any)
 			if !ok {
 				continue
 			}

--- a/cmd/novactl/pkg/printer/printer.go
+++ b/cmd/novactl/pkg/printer/printer.go
@@ -169,7 +169,7 @@ func (p *Printer) printBackendTable(w *tabwriter.Writer, items []unstructured.Un
 		// Count healthy endpoints
 		healthyCount := 0
 		for _, ep := range endpoints {
-			epMap, ok := ep.(map[string]interface{})
+			epMap, ok := ep.(map[string]any)
 			if !ok {
 				continue
 			}

--- a/cmd/novactl/pkg/prometheus/client.go
+++ b/cmd/novactl/pkg/prometheus/client.go
@@ -55,8 +55,8 @@ type QueryData struct {
 // Result represents a single result entry
 type Result struct {
 	Metric map[string]string `json:"metric"`
-	Value  []interface{}     `json:"value,omitempty"`  // For instant queries
-	Values [][]interface{}   `json:"values,omitempty"` // For range queries
+	Value  []any             `json:"value,omitempty"`  // For instant queries
+	Values [][]any           `json:"values,omitempty"` // For range queries
 }
 
 // InstantQueryParams defines parameters for instant queries

--- a/cmd/novactl/pkg/webui/auth/auth.go
+++ b/cmd/novactl/pkg/webui/auth/auth.go
@@ -134,7 +134,7 @@ func (m *Manager) evictExcessSessions() {
 	var entries []entry
 	now := time.Now()
 
-	m.sessions.Range(func(key, value interface{}) bool {
+	m.sessions.Range(func(key, value any) bool {
 		tok, ok := key.(string)
 		if !ok {
 			m.sessions.Delete(key)
@@ -191,7 +191,7 @@ func (m *Manager) createToken(user string) (string, error) {
 
 // ValidateToken verifies the JWT signature and checks that the session has not expired or been revoked.
 func (m *Manager) ValidateToken(tokenStr string) error {
-	_, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+	_, err := jwt.Parse(tokenStr, func(t *jwt.Token) (any, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("%w: %v", errUnexpectedSigningMethod, t.Header["alg"])
 		}

--- a/cmd/novactl/pkg/webui/handlers_observability.go
+++ b/cmd/novactl/pkg/webui/handlers_observability.go
@@ -60,7 +60,7 @@ func (s *Server) handleTraces(w http.ResponseWriter, r *http.Request) {
 
 	// Jaeger requires a service parameter; return empty list if not provided
 	if params.ServiceName == "" {
-		writeJSON(w, http.StatusOK, []interface{}{})
+		writeJSON(w, http.StatusOK, []any{})
 		return
 	}
 
@@ -650,17 +650,17 @@ func (s *Server) handleMeshPoliciesList(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Filter for policies that are of mesh authorization type
-	meshPolicies := make([]map[string]interface{}, 0)
+	meshPolicies := make([]map[string]any, 0)
 	for _, p := range policies {
 		if p.Type == "MeshAuthorization" {
-			meshPolicies = append(meshPolicies, map[string]interface{}{
+			meshPolicies = append(meshPolicies, map[string]any{
 				"apiVersion": "novaedge.io/v1alpha1",
 				"kind":       "MeshAuthorizationPolicy",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      p.Name,
 					"namespace": p.Namespace,
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"targetRef": p.TargetRef,
 				},
 			})
@@ -692,14 +692,14 @@ func (s *Server) handleMeshPolicyGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		"apiVersion": "novaedge.io/v1alpha1",
 		"kind":       "MeshAuthorizationPolicy",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      policy.Name,
 			"namespace": policy.Namespace,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"type":      policy.Type,
 			"targetRef": policy.TargetRef,
 			"rateLimit": policy.RateLimit,
@@ -729,7 +729,7 @@ func (s *Server) handleMeshPolicyWrite(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodPost:
-		var resource map[string]interface{}
+		var resource map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&resource); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
@@ -751,7 +751,7 @@ func (s *Server) handleMeshPolicyWrite(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		var resource map[string]interface{}
+		var resource map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&resource); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
@@ -789,12 +789,12 @@ func (s *Server) handleMeshPolicyWrite(w http.ResponseWriter, r *http.Request) {
 }
 
 // meshResourceToPolicy converts a generic mesh policy resource to a Policy model
-func meshResourceToPolicy(resource map[string]interface{}) *models.Policy {
+func meshResourceToPolicy(resource map[string]any) *models.Policy {
 	policy := &models.Policy{
 		Type: "MeshAuthorization",
 	}
 
-	if metadata, ok := resource["metadata"].(map[string]interface{}); ok {
+	if metadata, ok := resource["metadata"].(map[string]any); ok {
 		if name, ok := metadata["name"].(string); ok {
 			policy.Name = name
 		}
@@ -816,7 +816,7 @@ func (s *Server) handleOverloadStatus(w http.ResponseWriter, r *http.Request) {
 	// Return current overload status.
 	// The novactl backend doesn't embed the overload manager directly; return
 	// reasonable defaults so that the UI renders without errors.
-	status := map[string]interface{}{
+	status := map[string]any{
 		"state":             "normal",
 		"heapUsageRatio":    0.0,
 		"goroutineCount":    0,
@@ -831,7 +831,7 @@ func (s *Server) handleOverloadStatus(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleOverloadConfig(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		config := map[string]interface{}{
+		config := map[string]any{
 			"enabled":                      false,
 			"heapMemoryTriggerPercent":     90,
 			"heapMemoryRecoverPercent":     80,
@@ -844,7 +844,7 @@ func (s *Server) handleOverloadConfig(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, config)
 
 	case http.MethodPost:
-		var config map[string]interface{}
+		var config map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&config); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return

--- a/cmd/novactl/pkg/webui/handlers_write.go
+++ b/cmd/novactl/pkg/webui/handlers_write.go
@@ -117,7 +117,7 @@ func (s *Server) handleMode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"mode":     string(s.backend.Mode()),
 		"readOnly": s.backend.ReadOnly(),
 	}
@@ -445,7 +445,7 @@ func (s *Server) handleConfigHistoryRestore(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
+	writeJSON(w, http.StatusOK, map[string]any{
 		"message":    "configuration restored from snapshot",
 		"snapshotId": snapshotID,
 		"timestamp":  snapshot.Timestamp.Format(time.RFC3339),

--- a/cmd/novactl/pkg/webui/mode/kubernetes.go
+++ b/cmd/novactl/pkg/webui/mode/kubernetes.go
@@ -937,7 +937,7 @@ func (k *KubernetesBackend) unstructuredToGateway(obj *unstructured.Unstructured
 	// Parse listeners
 	if listeners, found, _ := unstructured.NestedSlice(spec, "listeners"); found {
 		for _, l := range listeners {
-			if lm, ok := l.(map[string]interface{}); ok {
+			if lm, ok := l.(map[string]any); ok {
 				listener := models.Listener{
 					Name:     getStringField(lm, "name"),
 					Port:     int(getInt64Field(lm, "port")),
@@ -956,14 +956,14 @@ func (k *KubernetesBackend) unstructuredToGateway(obj *unstructured.Unstructured
 
 func (k *KubernetesBackend) gatewayToUnstructured(gw *models.Gateway) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "novaedge.io/v1alpha1",
 			"kind":       "ProxyGateway",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      gw.Name,
 				"namespace": gw.Namespace,
 			},
-			"spec": map[string]interface{}{},
+			"spec": map[string]any{},
 		},
 	}
 
@@ -971,16 +971,16 @@ func (k *KubernetesBackend) gatewayToUnstructured(gw *models.Gateway) *unstructu
 		obj.SetResourceVersion(gw.ResourceVersion)
 	}
 
-	spec, ok := obj.Object["spec"].(map[string]interface{})
+	spec, ok := obj.Object["spec"].(map[string]any)
 	if !ok {
 		return obj
 	}
 
 	// Convert listeners
 	if len(gw.Listeners) > 0 {
-		listeners := make([]interface{}, 0, len(gw.Listeners))
+		listeners := make([]any, 0, len(gw.Listeners))
 		for _, l := range gw.Listeners {
-			listener := map[string]interface{}{
+			listener := map[string]any{
 				"name":     l.Name,
 				"port":     l.Port,
 				"protocol": l.Protocol,
@@ -1019,7 +1019,7 @@ func (k *KubernetesBackend) unstructuredToRoute(obj *unstructured.Unstructured) 
 	// Parse backend refs
 	if backends, found, _ := unstructured.NestedSlice(spec, "backendRefs"); found {
 		for _, b := range backends {
-			if bm, ok := b.(map[string]interface{}); ok {
+			if bm, ok := b.(map[string]any); ok {
 				ref := models.BackendRef{
 					Name:   getStringField(bm, "name"),
 					Weight: int(getInt64Field(bm, "weight")),
@@ -1034,14 +1034,14 @@ func (k *KubernetesBackend) unstructuredToRoute(obj *unstructured.Unstructured) 
 
 func (k *KubernetesBackend) routeToUnstructured(rt *models.Route) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "novaedge.io/v1alpha1",
 			"kind":       "ProxyRoute",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      rt.Name,
 				"namespace": rt.Namespace,
 			},
-			"spec": map[string]interface{}{},
+			"spec": map[string]any{},
 		},
 	}
 
@@ -1049,7 +1049,7 @@ func (k *KubernetesBackend) routeToUnstructured(rt *models.Route) *unstructured.
 		obj.SetResourceVersion(rt.ResourceVersion)
 	}
 
-	spec, ok := obj.Object["spec"].(map[string]interface{})
+	spec, ok := obj.Object["spec"].(map[string]any)
 	if !ok {
 		return obj
 	}
@@ -1059,9 +1059,9 @@ func (k *KubernetesBackend) routeToUnstructured(rt *models.Route) *unstructured.
 	}
 
 	if len(rt.BackendRefs) > 0 {
-		backends := make([]interface{}, 0, len(rt.BackendRefs))
+		backends := make([]any, 0, len(rt.BackendRefs))
 		for _, b := range rt.BackendRefs {
-			backend := map[string]interface{}{
+			backend := map[string]any{
 				"name": b.Name,
 			}
 			if b.Weight > 0 {
@@ -1095,7 +1095,7 @@ func (k *KubernetesBackend) unstructuredToBackend(obj *unstructured.Unstructured
 	// Parse endpoints
 	if endpoints, found, _ := unstructured.NestedSlice(spec, "endpoints"); found {
 		for _, e := range endpoints {
-			if em, ok := e.(map[string]interface{}); ok {
+			if em, ok := e.(map[string]any); ok {
 				endpoint := models.Endpoint{
 					Address: getStringField(em, "address"),
 					Weight:  int(getInt64Field(em, "weight")),
@@ -1110,14 +1110,14 @@ func (k *KubernetesBackend) unstructuredToBackend(obj *unstructured.Unstructured
 
 func (k *KubernetesBackend) backendToUnstructured(be *models.Backend) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "novaedge.io/v1alpha1",
 			"kind":       "ProxyBackend",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      be.Name,
 				"namespace": be.Namespace,
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"lbPolicy": be.LBPolicy,
 			},
 		},
@@ -1127,15 +1127,15 @@ func (k *KubernetesBackend) backendToUnstructured(be *models.Backend) *unstructu
 		obj.SetResourceVersion(be.ResourceVersion)
 	}
 
-	spec, ok := obj.Object["spec"].(map[string]interface{})
+	spec, ok := obj.Object["spec"].(map[string]any)
 	if !ok {
 		return obj
 	}
 
 	if len(be.Endpoints) > 0 {
-		endpoints := make([]interface{}, 0, len(be.Endpoints))
+		endpoints := make([]any, 0, len(be.Endpoints))
 		for _, e := range be.Endpoints {
-			endpoint := map[string]interface{}{
+			endpoint := map[string]any{
 				"address": e.Address,
 			}
 			if e.Weight > 0 {
@@ -1171,14 +1171,14 @@ func (k *KubernetesBackend) unstructuredToPolicy(obj *unstructured.Unstructured)
 
 func (k *KubernetesBackend) policyToUnstructured(pol *models.Policy) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "novaedge.io/v1alpha1",
 			"kind":       "ProxyPolicy",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      pol.Name,
 				"namespace": pol.Namespace,
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"type": pol.Type,
 			},
 		},
@@ -1193,7 +1193,7 @@ func (k *KubernetesBackend) policyToUnstructured(pol *models.Policy) *unstructur
 
 // Helper functions
 
-func getStringField(m map[string]interface{}, key string) string {
+func getStringField(m map[string]any, key string) string {
 	if v, ok := m[key]; ok {
 		if s, ok := v.(string); ok {
 			return s
@@ -1202,7 +1202,7 @@ func getStringField(m map[string]interface{}, key string) string {
 	return ""
 }
 
-func getInt64Field(m map[string]interface{}, key string) int64 {
+func getInt64Field(m map[string]any, key string) int64 {
 	if v, ok := m[key]; ok {
 		switch n := v.(type) {
 		case int64:
@@ -1269,14 +1269,14 @@ func (k *KubernetesBackend) unstructuredToCertificate(obj *unstructured.Unstruct
 
 func (k *KubernetesBackend) certificateToUnstructured(cert *models.Certificate) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "novaedge.io/v1alpha1",
 			"kind":       "ProxyCertificate",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cert.Name,
 				"namespace": cert.Namespace,
 			},
-			"spec": map[string]interface{}{},
+			"spec": map[string]any{},
 		},
 	}
 
@@ -1290,24 +1290,24 @@ func (k *KubernetesBackend) certificateToUnstructured(cert *models.Certificate) 
 		obj.SetAnnotations(cert.Annotations)
 	}
 
-	spec, ok := obj.Object["spec"].(map[string]interface{})
+	spec, ok := obj.Object["spec"].(map[string]any)
 	if !ok {
 		return obj
 	}
 
 	if len(cert.Spec.Domains) > 0 {
-		domains := make([]interface{}, len(cert.Spec.Domains))
+		domains := make([]any, len(cert.Spec.Domains))
 		for i, d := range cert.Spec.Domains {
 			domains[i] = d
 		}
 		spec["domains"] = domains
 	}
 
-	issuer := map[string]interface{}{
+	issuer := map[string]any{
 		"type": cert.Spec.Issuer.Type,
 	}
 	if cert.Spec.ACME != nil {
-		acme := map[string]interface{}{}
+		acme := map[string]any{}
 		if cert.Spec.ACME.Server != "" {
 			acme["server"] = cert.Spec.ACME.Server
 		}
@@ -1375,13 +1375,13 @@ func (k *KubernetesBackend) unstructuredToIPPool(obj *unstructured.Unstructured)
 
 func (k *KubernetesBackend) ipPoolToUnstructured(pool *models.IPPool) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "novaedge.io/v1alpha1",
 			"kind":       "ProxyIPPool",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": pool.Name,
 			},
-			"spec": map[string]interface{}{},
+			"spec": map[string]any{},
 		},
 	}
 
@@ -1395,20 +1395,20 @@ func (k *KubernetesBackend) ipPoolToUnstructured(pool *models.IPPool) *unstructu
 		obj.SetAnnotations(pool.Annotations)
 	}
 
-	spec, ok := obj.Object["spec"].(map[string]interface{})
+	spec, ok := obj.Object["spec"].(map[string]any)
 	if !ok {
 		return obj
 	}
 
 	if len(pool.Spec.CIDRs) > 0 {
-		cidrs := make([]interface{}, len(pool.Spec.CIDRs))
+		cidrs := make([]any, len(pool.Spec.CIDRs))
 		for i, c := range pool.Spec.CIDRs {
 			cidrs[i] = c
 		}
 		spec["cidrs"] = cidrs
 	}
 	if len(pool.Spec.Addresses) > 0 {
-		addresses := make([]interface{}, len(pool.Spec.Addresses))
+		addresses := make([]any, len(pool.Spec.Addresses))
 		for i, a := range pool.Spec.Addresses {
 			addresses[i] = a
 		}
@@ -1426,8 +1426,8 @@ type genericModel struct {
 	namespace       string
 	labels          map[string]string
 	annotations     map[string]string
-	spec            map[string]interface{}
-	status          map[string]interface{}
+	spec            map[string]any
+	status          map[string]any
 	resourceVersion string
 }
 
@@ -1547,11 +1547,11 @@ func genericToRemoteClusterModel(g genericModel) *models.RemoteClusterModel {
 }
 
 func genericModelToUnstructured(kind, name, namespace string,
-	labels, annotations map[string]string, spec map[string]interface{}, resourceVersion string) *unstructured.Unstructured {
+	labels, annotations map[string]string, spec map[string]any, resourceVersion string) *unstructured.Unstructured {
 
 	const apiVersion = "novaedge.io/v1alpha1"
 
-	metadata := map[string]interface{}{
+	metadata := map[string]any{
 		"name": name,
 	}
 	if namespace != "" {
@@ -1559,7 +1559,7 @@ func genericModelToUnstructured(kind, name, namespace string,
 	}
 
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": apiVersion,
 			"kind":       kind,
 			"metadata":   metadata,
@@ -1579,13 +1579,13 @@ func genericModelToUnstructured(kind, name, namespace string,
 	if spec != nil {
 		obj.Object["spec"] = spec
 	} else {
-		obj.Object["spec"] = map[string]interface{}{}
+		obj.Object["spec"] = map[string]any{}
 	}
 
 	return obj
 }
 
-func getBoolField(m map[string]interface{}, key string) bool {
+func getBoolField(m map[string]any, key string) bool {
 	if v, ok := m[key]; ok {
 		if b, ok := v.(bool); ok {
 			return b

--- a/cmd/novactl/pkg/webui/mode/standalone.go
+++ b/cmd/novactl/pkg/webui/mode/standalone.go
@@ -30,10 +30,13 @@ import (
 
 var (
 	errConfigPathIsRequired                            = errors.New("config path is required")
-	errGateway                                         = errors.New("gateway '")
-	errRoute2                                          = errors.New("route '")
-	errBackend2                                        = errors.New("backend '")
-	errPolicy                                          = errors.New("policy '")
+	errGatewayNotFound                                 = errors.New("gateway not found")
+	errRouteNotFound                                   = errors.New("route not found")
+	errRouteAlreadyExists                              = errors.New("route already exists")
+	errBackendNotFound                                 = errors.New("backend not found")
+	errBackendAlreadyExists                            = errors.New("backend already exists")
+	errPolicyNotFound                                  = errors.New("policy not found")
+	errPolicyAlreadyExists                             = errors.New("policy already exists")
 	errCertificatesAreNotSupportedInStandaloneMode     = errors.New("certificates are not supported in standalone mode")
 	errIPPoolsAreNotSupportedInStandaloneMode          = errors.New("IP pools are not supported in standalone mode")
 	errNovaEdgeClustersAreNotSupportedInStandaloneMode = errors.New("NovaEdge clusters are not supported in standalone mode")
@@ -180,7 +183,7 @@ func (s *StandaloneBackend) GetGateway(ctx context.Context, namespace, name stri
 		}
 	}
 
-	return nil, fmt.Errorf("%w: %s' not found", errGateway, name)
+	return nil, fmt.Errorf("%w: %s", errGatewayNotFound, name)
 }
 
 // CreateGateway creates a new gateway (adds listeners in standalone mode)
@@ -292,7 +295,7 @@ func (s *StandaloneBackend) DeleteGateway(_ context.Context, _, name string) err
 		return s.save()
 	}
 
-	return fmt.Errorf("%w: %s' not found", errGateway, name)
+	return fmt.Errorf("%w: %s", errGatewayNotFound, name)
 }
 
 // ListRoutes returns all routes
@@ -376,7 +379,7 @@ func (s *StandaloneBackend) GetRoute(ctx context.Context, namespace, name string
 		}
 	}
 
-	return nil, fmt.Errorf("%w: %s' not found", errRoute2, name)
+	return nil, fmt.Errorf("%w: %s", errRouteNotFound, name)
 }
 
 // CreateRoute creates a new route
@@ -391,7 +394,7 @@ func (s *StandaloneBackend) CreateRoute(_ context.Context, route *models.Route) 
 	// Check for duplicate
 	for _, r := range s.config.Routes {
 		if r.Name == route.Name {
-			return nil, fmt.Errorf("%w: %s' already exists", errRoute2, route.Name)
+			return nil, fmt.Errorf("%w: %s' ", errRouteAlreadyExists, route.Name)
 		}
 	}
 
@@ -424,7 +427,7 @@ func (s *StandaloneBackend) UpdateRoute(_ context.Context, route *models.Route) 
 	}
 
 	if !found {
-		return nil, fmt.Errorf("%w: %s' not found", errRoute2, route.Name)
+		return nil, fmt.Errorf("%w: %s", errRouteNotFound, route.Name)
 	}
 
 	if err := s.save(); err != nil {
@@ -450,7 +453,7 @@ func (s *StandaloneBackend) DeleteRoute(_ context.Context, _, name string) error
 		}
 	}
 
-	return fmt.Errorf("%w: %s' not found", errRoute2, name)
+	return fmt.Errorf("%w: %s", errRouteNotFound, name)
 }
 
 // ListBackends returns all backends
@@ -542,7 +545,7 @@ func (s *StandaloneBackend) GetBackend(ctx context.Context, namespace, name stri
 		}
 	}
 
-	return nil, fmt.Errorf("%w: %s' not found", errBackend2, name)
+	return nil, fmt.Errorf("%w: %s", errBackendNotFound, name)
 }
 
 // CreateBackend creates a new backend
@@ -557,7 +560,7 @@ func (s *StandaloneBackend) CreateBackend(_ context.Context, backend *models.Bac
 	// Check for duplicate
 	for _, b := range s.config.Backends {
 		if b.Name == backend.Name {
-			return nil, fmt.Errorf("%w: %s' already exists", errBackend2, backend.Name)
+			return nil, fmt.Errorf("%w: %s' ", errBackendAlreadyExists, backend.Name)
 		}
 	}
 
@@ -590,7 +593,7 @@ func (s *StandaloneBackend) UpdateBackend(_ context.Context, backend *models.Bac
 	}
 
 	if !found {
-		return nil, fmt.Errorf("%w: %s' not found", errBackend2, backend.Name)
+		return nil, fmt.Errorf("%w: %s", errBackendNotFound, backend.Name)
 	}
 
 	if err := s.save(); err != nil {
@@ -616,7 +619,7 @@ func (s *StandaloneBackend) DeleteBackend(_ context.Context, _, name string) err
 		}
 	}
 
-	return fmt.Errorf("%w: %s' not found", errBackend2, name)
+	return fmt.Errorf("%w: %s", errBackendNotFound, name)
 }
 
 // ListPolicies returns all policies
@@ -687,7 +690,7 @@ func (s *StandaloneBackend) GetPolicy(ctx context.Context, namespace, name strin
 		}
 	}
 
-	return nil, fmt.Errorf("%w: %s' not found", errPolicy, name)
+	return nil, fmt.Errorf("%w: %s", errPolicyNotFound, name)
 }
 
 // CreatePolicy creates a new policy
@@ -702,7 +705,7 @@ func (s *StandaloneBackend) CreatePolicy(_ context.Context, policy *models.Polic
 	// Check for duplicate
 	for _, p := range s.config.Policies {
 		if p.Name == policy.Name {
-			return nil, fmt.Errorf("%w: %s' already exists", errPolicy, policy.Name)
+			return nil, fmt.Errorf("%w: %s' ", errPolicyAlreadyExists, policy.Name)
 		}
 	}
 
@@ -735,7 +738,7 @@ func (s *StandaloneBackend) UpdatePolicy(_ context.Context, policy *models.Polic
 	}
 
 	if !found {
-		return nil, fmt.Errorf("%w: %s' not found", errPolicy, policy.Name)
+		return nil, fmt.Errorf("%w: %s", errPolicyNotFound, policy.Name)
 	}
 
 	if err := s.save(); err != nil {
@@ -761,7 +764,7 @@ func (s *StandaloneBackend) DeletePolicy(_ context.Context, _, name string) erro
 		}
 	}
 
-	return fmt.Errorf("%w: %s' not found", errPolicy, name)
+	return fmt.Errorf("%w: %s", errPolicyNotFound, name)
 }
 
 // ListCertificates returns all certificates (not supported in standalone mode)

--- a/cmd/novactl/pkg/webui/models/config.go
+++ b/cmd/novactl/pkg/webui/models/config.go
@@ -456,33 +456,33 @@ type IPAllocation struct {
 
 // NovaEdgeClusterModel represents a NovaEdgeCluster configuration
 type NovaEdgeClusterModel struct {
-	Name            string                 `json:"name" yaml:"name"`
-	Namespace       string                 `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Labels          map[string]string      `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations     map[string]string      `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Spec            map[string]interface{} `json:"spec" yaml:"spec"`
-	Status          map[string]interface{} `json:"status,omitempty" yaml:"status,omitempty"`
-	ResourceVersion string                 `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+	Name            string            `json:"name" yaml:"name"`
+	Namespace       string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Spec            map[string]any    `json:"spec" yaml:"spec"`
+	Status          map[string]any    `json:"status,omitempty" yaml:"status,omitempty"`
+	ResourceVersion string            `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
 }
 
 // FederationModel represents a NovaEdgeFederation configuration
 type FederationModel struct {
-	Name            string                 `json:"name" yaml:"name"`
-	Namespace       string                 `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Labels          map[string]string      `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations     map[string]string      `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Spec            map[string]interface{} `json:"spec" yaml:"spec"`
-	Status          map[string]interface{} `json:"status,omitempty" yaml:"status,omitempty"`
-	ResourceVersion string                 `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+	Name            string            `json:"name" yaml:"name"`
+	Namespace       string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Spec            map[string]any    `json:"spec" yaml:"spec"`
+	Status          map[string]any    `json:"status,omitempty" yaml:"status,omitempty"`
+	ResourceVersion string            `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
 }
 
 // RemoteClusterModel represents a NovaEdgeRemoteCluster configuration
 type RemoteClusterModel struct {
-	Name            string                 `json:"name" yaml:"name"`
-	Namespace       string                 `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Labels          map[string]string      `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations     map[string]string      `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Spec            map[string]interface{} `json:"spec" yaml:"spec"`
-	Status          map[string]interface{} `json:"status,omitempty" yaml:"status,omitempty"`
-	ResourceVersion string                 `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+	Name            string            `json:"name" yaml:"name"`
+	Namespace       string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Spec            map[string]any    `json:"spec" yaml:"spec"`
+	Status          map[string]any    `json:"status,omitempty" yaml:"status,omitempty"`
+	ResourceVersion string            `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
 }

--- a/cmd/novactl/pkg/webui/server.go
+++ b/cmd/novactl/pkg/webui/server.go
@@ -1481,7 +1481,7 @@ func (s *Server) handleAuthSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
+	writeJSON(w, http.StatusOK, map[string]any{
 		"authenticated": authenticated,
 		"authEnabled":   authEnabled,
 		"oidcEnabled":   s.authManager.OIDCEnabled(),

--- a/cmd/novaedge-controller/main.go
+++ b/cmd/novaedge-controller/main.go
@@ -243,6 +243,7 @@ func initVaultIntegration(f *controllerFlags, reconciler *controller.ProxyGatewa
 // initConfigServer creates the config server, wires mesh CA and federation, and starts the gRPC server.
 func initConfigServer(mgr ctrl.Manager, f *controllerFlags, zapLogger *uberzap.Logger) (*grpc.Server, *snapshot.Server) {
 	configServer := snapshot.NewServer(mgr.GetClient())
+	configServer.Start()
 
 	// Initialize mesh CA for issuing workload certificates (only when enabled).
 	if f.meshCAEnabled {

--- a/internal/acme/dns/cloudflare.go
+++ b/internal/acme/dns/cloudflare.go
@@ -84,10 +84,10 @@ type cloudflareRecord struct {
 }
 
 type cloudflareResponse struct {
-	Success  bool                     `json:"success"`
-	Errors   []cloudflareError        `json:"errors"`
-	Result   json.RawMessage          `json:"result"`
-	Messages []map[string]interface{} `json:"messages"`
+	Success  bool              `json:"success"`
+	Errors   []cloudflareError `json:"errors"`
+	Result   json.RawMessage   `json:"result"`
+	Messages []map[string]any  `json:"messages"`
 }
 
 type cloudflareError struct {
@@ -104,7 +104,7 @@ func (p *CloudflareProvider) CreateTXTRecord(ctx context.Context, fqdn, value st
 		return fmt.Errorf("failed to find zone for %s: %w", recordName, err)
 	}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"type":    "TXT",
 		"name":    recordName,
 		"content": value,

--- a/internal/acme/dns/route53.go
+++ b/internal/acme/dns/route53.go
@@ -22,7 +22,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -236,4 +235,3 @@ func getSignatureKey(secret, dateStamp, region, service string) []byte {
 }
 
 // Ensure xml import is used by referencing it.
-var _ = xml.Header

--- a/internal/acme/selfsigned.go
+++ b/internal/acme/selfsigned.go
@@ -24,7 +24,7 @@ var (
 )
 
 // generateKeyPair generates a private/public key pair based on the configured key type.
-func generateKeyPair(keyType string) (privateKey, publicKey interface{}, err error) {
+func generateKeyPair(keyType string) (privateKey, publicKey any, err error) {
 	switch keyType {
 	case KeyTypeEC256:
 		key, genErr := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -211,7 +211,7 @@ func SignCertificate(caCert *Certificate, config *SelfSignedConfig) (*Certificat
 		return nil, errFailedToDecodeCAPrivateKey
 	}
 
-	var caPrivateKey interface{}
+	var caPrivateKey any
 	switch caKeyBlock.Type {
 	case "EC PRIVATE KEY":
 		caPrivateKey, err = x509.ParseECPrivateKey(caKeyBlock.Bytes)

--- a/internal/agent/server/admin.go
+++ b/internal/agent/server/admin.go
@@ -221,11 +221,11 @@ func (a *AdminServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		configVersion = snap.GetVersion()
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"uptime_seconds":  time.Since(a.startedAt).Seconds(),
 		"config_version":  configVersion,
 		"goroutine_count": runtime.NumGoroutine(),
-		"memory": map[string]interface{}{
+		"memory": map[string]any{
 			"alloc_bytes":       memStats.Alloc,
 			"total_alloc_bytes": memStats.TotalAlloc,
 			"sys_bytes":         memStats.Sys,
@@ -250,7 +250,7 @@ func (a *AdminServer) handleStats(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"total_clusters":  totalClusters,
 		"total_routes":    totalRoutes,
 		"total_endpoints": totalEndpoints,
@@ -303,13 +303,13 @@ func (a *AdminServer) handleClusters(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"clusters": clusters})
+	writeJSON(w, http.StatusOK, map[string]any{"clusters": clusters})
 }
 
 func (a *AdminServer) handleConfig(w http.ResponseWriter, _ *http.Request) {
 	snap := a.getSnapshot()
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"version":          "",
 		"num_routes":       0,
 		"num_clusters":     0,
@@ -399,7 +399,7 @@ func (a *AdminServer) handleRoutes(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"routes": routeTable})
+	writeJSON(w, http.StatusOK, map[string]any{"routes": routeTable})
 }
 
 func (a *AdminServer) handleLogging(w http.ResponseWriter, r *http.Request) {

--- a/internal/agent/server/admin_test.go
+++ b/internal/agent/server/admin_test.go
@@ -99,7 +99,7 @@ func TestAdminHealthReturnsJSON(t *testing.T) {
 		t.Fatalf("expected application/json, got %s", ct)
 	}
 
-	var body map[string]interface{}
+	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestAdminStatsReturnsJSON(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	var body map[string]interface{}
+	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
@@ -161,11 +161,11 @@ func TestAdminClustersReturnsJSON(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	var body map[string]interface{}
+	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
-	clusters, ok := body["clusters"].([]interface{})
+	clusters, ok := body["clusters"].([]any)
 	if !ok {
 		t.Fatal("expected clusters array")
 	}
@@ -192,7 +192,7 @@ func TestAdminConfigReturnsJSON(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	var body map[string]interface{}
+	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
@@ -239,11 +239,11 @@ func TestAdminRoutesReturnsJSON(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	var body map[string]interface{}
+	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
-	routes, ok := body["routes"].(map[string]interface{})
+	routes, ok := body["routes"].(map[string]any)
 	if !ok {
 		t.Fatal("expected routes map")
 	}
@@ -371,7 +371,7 @@ func TestAdminNoSnapshotGraceful(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Errorf("%s: expected 200 with no snapshot, got %d", endpoint, rec.Code)
 		}
-		var body map[string]interface{}
+		var body map[string]any
 		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 			t.Errorf("%s: invalid JSON with no snapshot: %v", endpoint, err)
 		}

--- a/internal/controller/certmanager/certificate.go
+++ b/internal/controller/certmanager/certificate.go
@@ -213,10 +213,10 @@ func buildCertificateUnstructured(
 	cert.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 
 	// Build spec
-	spec := map[string]interface{}{
+	spec := map[string]any{
 		"dnsNames":   toInterfaceSlice(dnsNames),
 		"secretName": secretName,
-		"issuerRef": map[string]interface{}{
+		"issuerRef": map[string]any{
 			"name":  issuerName,
 			"kind":  issuerKind,
 			"group": "cert-manager.io",
@@ -232,8 +232,8 @@ func buildCertificateUnstructured(
 }
 
 // toInterfaceSlice converts a string slice to interface slice for unstructured objects.
-func toInterfaceSlice(ss []string) []interface{} {
-	result := make([]interface{}, len(ss))
+func toInterfaceSlice(ss []string) []any {
+	result := make([]any, len(ss))
 	for i, s := range ss {
 		result[i] = s
 	}
@@ -251,7 +251,7 @@ func extractReadyCondition(cert *unstructured.Unstructured) (bool, string, error
 	}
 
 	for _, c := range conditions {
-		condMap, ok := c.(map[string]interface{})
+		condMap, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/internal/controller/certmanager/certificate_extended_test.go
+++ b/internal/controller/certmanager/certificate_extended_test.go
@@ -244,8 +244,8 @@ func TestCertificateManager_GetCertificateStatus_Ready(t *testing.T) {
 	cert.SetName("test-cert")
 	cert.SetNamespace("default")
 
-	conditions := []interface{}{
-		map[string]interface{}{
+	conditions := []any{
+		map[string]any{
 			"type":    "Ready",
 			"status":  "True",
 			"message": "Certificate is up to date",
@@ -280,8 +280,8 @@ func TestCertificateManager_GetCertificateStatus_NotReady(t *testing.T) {
 	cert.SetName("test-cert")
 	cert.SetNamespace("default")
 
-	conditions := []interface{}{
-		map[string]interface{}{
+	conditions := []any{
+		map[string]any{
 			"type":    "Ready",
 			"status":  "False",
 			"message": "Waiting for validation",

--- a/internal/controller/certmanager/cleanup_test.go
+++ b/internal/controller/certmanager/cleanup_test.go
@@ -154,9 +154,9 @@ func createTestCertificate(name, gatewayName string) *unstructured.Unstructured 
 	})
 
 	// Set spec
-	spec := map[string]interface{}{
+	spec := map[string]any{
 		"secretName": name + "-secret",
-		"dnsNames":   []interface{}{"example.com"},
+		"dnsNames":   []any{"example.com"},
 	}
 	_ = unstructured.SetNestedMap(cert.Object, spec, "spec")
 

--- a/internal/controller/certmanager/watcher.go
+++ b/internal/controller/certmanager/watcher.go
@@ -158,7 +158,7 @@ func (w *CertificateWatcher) watch(ctx context.Context) error {
 }
 
 // handleCertificateEvent processes a Certificate watch event.
-func (w *CertificateWatcher) handleCertificateEvent(ctx context.Context, obj interface{}) {
+func (w *CertificateWatcher) handleCertificateEvent(ctx context.Context, obj any) {
 	logger := log.FromContext(ctx).WithName("cert-manager-watcher")
 
 	u, ok := obj.(*unstructured.Unstructured)
@@ -203,7 +203,7 @@ func isCertFailed(cert *unstructured.Unstructured) bool {
 	}
 
 	for _, c := range conditions {
-		condMap, ok := c.(map[string]interface{})
+		condMap, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/internal/controller/certmanager/watcher_test.go
+++ b/internal/controller/certmanager/watcher_test.go
@@ -153,8 +153,8 @@ func TestCertificateWatcher_HandleCertificateEvent_Ready(t *testing.T) {
 	_ = unstructured.SetNestedField(cert.Object, "test-secret", "spec", "secretName")
 
 	// Set Ready condition
-	conditions := []interface{}{
-		map[string]interface{}{
+	conditions := []any{
+		map[string]any{
 			"type":    "Ready",
 			"status":  "True",
 			"message": "Certificate is ready",
@@ -202,13 +202,13 @@ func TestCertificateWatcher_HandleCertificateEvent_Failed(t *testing.T) {
 	cert.SetName("test-cert")
 	cert.SetNamespace("test-ns")
 
-	conditions := []interface{}{
-		map[string]interface{}{
+	conditions := []any{
+		map[string]any{
 			"type":    "Ready",
 			"status":  "False",
 			"message": "Certificate validation failed",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"type":   "Issuing",
 			"status": "False",
 		},
@@ -230,13 +230,13 @@ func TestCertificateWatcher_HandleCertificateEvent_Failed(t *testing.T) {
 func TestIsCertFailed(t *testing.T) {
 	tests := []struct {
 		name       string
-		conditions []interface{}
+		conditions []any
 		expected   bool
 	}{
 		{
 			name: "issuing false indicates failure",
-			conditions: []interface{}{
-				map[string]interface{}{
+			conditions: []any{
+				map[string]any{
 					"type":   "Issuing",
 					"status": "False",
 				},
@@ -245,8 +245,8 @@ func TestIsCertFailed(t *testing.T) {
 		},
 		{
 			name: "issuing true is not failure",
-			conditions: []interface{}{
-				map[string]interface{}{
+			conditions: []any{
+				map[string]any{
 					"type":   "Issuing",
 					"status": "True",
 				},
@@ -255,8 +255,8 @@ func TestIsCertFailed(t *testing.T) {
 		},
 		{
 			name: "no issuing condition is not failure",
-			conditions: []interface{}{
-				map[string]interface{}{
+			conditions: []any{
+				map[string]any{
 					"type":   "Ready",
 					"status": "False",
 				},
@@ -273,7 +273,7 @@ func TestIsCertFailed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cert := &unstructured.Unstructured{
-				Object: make(map[string]interface{}),
+				Object: make(map[string]any),
 			}
 			if tt.conditions != nil {
 				_ = unstructured.SetNestedSlice(cert.Object, tt.conditions, "status", "conditions")

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -21,39 +21,42 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/azrtydxb/novaedge/internal/controller/snapshot"
 )
 
 // Condition reason constants used across controllers
 const (
-	// ConditionReasonValid indicates the resource configuration is valid
-	ConditionReasonValid = "Valid"
-	// ConditionReasonValidationFailed indicates the resource configuration failed validation
+	ConditionReasonValid            = "Valid"
 	ConditionReasonValidationFailed = "ValidationFailed"
 )
 
-// kindGateway is the Gateway API Kind string for Gateway resources.
 const kindGateway = "Gateway"
 
-// triggerConfigUpdate triggers a config update for all nodes via the given server.
-// If server is nil the call is a no-op.
 func triggerConfigUpdate(server *snapshot.Server) {
 	if server != nil {
 		server.TriggerUpdate("")
 	}
 }
 
-// reconcileWithGenerationCheck implements the common CRD reconciliation pattern:
-// fetch the resource, skip if not found, skip if generation already reconciled,
-// run validation, then trigger a config update.
+func defaultControllerOptions() controller.Options {
+	return controller.Options{
+		RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](5*time.Millisecond, 1000*time.Second),
+	}
+}
+
 func reconcileWithGenerationCheck(
 	ctx context.Context,
 	cli client.Client,
@@ -62,7 +65,7 @@ func reconcileWithGenerationCheck(
 	kind string,
 	cfgServer *snapshot.Server,
 	getObservedGeneration func() int64,
-	logFields func() []interface{},
+	logFields func() []any,
 	validate func() error,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -76,8 +79,6 @@ func reconcileWithGenerationCheck(
 		return ctrl.Result{}, err
 	}
 
-	// Skip if already reconciled this generation (ObservedGeneration > 0
-	// ensures first-ever reconciliation always proceeds)
 	observed := getObservedGeneration()
 	if observed != 0 && observed == obj.GetGeneration() {
 		return ctrl.Result{}, nil
@@ -87,7 +88,6 @@ func reconcileWithGenerationCheck(
 
 	if err := validate(); err != nil {
 		logger.Error(err, "Failed to validate "+kind)
-		// Return only the error so controller-runtime applies exponential backoff.
 		return ctrl.Result{}, err
 	}
 
@@ -95,14 +95,15 @@ func reconcileWithGenerationCheck(
 	return ctrl.Result{}, nil
 }
 
-// handleResourceDeletion is a shared helper that deletes an associated proxy resource and removes
-// a finalizer from the source Gateway API resource (Gateway or HTTPRoute).
 func handleResourceDeletion(ctx context.Context, cli client.Client, source client.Object, proxyObj client.Object, kind, finalizerName string) (ctrl.Result, error) {
+	return handleResourceDeletionWithName(ctx, cli, source, proxyObj, source.GetName(), kind, finalizerName)
+}
+
+func handleResourceDeletionWithName(ctx context.Context, cli client.Client, source client.Object, proxyObj client.Object, proxyName, kind, finalizerName string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Handling "+kind+" deletion", "name", source.GetName())
 
-	// Delete associated proxy resource if it exists
-	err := cli.Get(ctx, types.NamespacedName{Name: source.GetName(), Namespace: source.GetNamespace()}, proxyObj)
+	err := cli.Get(ctx, types.NamespacedName{Name: proxyName, Namespace: source.GetNamespace()}, proxyObj)
 	if err == nil {
 		logger.Info("Deleting associated proxy resource", "kind", kind, "name", proxyObj.GetName())
 		if err := cli.Delete(ctx, proxyObj); err != nil && !apierrors.IsNotFound(err) {
@@ -114,7 +115,6 @@ func handleResourceDeletion(ctx context.Context, cli client.Client, source clien
 		return ctrl.Result{}, err
 	}
 
-	// Remove finalizer if it exists
 	if controllerutil.ContainsFinalizer(source, finalizerName) {
 		controllerutil.RemoveFinalizer(source, finalizerName)
 		if err := cli.Update(ctx, source); err != nil {
@@ -123,4 +123,33 @@ func handleResourceDeletion(ctx context.Context, cli client.Client, source clien
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func createOrUpdateResource(ctx context.Context, cli client.Client, kind string, desired, existing client.Object, applySpec func()) error {
+	logger := log.FromContext(ctx)
+
+	err := cli.Get(ctx, client.ObjectKey{
+		Name:      desired.GetName(),
+		Namespace: desired.GetNamespace(),
+	}, existing)
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Creating "+kind, "name", desired.GetName())
+			if err := cli.Create(ctx, desired); err != nil {
+				return fmt.Errorf("failed to create %s: %w", kind, err)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to get %s: %w", kind, err)
+	}
+
+	logger.Info("Updating "+kind, "name", desired.GetName())
+	applySpec()
+	existing.SetLabels(desired.GetLabels())
+	if err := cli.Update(ctx, existing); err != nil {
+		return fmt.Errorf("failed to update %s: %w", kind, err)
+	}
+
+	return nil
 }

--- a/internal/controller/endpointslice_controller.go
+++ b/internal/controller/endpointslice_controller.go
@@ -53,5 +53,6 @@ func (r *EndpointSliceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *EndpointSliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&discoveryv1.EndpointSlice{}).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/federation/antientropy.go
+++ b/internal/controller/federation/antientropy.go
@@ -457,7 +457,7 @@ func (m *AntiEntropyManager) rebuildLocalTree() {
 	}
 
 	// Iterate through tracked resources
-	m.server.resources.Range(func(key, value interface{}) bool {
+	m.server.resources.Range(func(key, value any) bool {
 		keyStr, ok := key.(string)
 		if !ok {
 			return true
@@ -664,7 +664,7 @@ func (m *AntiEntropyManager) handleWeAreAhead(peerName string) *DriftReport {
 
 	// Find resources the peer is missing or has outdated versions of
 	sent := 0
-	m.server.resources.Range(func(key, value interface{}) bool {
+	m.server.resources.Range(func(key, value any) bool {
 		if sent >= m.config.BatchSize {
 			return false
 		}
@@ -785,7 +785,7 @@ func (m *AntiEntropyManager) handlePeerIsAhead(peerName string) *DriftReport {
 func (m *AntiEntropyManager) reconcileWithPeerResources(peerName string, peerResources map[string]*pb.ResourceChange, report *DriftReport) {
 	// Build local resource hashes
 	localHashes := make(map[string]string)
-	m.server.resources.Range(func(key, value interface{}) bool {
+	m.server.resources.Range(func(key, value any) bool {
 		keyStr, ok := key.(string)
 		if !ok {
 			return true
@@ -848,7 +848,7 @@ func (m *AntiEntropyManager) reconcileWithPeerResources(peerName string, peerRes
 			peerKeys[k] = true
 		}
 
-		m.server.resources.Range(func(key, value interface{}) bool {
+		m.server.resources.Range(func(key, value any) bool {
 			if pushed+applied >= m.config.BatchSize {
 				return false
 			}

--- a/internal/controller/federation/server.go
+++ b/internal/controller/federation/server.go
@@ -148,7 +148,7 @@ func (s *Server) Stop() {
 	close(s.shutdownCh)
 
 	// Cancel all active streams
-	s.activeStreams.Range(func(_, value interface{}) bool {
+	s.activeStreams.Range(func(_, value any) bool {
 		if cancel, ok := value.(context.CancelFunc); ok {
 			cancel()
 		}
@@ -533,7 +533,7 @@ func (s *Server) mergeResources(local, remote *TrackedResource) (*TrackedResourc
 	// For now, we implement a simple JSON merge for maps
 	// In practice, this should be resource-type specific
 
-	var localData, remoteData map[string]interface{}
+	var localData, remoteData map[string]any
 	if err := json.Unmarshal(local.Data, &localData); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal local data: %w", err)
 	}
@@ -565,15 +565,15 @@ func (s *Server) mergeResources(local, remote *TrackedResource) (*TrackedResourc
 }
 
 // mergeMaps recursively merges two maps
-func mergeMaps(base, overlay map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
+func mergeMaps(base, overlay map[string]any) map[string]any {
+	result := make(map[string]any)
 	for k, v := range base {
 		result[k] = v
 	}
 	for k, v := range overlay {
 		if baseVal, ok := result[k]; ok {
-			if baseMap, ok := baseVal.(map[string]interface{}); ok {
-				if overlayMap, ok := v.(map[string]interface{}); ok {
+			if baseMap, ok := baseVal.(map[string]any); ok {
+				if overlayMap, ok := v.(map[string]any); ok {
 					result[k] = mergeMaps(baseMap, overlayMap)
 					continue
 				}
@@ -649,7 +649,7 @@ func (s *Server) GetState(_ context.Context, req *pb.GetStateRequest) (*pb.GetSt
 
 	// Count resources by type
 	resourceCounts := make(map[string]int32)
-	s.resources.Range(func(_, value interface{}) bool {
+	s.resources.Range(func(_, value any) bool {
 		res, ok := value.(*TrackedResource)
 		if !ok {
 			return true
@@ -660,7 +660,7 @@ func (s *Server) GetState(_ context.Context, req *pb.GetStateRequest) (*pb.GetSt
 
 	// Collect last sync times
 	lastSyncTimes := make(map[string]int64)
-	s.peerStates.Range(func(key, value interface{}) bool {
+	s.peerStates.Range(func(key, value any) bool {
 		state, ok := value.(*PeerState)
 		if !ok {
 			return true
@@ -677,7 +677,7 @@ func (s *Server) GetState(_ context.Context, req *pb.GetStateRequest) (*pb.GetSt
 
 	// Count pending conflicts
 	var conflictCount int32
-	s.conflicts.Range(func(_, _ interface{}) bool {
+	s.conflicts.Range(func(_, _ any) bool {
 		conflictCount++
 		return true
 	})
@@ -728,7 +728,7 @@ func (s *Server) RequestFullSync(req *pb.FullSyncRequest, stream pb.FederationSe
 	var resources []*pb.ResourceChange
 	requesterVC := NewVectorClockFromMap(req.VectorClock)
 
-	s.resources.Range(func(_, value interface{}) bool {
+	s.resources.Range(func(_, value any) bool {
 		res, ok := value.(*TrackedResource)
 		if !ok {
 			return true
@@ -914,7 +914,7 @@ func (s *Server) GetStats() SyncStats {
 // GetPeerStates returns the state of all peers
 func (s *Server) GetPeerStates() map[string]*PeerState {
 	result := make(map[string]*PeerState)
-	s.peerStates.Range(func(key, value interface{}) bool {
+	s.peerStates.Range(func(key, value any) bool {
 		keyStr, ok := key.(string)
 		if !ok {
 			return true
@@ -932,7 +932,7 @@ func (s *Server) GetPeerStates() map[string]*PeerState {
 // GetConflicts returns all pending conflicts
 func (s *Server) GetConflicts() []*ConflictInfo {
 	var conflicts []*ConflictInfo
-	s.conflicts.Range(func(_, value interface{}) bool {
+	s.conflicts.Range(func(_, value any) bool {
 		conflict, ok := value.(*ConflictInfo)
 		if !ok {
 			return true
@@ -991,7 +991,7 @@ func (s *Server) getPhase() Phase {
 	connectedCount := 0
 	totalPeers := len(s.config.Peers)
 
-	s.peerStates.Range(func(_, value interface{}) bool {
+	s.peerStates.Range(func(_, value any) bool {
 		state, ok := value.(*PeerState)
 		if !ok {
 			return true
@@ -1033,7 +1033,7 @@ func (s *Server) cleanupTombstones(ctx context.Context) {
 			return
 		case <-ticker.C:
 			now := time.Now()
-			s.tombstones.Range(func(key, value interface{}) bool {
+			s.tombstones.Range(func(key, value any) bool {
 				tombstone, ok := value.(*Tombstone)
 				if !ok {
 					return true

--- a/internal/controller/federation/splitbrain.go
+++ b/internal/controller/federation/splitbrain.go
@@ -682,7 +682,7 @@ func (d *SplitBrainDetector) getUnreachablePeerNames() []string {
 	// Get all known peers from server
 	var unreachable []string
 	if d.server != nil {
-		d.server.peerStates.Range(func(key, _ interface{}) bool {
+		d.server.peerStates.Range(func(key, _ any) bool {
 			peerName, ok := key.(string)
 			if !ok {
 				return true
@@ -872,16 +872,16 @@ func (d *SplitBrainDetector) CleanupStaleAgentReports() {
 }
 
 // GetAgentReachabilityStats returns statistics about agent reachability
-func (d *SplitBrainDetector) GetAgentReachabilityStats() map[string]interface{} {
+func (d *SplitBrainDetector) GetAgentReachabilityStats() map[string]any {
 	info := d.GetAgentQuorumInfo()
 	if info == nil {
-		return map[string]interface{}{
+		return map[string]any{
 			"mode":    string(d.config.QuorumMode),
 			"enabled": false,
 		}
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"mode":             string(d.config.QuorumMode),
 		"enabled":          true,
 		"totalAgents":      info.TotalAgents,

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -441,5 +441,6 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1.Gateway{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyGateway{}).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/gatewayclass_controller.go
+++ b/internal/controller/gatewayclass_controller.go
@@ -105,5 +105,6 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *GatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1.GatewayClass{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -29,7 +29,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -311,33 +310,12 @@ func (r *GRPCRouteReconciler) reconcileGRPCBackends(ctx context.Context, grpcRou
 	return nil
 }
 
-// handleGRPCRouteDeletion handles cleanup when a GRPCRoute is deleted
+// handleGRPCRouteDeletion handles cleanup when a GRPCRoute is deleted.
+// It delegates to the shared handleResourceDeletionWithName helper, passing
+// the "grpc-" prefixed name so the correct ProxyRoute is looked up.
 func (r *GRPCRouteReconciler) handleGRPCRouteDeletion(ctx context.Context, grpcRoute *gatewayv1.GRPCRoute) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-	logger.Info("Handling GRPCRoute deletion", "name", grpcRoute.Name)
-
-	grpcRouteName := "grpc-" + grpcRoute.Name
-	proxyRoute := &novaedgev1alpha1.ProxyRoute{}
-	err := r.Get(ctx, types.NamespacedName{Name: grpcRouteName, Namespace: grpcRoute.Namespace}, proxyRoute)
-	if err == nil {
-		logger.Info("Deleting associated ProxyRoute", "name", proxyRoute.Name)
-		if err := r.Delete(ctx, proxyRoute); err != nil && !apierrors.IsNotFound(err) {
-			logger.Error(err, "Failed to delete ProxyRoute")
-			return ctrl.Result{}, err
-		}
-	} else if !apierrors.IsNotFound(err) {
-		logger.Error(err, "Failed to get ProxyRoute for deletion")
-		return ctrl.Result{}, err
-	}
-
-	if controllerutil.ContainsFinalizer(grpcRoute, "novaedge.io/grpcroute-finalizer") {
-		controllerutil.RemoveFinalizer(grpcRoute, "novaedge.io/grpcroute-finalizer")
-		if err := r.Update(ctx, grpcRoute); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
-	return ctrl.Result{}, nil
+	return handleResourceDeletionWithName(ctx, r.Client, grpcRoute, &novaedgev1alpha1.ProxyRoute{},
+		"grpc-"+grpcRoute.Name, "GRPCRoute", "novaedge.io/grpcroute-finalizer")
 }
 
 // updateGRPCRouteStatus updates the GRPCRoute status with the given condition
@@ -358,5 +336,6 @@ func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gatewayv1.GRPCRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
 		Owns(&novaedgev1alpha1.ProxyBackend{}).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -387,5 +387,6 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gatewayv1.HTTPRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
 		Owns(&novaedgev1alpha1.ProxyBackend{}).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -20,22 +20,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	novaedgev1alpha1 "github.com/azrtydxb/novaedge/api/v1alpha1"
 	"github.com/azrtydxb/novaedge/internal/controller/snapshot"
@@ -203,32 +199,7 @@ func (r *IngressReconciler) handleDeletion(ctx context.Context, ingress *network
 // reconcileResource creates or updates a NovaEdge proxy resource.
 // The kind parameter is used for logging (e.g. "ProxyGateway").
 func (r *IngressReconciler) reconcileResource(ctx context.Context, kind string, desired, existing client.Object, applySpec func()) error {
-	logger := log.FromContext(ctx)
-
-	err := r.Get(ctx, client.ObjectKey{
-		Name:      desired.GetName(),
-		Namespace: desired.GetNamespace(),
-	}, existing)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("Creating "+kind, "name", desired.GetName())
-			if err := r.Create(ctx, desired); err != nil {
-				return fmt.Errorf("failed to create %s: %w", kind, err)
-			}
-			return nil
-		}
-		return fmt.Errorf("failed to get %s: %w", kind, err)
-	}
-
-	logger.Info("Updating "+kind, "name", desired.GetName())
-	applySpec()
-	existing.SetLabels(desired.GetLabels())
-	if err := r.Update(ctx, existing); err != nil {
-		return fmt.Errorf("failed to update %s: %w", kind, err)
-	}
-
-	return nil
+	return createOrUpdateResource(ctx, r.Client, kind, desired, existing, applySpec)
 }
 
 // reconcileGateway creates or updates a ProxyGateway
@@ -258,9 +229,7 @@ func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&novaedgev1alpha1.ProxyGateway{}).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
 		Owns(&novaedgev1alpha1.ProxyBackend{}).
-		WithOptions(controller.Options{
-			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](5*time.Millisecond, 1000*time.Second),
-		}).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }
 

--- a/internal/controller/proxybackend_controller.go
+++ b/internal/controller/proxybackend_controller.go
@@ -55,7 +55,7 @@ func (r *ProxyBackendReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	backend := &novaedgev1alpha1.ProxyBackend{}
 	return reconcileWithGenerationCheck(ctx, r.Client, req, backend, "ProxyBackend", r.ConfigServer,
 		func() int64 { return backend.Status.ObservedGeneration },
-		func() []interface{} { return []interface{}{"name", backend.Name, "lbPolicy", backend.Spec.LBPolicy} },
+		func() []any { return []any{"name", backend.Name, "lbPolicy", backend.Spec.LBPolicy} },
 		func() error { return r.validateAndUpdateStatus(ctx, backend) },
 	)
 }
@@ -198,5 +198,6 @@ func (r *ProxyBackendReconciler) validateAndUpdateStatus(ctx context.Context, ba
 func (r *ProxyBackendReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novaedgev1alpha1.ProxyBackend{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/proxygateway_controller.go
+++ b/internal/controller/proxygateway_controller.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,14 +28,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	novaedgev1alpha1 "github.com/azrtydxb/novaedge/api/v1alpha1"
 	"github.com/azrtydxb/novaedge/internal/controller/certmanager"
@@ -75,34 +71,25 @@ type ProxyGatewayReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop
 func (r *ProxyGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
-	// Fetch the ProxyGateway instance
 	gateway := &novaedgev1alpha1.ProxyGateway{}
-	err := r.Get(ctx, req.NamespacedName, gateway)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("ProxyGateway resource not found. Ignoring since object must be deleted")
-			return ctrl.Result{}, nil
-		}
-		logger.Error(err, "Failed to get ProxyGateway")
-		return ctrl.Result{}, err
-	}
+	return reconcileWithGenerationCheck(ctx, r.Client, req, gateway, "ProxyGateway", r.ConfigServer,
+		func() int64 { return gateway.Status.ObservedGeneration },
+		func() []any { return []any{"name", gateway.Name} },
+		func() error { return r.reconcileGateway(ctx, gateway) },
+	)
+}
 
-	// Skip if already reconciled this generation (ObservedGeneration > 0
-	// ensures first-ever reconciliation always proceeds)
-	if gateway.Status.ObservedGeneration != 0 && gateway.Status.ObservedGeneration == gateway.Generation {
-		return ctrl.Result{}, nil
-	}
-
-	logger.Info("Reconciling ProxyGateway", "name", gateway.Name)
+// reconcileGateway performs the gateway-specific reconciliation logic:
+// loadBalancerClass filtering, cert-manager, Vault PKI, and status validation.
+func (r *ProxyGatewayReconciler) reconcileGateway(ctx context.Context, gateway *novaedgev1alpha1.ProxyGateway) error {
+	logger := log.FromContext(ctx)
 
 	// Check loadBalancerClass: only reconcile gateways matching our class
 	if !r.shouldReconcileGateway(gateway) {
 		logger.Info("Skipping gateway with non-matching loadBalancerClass",
 			"class", gateway.Spec.LoadBalancerClass,
 			"controllerClass", r.ControllerClass)
-		return ctrl.Result{}, nil
+		return nil
 	}
 
 	// Ensure cert-manager Certificate CRs for gateways with cert-manager annotations
@@ -122,15 +109,7 @@ func (r *ProxyGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Validate and update status
-	if err := r.validateAndUpdateStatus(ctx, gateway); err != nil {
-		logger.Error(err, "Failed to validate gateway")
-		return ctrl.Result{RequeueAfter: time.Second}, err
-	}
-
-	// Trigger config update for all nodes
-	triggerConfigUpdate(r.ConfigServer)
-
-	return ctrl.Result{}, nil
+	return r.validateAndUpdateStatus(ctx, gateway)
 }
 
 // ensureVaultCertificates issues certificates from Vault PKI for listeners that reference VaultCertRef,
@@ -326,8 +305,6 @@ func (r *ProxyGatewayReconciler) shouldReconcileGateway(gateway *novaedgev1alpha
 func (r *ProxyGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novaedgev1alpha1.ProxyGateway{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		WithOptions(controller.Options{
-			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](5*time.Millisecond, 1000*time.Second),
-		}).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/proxypolicy_controller.go
+++ b/internal/controller/proxypolicy_controller.go
@@ -52,38 +52,14 @@ type ProxyPolicyReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop
 func (r *ProxyPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
-	// Fetch the ProxyPolicy instance
 	policy := &novaedgev1alpha1.ProxyPolicy{}
-	err := r.Get(ctx, req.NamespacedName, policy)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("ProxyPolicy resource not found. Ignoring since object must be deleted")
-			return ctrl.Result{}, nil
-		}
-		logger.Error(err, "Failed to get ProxyPolicy")
-		return ctrl.Result{}, err
-	}
-
-	// Skip if already reconciled this generation (ObservedGeneration > 0
-	// ensures first-ever reconciliation always proceeds)
-	if policy.Status.ObservedGeneration != 0 && policy.Status.ObservedGeneration == policy.Generation {
-		return ctrl.Result{}, nil
-	}
-
-	logger.Info("Reconciling ProxyPolicy", "name", policy.Name, "type", policy.Spec.Type, "target", policy.Spec.TargetRef.Name)
-
-	// Validate and update status
-	if err := r.validateAndUpdateStatus(ctx, policy); err != nil {
-		logger.Error(err, "Failed to validate policy")
-		return ctrl.Result{}, err
-	}
-
-	// Trigger config update for all nodes
-	triggerConfigUpdate(r.ConfigServer)
-
-	return ctrl.Result{}, nil
+	return reconcileWithGenerationCheck(ctx, r.Client, req, policy, "ProxyPolicy", r.ConfigServer,
+		func() int64 { return policy.Status.ObservedGeneration },
+		func() []any {
+			return []any{"name", policy.Name, "type", policy.Spec.Type, "target", policy.Spec.TargetRef.Name}
+		},
+		func() error { return r.validateAndUpdateStatus(ctx, policy) },
+	)
 }
 
 // validateTargetRef validates the policy's target reference exists.
@@ -303,5 +279,6 @@ func (r *ProxyPolicyReconciler) validateAndUpdateStatus(ctx context.Context, pol
 func (r *ProxyPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novaedgev1alpha1.ProxyPolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/proxyroute_controller.go
+++ b/internal/controller/proxyroute_controller.go
@@ -52,7 +52,7 @@ func (r *ProxyRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	route := &novaedgev1alpha1.ProxyRoute{}
 	return reconcileWithGenerationCheck(ctx, r.Client, req, route, "ProxyRoute", r.ConfigServer,
 		func() int64 { return route.Status.ObservedGeneration },
-		func() []interface{} { return []interface{}{"name", route.Name, "hostnames", route.Spec.Hostnames} },
+		func() []any { return []any{"name", route.Name, "hostnames", route.Spec.Hostnames} },
 		func() error { return r.validateAndUpdateStatus(ctx, route) },
 	)
 }
@@ -144,5 +144,6 @@ func (r *ProxyRouteReconciler) validateAndUpdateStatus(ctx context.Context, rout
 func (r *ProxyRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novaedgev1alpha1.ProxyRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/proxywanlink_controller.go
+++ b/internal/controller/proxywanlink_controller.go
@@ -111,7 +111,7 @@ func (r *ProxyWANLinkReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: link.Generation,
 		LastTransitionTime: metav1.Now(),
-		Reason:             "Reconciled",
+		Reason:             ConditionReasonValid,
 		Message:            "WAN link configured successfully",
 	})
 
@@ -129,5 +129,6 @@ func (r *ProxyWANLinkReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *ProxyWANLinkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novaedgev1alpha1.ProxyWANLink{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/proxywanpolicy_controller.go
+++ b/internal/controller/proxywanpolicy_controller.go
@@ -109,7 +109,7 @@ func (r *ProxyWANPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: policy.Generation,
 		LastTransitionTime: metav1.Now(),
-		Reason:             "Reconciled",
+		Reason:             ConditionReasonValid,
 		Message:            "WAN policy configured successfully",
 	})
 
@@ -127,5 +127,6 @@ func (r *ProxyWANPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (r *ProxyWANPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&novaedgev1alpha1.ProxyWANPolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/snapshot/server.go
+++ b/internal/controller/snapshot/server.go
@@ -112,9 +112,10 @@ type Server struct {
 	shutdownCh chan struct{}
 }
 
-// NewServer creates a new gRPC config server
+// NewServer creates a new gRPC config server.
+// Call Start() after construction to launch background goroutines.
 func NewServer(client client.Client) *Server {
-	s := &Server{
+	return &Server{
 		client:             client,
 		builder:            NewBuilder(client),
 		cache:              NewCache(),
@@ -122,11 +123,12 @@ func NewServer(client client.Client) *Server {
 		remoteAgentTracker: NewRemoteAgentTracker(),
 		shutdownCh:         make(chan struct{}),
 	}
+}
 
-	// Start the status cleanup goroutine
+// Start launches background goroutines such as the stale-agent cleanup loop.
+// It must be called after NewServer and before the server begins handling requests.
+func (s *Server) Start() {
 	go s.cleanupStaleAgents()
-
-	return s
 }
 
 // SetRemoteClusterHandler sets the handler for remote cluster updates
@@ -538,7 +540,7 @@ func (s *Server) GetAgentStatus(nodeName string) (*AgentStatusInfo, bool) {
 func (s *Server) GetAllAgentStatuses() []*AgentStatusInfo {
 	statuses := make([]*AgentStatusInfo, 0)
 
-	s.statusMap.Range(func(_, value interface{}) bool {
+	s.statusMap.Range(func(_, value any) bool {
 		status, ok := value.(*AgentStatusInfo)
 		if !ok {
 			return true
@@ -571,7 +573,7 @@ func (s *Server) cleanupStaleAgents() {
 		select {
 		case <-ticker.C:
 			now := time.Now()
-			s.statusMap.Range(func(key, value interface{}) bool {
+			s.statusMap.Range(func(key, value any) bool {
 				status, ok := value.(*AgentStatusInfo)
 				if !ok {
 					return true

--- a/internal/controller/tcproute_controller.go
+++ b/internal/controller/tcproute_controller.go
@@ -56,6 +56,7 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1alpha2.TCPRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }
 
@@ -85,5 +86,6 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1alpha2.TLSRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&novaedgev1alpha1.ProxyRoute{}).
+		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/internal/controller/vault/client.go
+++ b/internal/controller/vault/client.go
@@ -227,7 +227,7 @@ func (c *Client) authenticateKubernetes(ctx context.Context) error {
 
 	// POST to /v1/auth/{mount}/login
 	loginPath := fmt.Sprintf("auth/%s/login", mountPath)
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"role": config.Role,
 		"jwt":  string(jwt),
 	}
@@ -277,7 +277,7 @@ func (c *Client) authenticateAppRole(ctx context.Context) error {
 	}
 
 	loginPath := fmt.Sprintf("auth/%s/login", mountPath)
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"role_id":   config.RoleID,
 		"secret_id": config.SecretID,
 	}
@@ -338,7 +338,7 @@ func (c *Client) Read(ctx context.Context, path string) (*Response, error) {
 }
 
 // Write writes data to Vault.
-func (c *Client) Write(ctx context.Context, path string, data map[string]interface{}) (*Response, error) {
+func (c *Client) Write(ctx context.Context, path string, data map[string]any) (*Response, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.httpClient.Write(ctx, path, data)

--- a/internal/controller/vault/http.go
+++ b/internal/controller/vault/http.go
@@ -46,10 +46,10 @@ const (
 // Response represents a response from the Vault HTTP API.
 type Response struct {
 	// Auth contains authentication info (for login responses)
-	Auth map[string]interface{} `json:"auth,omitempty"`
+	Auth map[string]any `json:"auth,omitempty"`
 
 	// Data contains the secret data
-	Data map[string]interface{} `json:"data,omitempty"`
+	Data map[string]any `json:"data,omitempty"`
 
 	// LeaseDuration is the lease duration in seconds
 	LeaseDuration int `json:"lease_duration,omitempty"`
@@ -77,7 +77,7 @@ func (c *vaultHTTPClient) Read(ctx context.Context, path string) (*Response, err
 }
 
 // Write writes to the Vault API (POST/PUT request).
-func (c *vaultHTTPClient) Write(ctx context.Context, path string, data map[string]interface{}) (*Response, error) {
+func (c *vaultHTTPClient) Write(ctx context.Context, path string, data map[string]any) (*Response, error) {
 	url := c.buildURL(path)
 
 	var body io.Reader

--- a/internal/controller/vault/kv.go
+++ b/internal/controller/vault/kv.go
@@ -55,7 +55,7 @@ type KVManager struct {
 
 // cachedSecret stores a cached secret with expiry time.
 type cachedSecret struct {
-	data      map[string]interface{}
+	data      map[string]any
 	fetchedAt time.Time
 	ttl       time.Duration
 }
@@ -79,7 +79,7 @@ func NewKVManager(client *Client, logger *zap.Logger) *KVManager {
 
 // ReadSecret reads a secret from Vault KV engine.
 // For KV v2, the path is automatically adjusted to include "data/".
-func (k *KVManager) ReadSecret(ctx context.Context, engine KVEngine, path string) (map[string]interface{}, error) {
+func (k *KVManager) ReadSecret(ctx context.Context, engine KVEngine, path string) (map[string]any, error) {
 	apiPath := k.buildKVPath(engine, path)
 
 	resp, err := k.client.Read(ctx, apiPath)
@@ -93,7 +93,7 @@ func (k *KVManager) ReadSecret(ctx context.Context, engine KVEngine, path string
 
 	// KV v2 wraps data in a nested "data" key
 	if engine == KVEngineV2 {
-		if nestedData, ok := resp.Data["data"].(map[string]interface{}); ok {
+		if nestedData, ok := resp.Data["data"].(map[string]any); ok {
 			return nestedData, nil
 		}
 		return nil, fmt.Errorf("%w: %s", errUnexpectedKVV2ResponseStructureAtPath, path)
@@ -124,7 +124,7 @@ func (k *KVManager) ReadSecretKey(ctx context.Context, engine KVEngine, path, ke
 
 // ReadSecretCached reads a secret with caching support.
 // If the secret is in cache and not expired, the cached version is returned.
-func (k *KVManager) ReadSecretCached(ctx context.Context, engine KVEngine, path string, cacheTTL time.Duration) (map[string]interface{}, error) {
+func (k *KVManager) ReadSecretCached(ctx context.Context, engine KVEngine, path string, cacheTTL time.Duration) (map[string]any, error) {
 	cacheKey := fmt.Sprintf("%s:%s", engine, path)
 
 	// Check cache
@@ -169,12 +169,12 @@ func (k *KVManager) InvalidateAllCache() {
 }
 
 // WriteSecret writes a secret to Vault KV engine.
-func (k *KVManager) WriteSecret(ctx context.Context, engine KVEngine, path string, data map[string]interface{}) error {
+func (k *KVManager) WriteSecret(ctx context.Context, engine KVEngine, path string, data map[string]any) error {
 	apiPath := k.buildKVPath(engine, path)
 
-	var payload map[string]interface{}
+	var payload map[string]any
 	if engine == KVEngineV2 {
-		payload = map[string]interface{}{
+		payload = map[string]any{
 			"data": data,
 		}
 	} else {

--- a/internal/controller/vault/kv_test.go
+++ b/internal/controller/vault/kv_test.go
@@ -43,7 +43,7 @@ func TestKVManager_BuildKVPath_V2(t *testing.T) {
 
 func TestKVManager_CacheExpiry(t *testing.T) {
 	cached := &cachedSecret{
-		data:      map[string]interface{}{"key": "value"},
+		data:      map[string]any{"key": "value"},
 		fetchedAt: time.Now().Add(-10 * time.Minute),
 		ttl:       5 * time.Minute,
 	}
@@ -64,7 +64,7 @@ func TestKVManager_InvalidateCache(t *testing.T) {
 	// Add to cache
 	kv.mu.Lock()
 	kv.cache["kv-v2:secret/test"] = &cachedSecret{
-		data:      map[string]interface{}{"key": "value"},
+		data:      map[string]any{"key": "value"},
 		fetchedAt: time.Now(),
 		ttl:       5 * time.Minute,
 	}
@@ -94,8 +94,8 @@ func TestKVManager_InvalidateAllCache(t *testing.T) {
 	kv := NewKVManager(nil, zap.NewNop())
 
 	kv.mu.Lock()
-	kv.cache["key1"] = &cachedSecret{data: map[string]interface{}{"a": "1"}}
-	kv.cache["key2"] = &cachedSecret{data: map[string]interface{}{"b": "2"}}
+	kv.cache["key1"] = &cachedSecret{data: map[string]any{"a": "1"}}
+	kv.cache["key2"] = &cachedSecret{data: map[string]any{"b": "2"}}
 	kv.mu.Unlock()
 
 	kv.InvalidateAllCache()

--- a/internal/controller/vault/pki.go
+++ b/internal/controller/vault/pki.go
@@ -101,7 +101,7 @@ func (p *PKIManager) IssueCertificate(ctx context.Context, req *PKIRequest) (*PK
 
 	path := fmt.Sprintf("%s/issue/%s", req.MountPath, req.Role)
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"common_name": req.CommonName,
 	}
 
@@ -148,7 +148,7 @@ func (p *PKIManager) IssueCertificate(ctx context.Context, req *PKIRequest) (*PK
 	}
 
 	// Parse CA chain
-	if chain, ok := resp.Data["ca_chain"].([]interface{}); ok {
+	if chain, ok := resp.Data["ca_chain"].([]any); ok {
 		for _, c := range chain {
 			if chainStr, ok := c.(string); ok {
 				cert.CAChain = append(cert.CAChain, chainStr)
@@ -178,7 +178,7 @@ func (p *PKIManager) IssueCertificate(ctx context.Context, req *PKIRequest) (*PK
 func (p *PKIManager) RevokeCertificate(ctx context.Context, mountPath, serialNumber string) error {
 	path := fmt.Sprintf("%s/revoke", mountPath)
 
-	_, err := p.client.Write(ctx, path, map[string]interface{}{
+	_, err := p.client.Write(ctx, path, map[string]any{
 		"serial_number": serialNumber,
 	})
 	if err != nil {

--- a/internal/pkg/errors/errors.go
+++ b/internal/pkg/errors/errors.go
@@ -97,12 +97,12 @@ var (
 
 // NetworkError represents network-related errors
 type NetworkError struct {
-	Op      string                 // Operation that failed (e.g., "dial", "connect", "read")
-	Host    string                 // Host or address
-	Port    int32                  // Port number
-	Message string                 // Error message
-	Err     error                  // Underlying error
-	Fields  map[string]interface{} // Additional structured context
+	Op      string         // Operation that failed (e.g., "dial", "connect", "read")
+	Host    string         // Host or address
+	Port    int32          // Port number
+	Message string         // Error message
+	Err     error          // Underlying error
+	Fields  map[string]any // Additional structured context
 }
 
 func (e *NetworkError) Error() string {
@@ -133,18 +133,18 @@ func (e *NetworkError) Unwrap() error {
 }
 
 // WithField adds a structured field to the error
-func (e *NetworkError) WithField(key string, value interface{}) *NetworkError {
+func (e *NetworkError) WithField(key string, value any) *NetworkError {
 	if e.Fields == nil {
-		e.Fields = make(map[string]interface{})
+		e.Fields = make(map[string]any)
 	}
 	e.Fields[key] = value
 	return e
 }
 
 // WithFields adds multiple structured fields to the error
-func (e *NetworkError) WithFields(fields map[string]interface{}) *NetworkError {
+func (e *NetworkError) WithFields(fields map[string]any) *NetworkError {
 	if e.Fields == nil {
-		e.Fields = make(map[string]interface{})
+		e.Fields = make(map[string]any)
 	}
 	for k, v := range fields {
 		e.Fields[k] = v
@@ -156,17 +156,17 @@ func (e *NetworkError) WithFields(fields map[string]interface{}) *NetworkError {
 func NewNetworkError(message string) *NetworkError {
 	return &NetworkError{
 		Message: message,
-		Fields:  make(map[string]interface{}),
+		Fields:  make(map[string]any),
 	}
 }
 
 // ConfigError represents configuration-related errors
 type ConfigError struct {
-	Field   string                 // Configuration field that caused error
-	Value   interface{}            // Invalid value
-	Message string                 // Error message
-	Err     error                  // Underlying error
-	Fields  map[string]interface{} // Additional structured context
+	Field   string         // Configuration field that caused error
+	Value   any            // Invalid value
+	Message string         // Error message
+	Err     error          // Underlying error
+	Fields  map[string]any // Additional structured context
 }
 
 func (e *ConfigError) Error() string {
@@ -193,18 +193,18 @@ func (e *ConfigError) Unwrap() error {
 }
 
 // WithField adds a structured field to the error
-func (e *ConfigError) WithField(key string, value interface{}) *ConfigError {
+func (e *ConfigError) WithField(key string, value any) *ConfigError {
 	if e.Fields == nil {
-		e.Fields = make(map[string]interface{})
+		e.Fields = make(map[string]any)
 	}
 	e.Fields[key] = value
 	return e
 }
 
 // WithFields adds multiple structured fields to the error
-func (e *ConfigError) WithFields(fields map[string]interface{}) *ConfigError {
+func (e *ConfigError) WithFields(fields map[string]any) *ConfigError {
 	if e.Fields == nil {
-		e.Fields = make(map[string]interface{})
+		e.Fields = make(map[string]any)
 	}
 	for k, v := range fields {
 		e.Fields[k] = v
@@ -216,19 +216,19 @@ func (e *ConfigError) WithFields(fields map[string]interface{}) *ConfigError {
 func NewConfigError(message string) *ConfigError {
 	return &ConfigError{
 		Message: message,
-		Fields:  make(map[string]interface{}),
+		Fields:  make(map[string]any),
 	}
 }
 
 // ValidationError represents validation-related errors
 type ValidationError struct {
-	Field    string                 // Field that failed validation
-	Value    interface{}            // Invalid value
-	Rule     string                 // Validation rule that failed
-	Message  string                 // Error message
-	Err      error                  // Underlying error
-	Fields   map[string]interface{} // Additional structured context
-	Children []*ValidationError     // Nested validation errors
+	Field    string             // Field that failed validation
+	Value    any                // Invalid value
+	Rule     string             // Validation rule that failed
+	Message  string             // Error message
+	Err      error              // Underlying error
+	Fields   map[string]any     // Additional structured context
+	Children []*ValidationError // Nested validation errors
 }
 
 func (e *ValidationError) Error() string {
@@ -268,18 +268,18 @@ func (e *ValidationError) Unwrap() error {
 }
 
 // WithField adds a structured field to the error
-func (e *ValidationError) WithField(key string, value interface{}) *ValidationError {
+func (e *ValidationError) WithField(key string, value any) *ValidationError {
 	if e.Fields == nil {
-		e.Fields = make(map[string]interface{})
+		e.Fields = make(map[string]any)
 	}
 	e.Fields[key] = value
 	return e
 }
 
 // WithFields adds multiple structured fields to the error
-func (e *ValidationError) WithFields(fields map[string]interface{}) *ValidationError {
+func (e *ValidationError) WithFields(fields map[string]any) *ValidationError {
 	if e.Fields == nil {
-		e.Fields = make(map[string]interface{})
+		e.Fields = make(map[string]any)
 	}
 	for k, v := range fields {
 		e.Fields[k] = v
@@ -297,18 +297,18 @@ func (e *ValidationError) AddChild(child *ValidationError) *ValidationError {
 func NewValidationError(message string) *ValidationError {
 	return &ValidationError{
 		Message:  message,
-		Fields:   make(map[string]interface{}),
+		Fields:   make(map[string]any),
 		Children: make([]*ValidationError, 0),
 	}
 }
 
 // TLSError represents TLS-related errors
 type TLSError struct {
-	Op      string                 // Operation that failed (e.g., "handshake", "verify")
-	Host    string                 // Host or SNI name
-	Message string                 // Error message
-	Err     error                  // Underlying error
-	Fields  map[string]interface{} // Additional structured context
+	Op      string         // Operation that failed (e.g., "handshake", "verify")
+	Host    string         // Host or SNI name
+	Message string         // Error message
+	Err     error          // Underlying error
+	Fields  map[string]any // Additional structured context
 }
 
 func (e *TLSError) Error() string {
@@ -335,18 +335,18 @@ func (e *TLSError) Unwrap() error {
 }
 
 // WithField adds a structured field to the error
-func (e *TLSError) WithField(key string, value interface{}) *TLSError {
+func (e *TLSError) WithField(key string, value any) *TLSError {
 	if e.Fields == nil {
-		e.Fields = make(map[string]interface{})
+		e.Fields = make(map[string]any)
 	}
 	e.Fields[key] = value
 	return e
 }
 
 // WithFields adds multiple structured fields to the error
-func (e *TLSError) WithFields(fields map[string]interface{}) *TLSError {
+func (e *TLSError) WithFields(fields map[string]any) *TLSError {
 	if e.Fields == nil {
-		e.Fields = make(map[string]interface{})
+		e.Fields = make(map[string]any)
 	}
 	for k, v := range fields {
 		e.Fields[k] = v
@@ -358,6 +358,6 @@ func (e *TLSError) WithFields(fields map[string]interface{}) *TLSError {
 func NewTLSError(message string) *TLSError {
 	return &TLSError{
 		Message: message,
-		Fields:  make(map[string]interface{}),
+		Fields:  make(map[string]any),
 	}
 }

--- a/internal/pkg/errors/errors_test.go
+++ b/internal/pkg/errors/errors_test.go
@@ -118,7 +118,7 @@ func TestNetworkError(t *testing.T) {
 
 	t.Run("WithFields adds multiple fields", func(t *testing.T) {
 		err := NewNetworkError("test")
-		fields := map[string]interface{}{
+		fields := map[string]any{
 			"key1": "value1",
 			"key2": 42,
 		}
@@ -137,7 +137,7 @@ func TestNetworkError(t *testing.T) {
 
 	t.Run("WithFields on nil Fields map", func(t *testing.T) {
 		err := &NetworkError{}
-		result := err.WithFields(map[string]interface{}{"key": "value"})
+		result := err.WithFields(map[string]any{"key": "value"})
 		assert.Equal(t, err, result)
 		assert.Equal(t, "value", err.Fields["key"])
 	})
@@ -213,7 +213,7 @@ func TestConfigError(t *testing.T) {
 
 	t.Run("WithFields adds multiple fields", func(t *testing.T) {
 		err := NewConfigError("test")
-		fields := map[string]interface{}{
+		fields := map[string]any{
 			"key1": "value1",
 			"key2": 42,
 		}
@@ -310,7 +310,7 @@ func TestValidationError(t *testing.T) {
 
 	t.Run("WithFields adds multiple fields", func(t *testing.T) {
 		err := NewValidationError("test")
-		fields := map[string]interface{}{
+		fields := map[string]any{
 			"key1": "value1",
 			"key2": 42,
 		}
@@ -408,7 +408,7 @@ func TestTLSError(t *testing.T) {
 
 	t.Run("WithFields adds multiple fields", func(t *testing.T) {
 		err := NewTLSError("test")
-		fields := map[string]interface{}{
+		fields := map[string]any{
 			"key1": "value1",
 			"key2": 42,
 		}
@@ -487,7 +487,7 @@ func TestErrorChaining(t *testing.T) {
 		err := NewNetworkError("connection failed").
 			WithField("host", "example.com").
 			WithField("port", 8080).
-			WithFields(map[string]interface{}{
+			WithFields(map[string]any{
 				"timeout": 30,
 				"retry":   true,
 			})
@@ -501,7 +501,7 @@ func TestErrorChaining(t *testing.T) {
 	t.Run("ConfigError chaining", func(t *testing.T) {
 		err := NewConfigError("invalid config").
 			WithField("file", "config.yaml").
-			WithFields(map[string]interface{}{
+			WithFields(map[string]any{
 				"line": 10,
 			})
 
@@ -527,7 +527,7 @@ func TestErrorChaining(t *testing.T) {
 	t.Run("TLSError chaining", func(t *testing.T) {
 		err := NewTLSError("TLS failed").
 			WithField("version", "TLS1.3").
-			WithFields(map[string]interface{}{
+			WithFields(map[string]any{
 				"cipher": "AES-256-GCM",
 			})
 

--- a/internal/pkg/grpclimits/grpclimits.go
+++ b/internal/pkg/grpclimits/grpclimits.go
@@ -87,10 +87,10 @@ func ClientOptions() []grpc.DialOption {
 func unaryServerLoggingInterceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		peerAddr := "unknown"
 		if p, ok := peer.FromContext(ctx); ok {
 			peerAddr = p.Addr.String()
@@ -122,7 +122,7 @@ func unaryServerLoggingInterceptor(logger *zap.Logger) grpc.UnaryServerIntercept
 // streamServerLoggingInterceptor logs streaming RPC calls with peer info.
 func streamServerLoggingInterceptor(logger *zap.Logger) grpc.StreamServerInterceptor {
 	return func(
-		srv interface{},
+		srv any,
 		ss grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,

--- a/internal/pkg/grpclimits/grpclimits_interceptor_test.go
+++ b/internal/pkg/grpclimits/grpclimits_interceptor_test.go
@@ -52,11 +52,11 @@ func (m *mockServerStream) Context() context.Context {
 	return m.ctx
 }
 
-func (m *mockServerStream) SendMsg(interface{}) error {
+func (m *mockServerStream) SendMsg(any) error {
 	return nil
 }
 
-func (m *mockServerStream) RecvMsg(interface{}) error {
+func (m *mockServerStream) RecvMsg(any) error {
 	return nil
 }
 
@@ -80,7 +80,7 @@ func TestUnaryServerLoggingInterceptor_Success(t *testing.T) {
 	info := &grpc.UnaryServerInfo{
 		FullMethod: "/test/Method",
 	}
-	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+	handler := func(_ context.Context, _ any) (any, error) {
 		return "test-response", nil
 	}
 
@@ -103,7 +103,7 @@ func TestUnaryServerLoggingInterceptor_WithPeer(t *testing.T) {
 	info := &grpc.UnaryServerInfo{
 		FullMethod: "/test/Method",
 	}
-	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+	handler := func(_ context.Context, _ any) (any, error) {
 		return "test-response", nil
 	}
 
@@ -121,7 +121,7 @@ func TestUnaryServerLoggingInterceptor_HandlerError(t *testing.T) {
 	info := &grpc.UnaryServerInfo{
 		FullMethod: "/test/Method",
 	}
-	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+	handler := func(_ context.Context, _ any) (any, error) {
 		return nil, status.Error(codes.Internal, "test error")
 	}
 
@@ -140,7 +140,7 @@ func TestUnaryServerLoggingInterceptor_WithError(t *testing.T) {
 	info := &grpc.UnaryServerInfo{
 		FullMethod: "/test/Method",
 	}
-	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+	handler := func(_ context.Context, _ any) (any, error) {
 		return nil, errors.New("handler error")
 	}
 
@@ -158,7 +158,7 @@ func TestStreamServerLoggingInterceptor_Success(t *testing.T) {
 	info := &grpc.StreamServerInfo{
 		FullMethod: "/test/StreamMethod",
 	}
-	handler := func(_ interface{}, _ grpc.ServerStream) error {
+	handler := func(_ any, _ grpc.ServerStream) error {
 		return nil
 	}
 
@@ -180,7 +180,7 @@ func TestStreamServerLoggingInterceptor_WithPeer(t *testing.T) {
 	info := &grpc.StreamServerInfo{
 		FullMethod: "/test/StreamMethod",
 	}
-	handler := func(_ interface{}, _ grpc.ServerStream) error {
+	handler := func(_ any, _ grpc.ServerStream) error {
 		return nil
 	}
 
@@ -197,7 +197,7 @@ func TestStreamServerLoggingInterceptor_HandlerError(t *testing.T) {
 	info := &grpc.StreamServerInfo{
 		FullMethod: "/test/StreamMethod",
 	}
-	handler := func(_ interface{}, _ grpc.ServerStream) error {
+	handler := func(_ any, _ grpc.ServerStream) error {
 		return status.Error(codes.Unavailable, "service unavailable")
 	}
 
@@ -215,7 +215,7 @@ func TestStreamServerLoggingInterceptor_NonGRPCError(t *testing.T) {
 	info := &grpc.StreamServerInfo{
 		FullMethod: "/test/StreamMethod",
 	}
-	handler := func(_ interface{}, _ grpc.ServerStream) error {
+	handler := func(_ any, _ grpc.ServerStream) error {
 		return errors.New("random error")
 	}
 
@@ -232,7 +232,7 @@ func TestStreamServerLoggingInterceptor_WithError(t *testing.T) {
 	info := &grpc.StreamServerInfo{
 		FullMethod: "/test/StreamMethod",
 	}
-	handler := func(_ interface{}, _ grpc.ServerStream) error {
+	handler := func(_ any, _ grpc.ServerStream) error {
 		return errors.New("stream error")
 	}
 

--- a/internal/pkg/httpjson/response.go
+++ b/internal/pkg/httpjson/response.go
@@ -7,7 +7,7 @@ import (
 )
 
 // WriteJSON serializes v as pretty-printed JSON.
-func WriteJSON(w http.ResponseWriter, statusCode int, v interface{}) {
+func WriteJSON(w http.ResponseWriter, statusCode int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	enc := json.NewEncoder(w)
@@ -18,7 +18,7 @@ func WriteJSON(w http.ResponseWriter, statusCode int, v interface{}) {
 }
 
 // WriteJSONCompact serializes v as compact (non-indented) JSON.
-func WriteJSONCompact(w http.ResponseWriter, statusCode int, v interface{}) {
+func WriteJSONCompact(w http.ResponseWriter, statusCode int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	if err := json.NewEncoder(w).Encode(v); err != nil {

--- a/internal/pkg/pool/buffer.go
+++ b/internal/pkg/pool/buffer.go
@@ -27,7 +27,7 @@ import (
 // BufferPool is a sync.Pool for bytes.Buffer objects.
 // Use this for hot paths that frequently allocate byte buffers.
 var BufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(bytes.Buffer)
 	},
 }
@@ -58,7 +58,7 @@ func PutBuffer(buf *bytes.Buffer) {
 // StringBuilderPool is a sync.Pool for strings.Builder objects.
 // Use this for hot paths that frequently build strings.
 var StringBuilderPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(strings.Builder)
 	},
 }
@@ -97,7 +97,7 @@ func NewByteSlicePool(size int) *ByteSlicePool {
 	return &ByteSlicePool{
 		size: size,
 		pool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buf := make([]byte, size)
 				return &buf
 			},


### PR DESCRIPTION
## Summary

- **Controller pattern standardization (#974)**:
  - Migrate ProxyGateway and ProxyPolicy controllers to `reconcileWithGenerationCheck`
  - Extract create-or-update pattern from IngressReconciler to shared `createOrUpdateResource` in `config.go`
  - GRPCRoute deletion uses shared `handleResourceDeletionWithName` with name-mapping for `grpc-` prefix
  - Apply `defaultControllerOptions()` (exponential backoff 5ms-1000s) to all 15 controllers

- **Minor code quality improvements (#976)**:
  - Replace `interface{}` with `any` project-wide (55 files)
  - Replace `_ = cmd.MarkFlagRequired(...)` with `cobra.CheckErr(...)` in `generate.go`
  - Fix sentinel errors in `standalone.go` to proper `ErrXxxNotFound`/`ErrXxxAlreadyExists` sentinels
  - Remove dead `xml` import in `route53.go`
  - Move `go s.cleanupStaleAgents()` from `snapshot.NewServer` constructor to `Start()` method
  - Use `ConditionReasonValid` instead of hardcoded strings in WAN controllers

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes (6 packages)
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `cargo clippy` / `cargo fmt --check` pass

Closes #974, closes #976