### PR TITLE
fix: WASM security, Vault transport, gossiper lifecycle, context-aware sleeps, shutdown order

### DIFF
--- a/cmd/novaedge-controller/main.go
+++ b/cmd/novaedge-controller/main.go
@@ -385,6 +385,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Graceful shutdown of gRPC server
+	// Graceful shutdown: stop the snapshot server and gRPC server.
+	configServer.Shutdown()
 	grpcServer.GracefulStop()
 }

--- a/internal/agent/gossip/gossip.go
+++ b/internal/agent/gossip/gossip.go
@@ -86,6 +86,7 @@ type ConfigGossiper struct {
 	logger          *zap.Logger
 	ctx             context.Context
 	cancel          context.CancelFunc
+	wg              sync.WaitGroup
 }
 
 // NewConfigGossiper creates a new config version gossiper.
@@ -127,9 +128,10 @@ func (g *ConfigGossiper) Start(ctx context.Context) error {
 	cancel = nil // ownership transferred to g.cancel
 	g.conn = conn
 
-	go g.broadcastLoop(addr)
-	go g.receiveLoop()
-	go g.quorumCheckLoop()
+	g.wg.Add(3)
+	go func() { defer g.wg.Done(); g.broadcastLoop(addr) }()
+	go func() { defer g.wg.Done(); g.receiveLoop() }()
+	go func() { defer g.wg.Done(); g.quorumCheckLoop() }()
 
 	g.logger.Info("Config gossip started",
 		zap.String("node", g.nodeName),
@@ -143,6 +145,19 @@ func (g *ConfigGossiper) Start(ctx context.Context) error {
 func (g *ConfigGossiper) UpdateGenTime(genTime int64) {
 	g.currentGenTime.Store(genTime)
 	g.logger.Debug("Gossip generation time updated", zap.Int64("genTime", genTime))
+}
+
+// Stop cancels the gossip context, closes the UDP connection, and waits for
+// all goroutines to exit cleanly.
+func (g *ConfigGossiper) Stop() {
+	if g.cancel != nil {
+		g.cancel()
+	}
+	if g.conn != nil {
+		_ = g.conn.Close()
+	}
+	g.wg.Wait()
+	g.logger.Info("Config gossip stopped")
 }
 
 // broadcastLoop multicasts this node's config generation time at regular intervals.

--- a/internal/agent/sdwan/sdwan.go
+++ b/internal/agent/sdwan/sdwan.go
@@ -19,6 +19,7 @@ package sdwan
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -173,7 +174,11 @@ func (m *Manager) ApplyConfig(links []LinkConfig, policies []PolicyConfig) error
 	for _, cfg := range links {
 		desired[cfg.Name] = struct{}{}
 		if err := m.AddLink(cfg); err != nil {
-			m.logger.Debug("Link already managed, skipping add", zap.String("link", cfg.Name))
+			if strings.Contains(err.Error(), "already exists") {
+				m.logger.Debug("Link already managed, skipping add", zap.String("link", cfg.Name))
+			} else {
+				m.logger.Error("Failed to add link", zap.String("link", cfg.Name), zap.Error(err))
+			}
 		}
 	}
 

--- a/internal/agent/wasm/host.go
+++ b/internal/agent/wasm/host.go
@@ -34,6 +34,10 @@ const hostModuleName = "novaedge"
 // maxUint32 is the maximum value for uint32, used for safe conversion checks.
 const maxUint32 = 1<<32 - 1
 
+// maxLogMessageLen caps the message length a WASM plugin can log in a single
+// call to prevent log flooding from untrusted plugins.
+const maxLogMessageLen uint32 = 8192
+
 // safeU32 safely converts a uint64 stack value to uint32.
 // WASM i32 values are stored as uint64 on the Go side but are guaranteed
 // by the WASM runtime to fit in 32 bits when the function signature
@@ -276,6 +280,11 @@ func hostLogMessage(_ context.Context, mod api.Module, stack []uint64) {
 	msgPtr := safeU32(stack[1])
 	msgLen := safeU32(stack[2])
 
+	// Cap message length to prevent log flooding from untrusted WASM plugins.
+	if msgLen > maxLogMessageLen {
+		msgLen = maxLogMessageLen
+	}
+
 	mem := mod.Memory()
 	msgBytes, ok := mem.Read(msgPtr, msgLen)
 	if !ok {
@@ -313,6 +322,13 @@ func hostSendResponse(ctx context.Context, mod api.Module, stack []uint64) {
 	if !ok {
 		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostSendResponse"))
 		bodyBytes = []byte("WASM plugin error: could not read body from memory")
+	}
+
+	// Validate the HTTP status code before writing to prevent invalid responses
+	// from malicious or buggy WASM plugins.
+	if statusCode < 100 || statusCode > 599 {
+		zap.L().Warn("WASM plugin attempted invalid status code", zap.Uint32("code", statusCode))
+		statusCode = 500
 	}
 
 	rc.ResponseWriter.WriteHeader(int(statusCode))

--- a/internal/agent/wasm/plugin.go
+++ b/internal/agent/wasm/plugin.go
@@ -137,6 +137,11 @@ func (p *Plugin) executionTimeout() time.Duration {
 
 // instantiate creates a new WASM module instance from the compiled module.
 func (p *Plugin) instantiate(ctx context.Context) (api.Module, error) {
+	// TODO(#1000): wazero's WithMemoryLimitPages is a RuntimeConfig option
+	// applied globally at runtime creation time, not per-module. The per-plugin
+	// MaxMemoryPages from PluginConfig cannot be enforced at instantiation time
+	// with the current wazero API. The global runtime limit (set in NewRuntime
+	// via WithMemoryLimitPages) is the effective cap for all plugins.
 	cfg := wazero.NewModuleConfig().
 		WithName(""). // unnamed so multiple instances can coexist
 		WithStartFunctions("_start", "_initialize")

--- a/internal/controller/federation/manager.go
+++ b/internal/controller/federation/manager.go
@@ -543,7 +543,11 @@ func (m *Manager) maintainPeerConnection(peerName string, client *PeerClient) {
 				zap.String("peer", peerName),
 				zap.Error(err),
 			)
-			time.Sleep(backoff)
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
 			backoff = min(backoff*2, 30*time.Second)
 			continue
 		}
@@ -555,7 +559,11 @@ func (m *Manager) maintainPeerConnection(peerName string, client *PeerClient) {
 				zap.Error(err),
 			)
 			client.Disconnect()
-			time.Sleep(backoff)
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
 			backoff = min(backoff*2, 30*time.Second)
 			continue
 		}
@@ -583,7 +591,11 @@ func (m *Manager) maintainPeerConnection(peerName string, client *PeerClient) {
 			m.logger.Info("Peer disconnected, will reconnect",
 				zap.String("peer", peerName),
 			)
-			time.Sleep(backoff)
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
 		}
 	}
 }

--- a/internal/controller/federation/server.go
+++ b/internal/controller/federation/server.go
@@ -420,8 +420,14 @@ func (s *Server) handleResourceChange(_ context.Context, peerName string, change
 			s.applyServiceEndpoints(change.ResourceData, peerName)
 		}
 
-		// Notify callbacks
-		s.notifyChange(key, ChangeType(change.ChangeType.String()), change.ResourceData)
+		// Notify callbacks using internal constants to avoid proto-string/internal-string mismatch.
+		var localChangeType ChangeType
+		if change.ChangeType == pb.ChangeType_CREATED {
+			localChangeType = ChangeTypeCreated
+		} else {
+			localChangeType = ChangeTypeUpdated
+		}
+		s.notifyChange(key, localChangeType, change.ResourceData)
 
 	case pb.ChangeType_DELETED:
 		s.resources.Delete(keyStr)

--- a/internal/controller/vault/client.go
+++ b/internal/controller/vault/client.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -133,11 +134,13 @@ type Client struct {
 // vaultHTTPClient is a minimal Vault HTTP API client to avoid
 // large dependency on github.com/hashicorp/vault/api.
 type vaultHTTPClient struct {
-	address   string
-	token     string
-	namespace string
-	caCert    string
-	skipTLS   bool
+	address    string
+	token      string
+	namespace  string
+	caCert     string
+	skipTLS    bool
+	client     *http.Client
+	clientOnce sync.Once
 }
 
 // NewClient creates a new Vault client.

--- a/internal/controller/vault/http.go
+++ b/internal/controller/vault/http.go
@@ -138,7 +138,7 @@ func (c *vaultHTTPClient) doRequest(req *http.Request) (*Response, error) {
 		req.Header.Set("X-Vault-Namespace", c.namespace)
 	}
 
-	httpClient, err := c.newHTTPClient()
+	httpClient, err := c.cachedHTTPClient()
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,26 @@ func (c *vaultHTTPClient) doRequest(req *http.Request) (*Response, error) {
 	return &vaultResp, nil
 }
 
+// cachedHTTPClient returns the shared HTTP client, initializing it once.
+// The client is safe for concurrent use and reuses connections across requests.
+func (c *vaultHTTPClient) cachedHTTPClient() (*http.Client, error) {
+	var initErr error
+	c.clientOnce.Do(func() {
+		client, err := c.newHTTPClient()
+		if err != nil {
+			initErr = err
+			return
+		}
+		c.client = client
+	})
+	if initErr != nil {
+		return nil, initErr
+	}
+	return c.client, nil
+}
+
 // newHTTPClient creates an HTTP client with optional TLS configuration.
+// Call cachedHTTPClient() instead to reuse the client across requests.
 func (c *vaultHTTPClient) newHTTPClient() (*http.Client, error) {
 	transport := &http.Transport{}
 
@@ -211,7 +230,7 @@ func (c *vaultHTTPClient) HealthCheck(ctx context.Context) (*HealthStatus, error
 		return nil, fmt.Errorf("failed to create health check request: %w", err)
 	}
 
-	httpClient, err := c.newHTTPClient()
+	httpClient, err := c.cachedHTTPClient()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/operator/controller/novaedgefederation_controller.go
+++ b/internal/operator/controller/novaedgefederation_controller.go
@@ -444,7 +444,7 @@ func (r *NovaEdgeFederationReconciler) syncStatus(ctx context.Context, fed *nova
 	fed.Status.LastSyncTime = &now
 
 	// Update conditions
-	fed.Status.Conditions = r.buildConditions(crdPhase, fed.Status.Conditions)
+	fed.Status.Conditions = r.buildConditions(crdPhase, fed.Status.Conditions, fed.Generation)
 
 	if err := r.Status().Update(ctx, fed); err != nil {
 		log.Error("Failed to update federation status", zap.Error(err))
@@ -470,7 +470,7 @@ func (r *NovaEdgeFederationReconciler) syncStatus(ctx context.Context, fed *nova
 func (r *NovaEdgeFederationReconciler) updateStatus(ctx context.Context, fed *novaedgev1alpha1.NovaEdgeFederation, phase novaedgev1alpha1.FederationPhase, _ string, log *zap.Logger) (ctrl.Result, error) {
 	fed.Status.Phase = phase
 	fed.Status.ObservedGeneration = fed.Generation
-	fed.Status.Conditions = r.buildConditions(phase, fed.Status.Conditions)
+	fed.Status.Conditions = r.buildConditions(phase, fed.Status.Conditions, fed.Generation)
 
 	if err := r.Status().Update(ctx, fed); err != nil {
 		log.Error("Failed to update federation status", zap.Error(err))
@@ -481,7 +481,7 @@ func (r *NovaEdgeFederationReconciler) updateStatus(ctx context.Context, fed *no
 }
 
 // buildConditions builds conditions based on the current phase
-func (r *NovaEdgeFederationReconciler) buildConditions(phase novaedgev1alpha1.FederationPhase, existing []metav1.Condition) []metav1.Condition {
+func (r *NovaEdgeFederationReconciler) buildConditions(phase novaedgev1alpha1.FederationPhase, existing []metav1.Condition, generation int64) []metav1.Condition {
 	now := metav1.Now()
 
 	// Helper to find existing condition
@@ -498,7 +498,7 @@ func (r *NovaEdgeFederationReconciler) buildConditions(phase novaedgev1alpha1.Fe
 	readyCondition := metav1.Condition{
 		Type:               FederationConditionReady,
 		LastTransitionTime: now,
-		ObservedGeneration: 0,
+		ObservedGeneration: generation,
 	}
 
 	switch phase {

--- a/internal/standalone/watcher.go
+++ b/internal/standalone/watcher.go
@@ -125,8 +125,13 @@ func (w *ConfigWatcher) Start(ctx context.Context, applyFunc ApplyFunc) error {
 				w.logger.Info("Config file changed, reloading",
 					zap.String("event", event.Op.String()))
 
-				// Small delay to ensure file is fully written
-				time.Sleep(100 * time.Millisecond)
+				// Small delay to ensure file is fully written; respect context cancellation.
+				select {
+				case <-ctx.Done():
+					w.logger.Info("Config watcher stopped")
+					return ctx.Err()
+				case <-time.After(100 * time.Millisecond):
+				}
 
 				if err := w.loadAndApply(applyFunc); err != nil {
 					w.logger.Error("Failed to reload config", zap.Error(err))
@@ -167,7 +172,11 @@ func (w *ConfigWatcher) loadAndApply(applyFunc ApplyFunc) error {
 	w.mu.Lock()
 	w.lastConfig = standaloneConfig
 	w.lastSnapshot = snapshot
-	hash, _ := w.computeHash()
+	hash, err := w.computeHash()
+	if err != nil {
+		w.mu.Unlock()
+		return fmt.Errorf("failed to compute config hash: %w", err)
+	}
 	w.lastHash = hash
 	w.mu.Unlock()
 


### PR DESCRIPTION
## Summary

Fixes 8 issues across WASM host security, Vault HTTP transport efficiency, gossiper goroutine management, context-aware sleeps, federation ChangeType correctness, and miscellaneous code quality.

- **#987** — `hostSendResponse`: validate plugin-supplied status code is in range 100–599 before calling `WriteHeader`; clamp out-of-range values to 500 with a Warn log.
- **#1000** — `hostLogMessage`: cap message length at 8192 bytes to prevent log flooding from untrusted WASM plugins. Add a TODO comment in `plugin.go` explaining that `wazero.WithMemoryLimitPages` is a runtime-global setting and cannot be applied per-module at instantiation time.
- **#990** — `vaultHTTPClient`: add `client *http.Client` + `clientOnce sync.Once` to the struct; introduce `cachedHTTPClient()` that initialises the TLS transport once and returns the shared client; update `doRequest` and `HealthCheck` callers.
- **#991** — `ConfigGossiper`: add `wg sync.WaitGroup`; wrap `broadcastLoop`, `receiveLoop`, and `quorumCheckLoop` goroutines with `wg.Add/Done`; add `Stop()` method that cancels context, closes the UDP connection, and calls `wg.Wait()`.
- **#992** — `maintainPeerConnection`: replace all three `time.Sleep(backoff)` calls with `select { case <-m.ctx.Done(): return; case <-time.After(backoff): }` so context cancellation interrupts reconnect back-off immediately.
- **#997** — `cmd/novaedge-controller/main.go`: call `configServer.Shutdown()` explicitly on the normal exit path (before `grpcServer.GracefulStop()`), avoiding the `exitAfterDefer` antipattern on the `os.Exit` paths.
- **#998** — `server.go`: replace `ChangeType(change.ChangeType.String())` (which produces `"CREATED"`) with an explicit mapping to `ChangeTypeCreated`/`ChangeTypeUpdated` (which are `"Created"`/`"Updated"`). `novaedgefederation_controller.go`: pass `fed.Generation` to `buildConditions` and use it as `ObservedGeneration` instead of hardcoded `0`.
- **#999** — `standalone/watcher.go`: replace `time.Sleep(100ms)` with a context-aware select; return error from `computeHash()` in `loadAndApply` instead of discarding it. `agent/sdwan/sdwan.go`: distinguish "already exists" from real `AddLink` errors and log the latter at `Error`.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes (pre-commit hook verified)
- [ ] WASM host tests: `go test ./internal/agent/wasm/...`
- [ ] Vault client tests: `go test ./internal/controller/vault/...`
- [ ] Gossip tests: `go test ./internal/agent/gossip/...`
- [ ] Federation manager/server tests: `go test ./internal/controller/federation/...`
- [ ] Standalone watcher tests: `go test ./internal/standalone/...`

Closes #987, #990, #991, #992, #997, #998, #999, #1000