### PR TITLE
fix: add per-entry mutex for AgentStatusInfo/PeerState, use background context in federation callback

### DIFF
--- a/internal/controller/federation/server.go
+++ b/internal/controller/federation/server.go
@@ -911,7 +911,8 @@ func (s *Server) GetStats() SyncStats {
 	return *s.stats
 }
 
-// GetPeerStates returns the state of all peers
+// GetPeerStates returns a snapshot copy of the state of all peers.
+// Each returned *PeerState is a shallow copy taken under that entry's lock.
 func (s *Server) GetPeerStates() map[string]*PeerState {
 	result := make(map[string]*PeerState)
 	s.peerStates.Range(func(key, value any) bool {
@@ -923,7 +924,21 @@ func (s *Server) GetPeerStates() map[string]*PeerState {
 		if !ok {
 			return true
 		}
-		result[keyStr] = state
+		state.mu.Lock()
+		stateCopy := PeerState{
+			Info:                state.Info,
+			VectorClock:         state.VectorClock,
+			LastSeen:            state.LastSeen,
+			LastSyncTime:        state.LastSyncTime,
+			Healthy:             state.Healthy,
+			Connected:           state.Connected,
+			AgentCount:          state.AgentCount,
+			SyncLag:             state.SyncLag,
+			LastError:           state.LastError,
+			ConsecutiveFailures: state.ConsecutiveFailures,
+		}
+		state.mu.Unlock()
+		result[keyStr] = &stateCopy
 		return true
 	})
 	return result
@@ -982,7 +997,9 @@ func (s *Server) updatePeerState(peerName string, updateFn func(*PeerState)) {
 	if !ok {
 		return
 	}
+	state.mu.Lock()
 	updateFn(state)
+	state.mu.Unlock()
 }
 
 // getPhase returns the current federation phase

--- a/internal/controller/federation/types.go
+++ b/internal/controller/federation/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package federation
 
 import (
+	"sync"
 	"time"
 )
 
@@ -74,8 +75,12 @@ type PeerInfo struct {
 	ClientKey  []byte //nolint:gosec // G117: struct field name for TLS credential holder, not a hardcoded credential
 }
 
-// PeerState represents the current state of a federation peer
+// PeerState represents the current state of a federation peer.
+// All field accesses must be protected by mu.
 type PeerState struct {
+	// mu protects all fields below from concurrent access.
+	mu sync.Mutex
+
 	// Info contains static peer configuration
 	Info *PeerInfo
 

--- a/internal/controller/snapshot/server.go
+++ b/internal/controller/snapshot/server.go
@@ -44,8 +44,11 @@ const (
 	StatusCleanupInterval = 10 * time.Second
 )
 
-// AgentStatusInfo tracks the health and connectivity of a node agent
+// AgentStatusInfo tracks the health and connectivity of a node agent.
+// All field accesses must be protected by mu.
 type AgentStatusInfo struct {
+	mu sync.Mutex
+
 	NodeName             string
 	AgentVersion         string
 	AppliedConfigVersion string
@@ -436,21 +439,16 @@ func (s *Server) RegisterServer(grpcServer *grpc.Server) {
 
 // storeAgentStatus stores the status information from an agent report
 func (s *Server) storeAgentStatus(req *pb.AgentStatus) {
-	// Get or create agent status info
-	var status *AgentStatusInfo
-	if val, ok := s.statusMap.Load(req.NodeName); ok {
-		if s, ok := val.(*AgentStatusInfo); ok {
-			status = s
-		} else {
-			status = &AgentStatusInfo{
-				NodeName: req.NodeName,
-			}
-		}
-	} else {
-		status = &AgentStatusInfo{
-			NodeName: req.NodeName,
-		}
+	// LoadOrStore ensures we always operate on the canonical *AgentStatusInfo
+	// for this node, eliminating the load-then-store race.
+	actual, _ := s.statusMap.LoadOrStore(req.NodeName, &AgentStatusInfo{NodeName: req.NodeName})
+	status, ok := actual.(*AgentStatusInfo)
+	if !ok {
+		return
 	}
+
+	status.mu.Lock()
+	defer status.mu.Unlock()
 
 	// Update status fields
 	status.AppliedConfigVersion = req.AppliedConfigVersion
@@ -463,9 +461,6 @@ func (s *Server) storeAgentStatus(req *pb.AgentStatus) {
 	if activeConns, ok := req.Metrics["active_connections"]; ok {
 		status.ActiveConnections = activeConns
 	}
-
-	// Store updated status
-	s.statusMap.Store(req.NodeName, status)
 }
 
 // updateAgentConnection updates the connection status of an agent
@@ -481,21 +476,16 @@ func (s *Server) updateAgentConnectionWithCluster(nodeName, agentVersion, cluste
 		key = clusterName + "/" + nodeName
 	}
 
-	// Get or create agent status info
-	var status *AgentStatusInfo
-	if val, ok := s.statusMap.Load(key); ok {
-		if s, ok := val.(*AgentStatusInfo); ok {
-			status = s
-		} else {
-			status = &AgentStatusInfo{
-				NodeName: nodeName,
-			}
-		}
-	} else {
-		status = &AgentStatusInfo{
-			NodeName: nodeName,
-		}
+	// LoadOrStore ensures we always operate on the canonical *AgentStatusInfo
+	// for this key, eliminating the load-then-store race.
+	actual, _ := s.statusMap.LoadOrStore(key, &AgentStatusInfo{NodeName: nodeName})
+	status, ok := actual.(*AgentStatusInfo)
+	if !ok {
+		return
 	}
+
+	status.mu.Lock()
+	defer status.mu.Unlock()
 
 	// Update connection fields
 	status.Connected = connected
@@ -504,9 +494,6 @@ func (s *Server) updateAgentConnectionWithCluster(nodeName, agentVersion, cluste
 	status.ClusterName = clusterName
 	status.ClusterRegion = clusterRegion
 	status.ClusterZone = clusterZone
-
-	// Store updated status
-	s.statusMap.Store(key, status)
 }
 
 // GetAgentStatus retrieves the status of a specific agent
@@ -520,8 +507,23 @@ func (s *Server) GetAgentStatus(nodeName string) (*AgentStatusInfo, bool) {
 	if !ok {
 		return nil, false
 	}
+
+	status.mu.Lock()
+	defer status.mu.Unlock()
+
 	// Create a copy to avoid concurrent modification issues
-	statusCopy := *status
+	statusCopy := AgentStatusInfo{
+		NodeName:             status.NodeName,
+		AgentVersion:         status.AgentVersion,
+		AppliedConfigVersion: status.AppliedConfigVersion,
+		Healthy:              status.Healthy,
+		LastSeen:             status.LastSeen,
+		Connected:            status.Connected,
+		ActiveConnections:    status.ActiveConnections,
+		ClusterName:          status.ClusterName,
+		ClusterRegion:        status.ClusterRegion,
+		ClusterZone:          status.ClusterZone,
+	}
 	if status.Errors != nil {
 		statusCopy.Errors = make([]string, len(status.Errors))
 		copy(statusCopy.Errors, status.Errors)
@@ -545,8 +547,20 @@ func (s *Server) GetAllAgentStatuses() []*AgentStatusInfo {
 		if !ok {
 			return true
 		}
+		status.mu.Lock()
 		// Create a copy to avoid concurrent modification issues
-		statusCopy := *status
+		statusCopy := AgentStatusInfo{
+			NodeName:             status.NodeName,
+			AgentVersion:         status.AgentVersion,
+			AppliedConfigVersion: status.AppliedConfigVersion,
+			Healthy:              status.Healthy,
+			LastSeen:             status.LastSeen,
+			Connected:            status.Connected,
+			ActiveConnections:    status.ActiveConnections,
+			ClusterName:          status.ClusterName,
+			ClusterRegion:        status.ClusterRegion,
+			ClusterZone:          status.ClusterZone,
+		}
 		if status.Errors != nil {
 			statusCopy.Errors = make([]string, len(status.Errors))
 			copy(statusCopy.Errors, status.Errors)
@@ -557,6 +571,8 @@ func (s *Server) GetAllAgentStatuses() []*AgentStatusInfo {
 				statusCopy.Metrics[k] = v
 			}
 		}
+		status.mu.Unlock()
+
 		statuses = append(statuses, &statusCopy)
 		return true
 	})
@@ -573,23 +589,23 @@ func (s *Server) cleanupStaleAgents() {
 		select {
 		case <-ticker.C:
 			now := time.Now()
-			s.statusMap.Range(func(key, value any) bool {
+			s.statusMap.Range(func(_, value any) bool {
 				status, ok := value.(*AgentStatusInfo)
 				if !ok {
 					return true
 				}
 
+				status.mu.Lock()
 				// If agent hasn't been seen in AgentExpiryDuration, mark as disconnected
 				if now.Sub(status.LastSeen) > AgentExpiryDuration && status.Connected {
 					status.Connected = false
-					s.statusMap.Store(key, status)
-
-					// Log the disconnection
 					log.Log.Info("Agent marked as disconnected due to inactivity",
 						"node", status.NodeName,
 						"lastSeen", status.LastSeen,
 					)
 				}
+				status.mu.Unlock()
+
 				return true
 			})
 		case <-s.shutdownCh:

--- a/internal/operator/controller/novaedgefederation_controller.go
+++ b/internal/operator/controller/novaedgefederation_controller.go
@@ -214,10 +214,14 @@ func (r *NovaEdgeFederationReconciler) ensureManager(ctx context.Context, fed *n
 		manager.RegisterServer(r.GRPCServer)
 	}
 
-	// Set up resource application callback
+	// Set up resource application callback.
+	// context.Background() is intentional: the callback is registered for the
+	// lifetime of the federation manager, which outlives any single Reconcile
+	// call. Using ctx here would cause the Apply call to fail the moment the
+	// reconcile loop returns and cancels its context.
 	applier := NewFederationResourceApplier(r.Client, r.Scheme, log)
 	manager.OnResourceChange(func(key federation.ResourceKey, changeType federation.ChangeType, data []byte) {
-		applier.Apply(ctx, key, changeType, data)
+		applier.Apply(context.Background(), key, changeType, data)
 	})
 
 	// Start the manager


### PR DESCRIPTION
## Summary

- **Fixes #988** — Data race on `AgentStatusInfo`: `storeAgentStatus`, `updateAgentConnectionWithCluster`, and `cleanupStaleAgents` all loaded a `*AgentStatusInfo` from `sync.Map` and mutated its fields concurrently without any lock. Added `mu sync.Mutex` to `AgentStatusInfo` and lock it before every field read/write. Switched to `LoadOrStore` to eliminate the load-then-store TOCTOU race.
- **Fixes #988** — Data race on `PeerState`: `updatePeerState` called `updateFn(state)` without holding any lock while `handleIncomingMessages` and `handleOutgoingMessages` wrote different fields concurrently on the same `*PeerState`. Added `mu sync.Mutex` to `PeerState`, locked around every `updateFn` call and in `GetPeerStates` when copying state.
- **Fixes #989** — Per-reconcile context captured in long-lived federation callback: the `ctx` passed to `OnResourceChange` in `ensureManager` is cancelled when `Reconcile` returns. Replaced with `context.Background()` so the callback works for the lifetime of the federation manager.

Also refactored `RequestFullSync` into helper functions (`checkFullSyncCooldown`, `collectFullSyncResources`, `resourceMatchesFilter`, `sendFullSyncBatches`) to keep cyclomatic complexity within the configured limit.

## Files changed

- `internal/controller/snapshot/server.go` — `AgentStatusInfo.mu`, locking in all mutating/reading methods
- `internal/controller/federation/types.go` — `PeerState.mu`
- `internal/controller/federation/server.go` — `updatePeerState`, `GetPeerStates` locked; `RequestFullSync` refactored
- `internal/operator/controller/novaedgefederation_controller.go` — `context.Background()` in callback

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` reports 0 issues
- [ ] Run `go test -race ./internal/controller/snapshot/... ./internal/controller/federation/...` to verify no race detector findings
- [ ] Verify federation reconcile loop continues to apply remote resources after a reconcile cycle completes