### PR TITLE
fix: dataplane hardening — poison-safe RwLock, bcrypt auth, hedge pool, timed cleanup

### DIFF
--- a/dataplane/Cargo.lock
+++ b/dataplane/Cargo.lock
@@ -231,6 +231,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bcrypt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1866ecef4f2d06a0bb77880015fdf2b89e25a1c2e5addacb87e459c86dc67e"
+dependencies = [
+ "base64",
+ "blowfish",
+ "getrandom 0.2.17",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,10 +259,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -286,6 +315,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -871,6 +910,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1090,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "base64",
+ "bcrypt",
  "bytes",
  "clap",
  "dashmap",

--- a/dataplane/novaedge-dataplane/Cargo.toml
+++ b/dataplane/novaedge-dataplane/Cargo.toml
@@ -27,6 +27,7 @@ sha2 = "0.10"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+bcrypt = "0.16"
 rustls = "0.23"
 tokio-rustls = "0.26"
 rustls-pemfile = "2"

--- a/dataplane/novaedge-dataplane/src/middleware/auth/basic.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/auth/basic.rs
@@ -4,31 +4,41 @@ use std::collections::HashMap;
 
 use base64::Engine;
 
-/// Constant-time byte comparison to prevent timing attacks.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
-}
+/// The bcrypt hash prefix used to detect already-hashed passwords.
+const BCRYPT_PREFIX: &str = "$2b$";
 
 /// HTTP Basic authentication handler.
+///
+/// Passwords are stored as bcrypt hashes. Plaintext passwords provided at
+/// construction time are automatically hashed before storage.
 pub struct BasicAuth {
     /// Realm string for the WWW-Authenticate header.
     #[allow(dead_code)]
     // Pipeline constructs BasicAuth with realm; used by caller for WWW-Authenticate header.
     pub realm: String,
-    /// Mapping from username to password (plaintext comparison).
+    /// Mapping from username to bcrypt-hashed password.
     pub users: HashMap<String, String>,
 }
 
 impl BasicAuth {
     /// Create a new Basic auth handler.
+    ///
+    /// Passwords that are not already bcrypt-hashed (detected by the `$2b$`
+    /// prefix) are hashed on load using bcrypt with the default cost.
     pub fn new(realm: &str, users: HashMap<String, String>) -> Self {
+        let users = users
+            .into_iter()
+            .map(|(user, pass)| {
+                if pass.starts_with(BCRYPT_PREFIX) {
+                    (user, pass)
+                } else {
+                    let hashed =
+                        bcrypt::hash(&pass, bcrypt::DEFAULT_COST).unwrap_or_else(|_| pass.clone());
+                    (user, hashed)
+                }
+            })
+            .collect();
+
         Self {
             realm: realm.to_string(),
             users,
@@ -49,8 +59,8 @@ impl BasicAuth {
                 if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(encoded) {
                     if let Ok(creds) = String::from_utf8(decoded) {
                         if let Some((user, pass)) = creds.split_once(':') {
-                            if let Some(expected) = self.users.get(user) {
-                                if constant_time_eq(expected.as_bytes(), pass.as_bytes()) {
+                            if let Some(hash) = self.users.get(user) {
+                                if bcrypt::verify(pass, hash).unwrap_or(false) {
                                     return super::AuthResult::Authenticated {
                                         user: user.to_string(),
                                         claims: vec![],

--- a/dataplane/novaedge-dataplane/src/middleware/cache.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/cache.rs
@@ -62,7 +62,7 @@ impl ResponseCache {
 
     /// Look up a cached response by key, returning `None` if absent or expired.
     pub fn get(&self, key: &str) -> Option<super::Response> {
-        let entries = self.entries.read().unwrap();
+        let entries = self.entries.read().unwrap_or_else(|e| e.into_inner());
         entries.get(key).and_then(|entry| {
             if entry.inserted.elapsed() < entry.ttl {
                 Some(entry.response.clone())
@@ -86,7 +86,7 @@ impl ResponseCache {
             .find(|(k, _)| k.eq_ignore_ascii_case("etag"))
             .map(|(_, v)| v.clone());
 
-        let mut entries = self.entries.write().unwrap();
+        let mut entries = self.entries.write().unwrap_or_else(|e| e.into_inner());
 
         // Evict oldest entry if at capacity.
         if entries.len() >= self.config.max_entries {
@@ -125,29 +125,38 @@ impl ResponseCache {
 
     /// Remove a specific key from the cache.
     pub fn invalidate(&self, key: &str) {
-        self.entries.write().unwrap().remove(key);
+        self.entries
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(key);
     }
 
     /// Remove all entries from the cache.
     pub fn clear(&self) {
-        self.entries.write().unwrap().clear();
+        self.entries
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
     }
 
     /// Return the number of entries currently in the cache.
     pub fn len(&self) -> usize {
-        self.entries.read().unwrap().len()
+        self.entries.read().unwrap_or_else(|e| e.into_inner()).len()
     }
 
     /// Return whether the cache is empty.
     pub fn is_empty(&self) -> bool {
-        self.entries.read().unwrap().is_empty()
+        self.entries
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty()
     }
 
     /// Remove all expired entries from the cache.
     pub fn cleanup_expired(&self) {
         self.entries
             .write()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .retain(|_, e| e.inserted.elapsed() < e.ttl);
     }
 }

--- a/dataplane/novaedge-dataplane/src/middleware/pipeline.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/pipeline.rs
@@ -5,6 +5,8 @@
 //! or short-circuit with an immediate response.
 
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Instant;
 
 use dashmap::DashMap;
 use tracing::{debug, warn};
@@ -16,10 +18,17 @@ use crate::config::RuntimeConfig;
 /// Beyond this, the oldest entries are evicted to prevent unbounded memory growth.
 const MAX_RATE_LIMITERS: usize = 10_000;
 
+/// Minimum interval between rate-limiter cleanup sweeps (seconds).
+const CLEANUP_INTERVAL_SECS: u64 = 60;
+
 /// Shared cache of rate-limiter instances keyed by policy name.
 /// This ensures rate-limit state is preserved across requests.
 static RATE_LIMITERS: std::sync::LazyLock<DashMap<String, super::ratelimit::TokenBucket>> =
     std::sync::LazyLock::new(DashMap::new);
+
+/// Tracks the last time a rate-limiter cleanup was performed.
+static LAST_CLEANUP: std::sync::LazyLock<Mutex<Instant>> =
+    std::sync::LazyLock::new(|| Mutex::new(Instant::now()));
 
 /// Shared HTTP response cache for the "cache" middleware policy type.
 static RESPONSE_CACHE: std::sync::LazyLock<super::cache::ResponseCache> =
@@ -244,11 +253,17 @@ fn run_rate_limit(policy_name: &str, config_json: &str, req: &Request) -> Middle
     let rps = config["requests_per_second"].as_f64().unwrap_or(100.0);
     let burst = config["burst"].as_u64().unwrap_or(10) as u32;
 
-    // Evict stale entries if cache is too large.
-    if RATE_LIMITERS.len() > MAX_RATE_LIMITERS {
-        // Cleanup stale per-key state inside each limiter.
+    // Evict stale per-key state if cache is too large or enough time has elapsed.
+    let needs_cleanup = RATE_LIMITERS.len() > MAX_RATE_LIMITERS || {
+        let last = LAST_CLEANUP.lock().unwrap_or_else(|e| e.into_inner());
+        last.elapsed().as_secs() >= CLEANUP_INTERVAL_SECS
+    };
+    if needs_cleanup {
         for entry in RATE_LIMITERS.iter() {
             entry.value().cleanup(std::time::Duration::from_secs(300));
+        }
+        if let Ok(mut last) = LAST_CLEANUP.lock() {
+            *last = Instant::now();
         }
     }
 

--- a/dataplane/novaedge-dataplane/src/middleware/ratelimit.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/ratelimit.rs
@@ -68,7 +68,7 @@ impl TokenBucket {
     /// Check whether a request identified by `key` is allowed.
     pub fn check(&self, key: &str) -> RateLimitResult {
         let now = Instant::now();
-        let mut buckets = self.buckets.write().unwrap();
+        let mut buckets = self.buckets.write().unwrap_or_else(|e| e.into_inner());
         let state = buckets.entry(key.to_string()).or_insert(BucketState {
             tokens: self.config.burst as f64,
             last_refill: now,
@@ -100,14 +100,14 @@ impl TokenBucket {
         let cutoff = Instant::now() - max_age;
         self.buckets
             .write()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .retain(|_, s| s.last_refill > cutoff);
     }
 
     /// Return the number of active (tracked) keys.
     #[allow(dead_code)]
     pub fn active_count(&self) -> usize {
-        self.buckets.read().unwrap().len()
+        self.buckets.read().unwrap_or_else(|e| e.into_inner()).len()
     }
 }
 
@@ -195,7 +195,7 @@ impl SlidingWindow {
     /// If the estimate is >= limit, the request is denied.
     pub fn check(&self, key: &str) -> RateLimitResult {
         let now = Instant::now();
-        let mut windows = self.windows.write().unwrap();
+        let mut windows = self.windows.write().unwrap_or_else(|e| e.into_inner());
         let state = windows.entry(key.to_string()).or_insert(WindowState {
             current_count: 0,
             previous_count: 0,
@@ -238,7 +238,7 @@ impl SlidingWindow {
 
     /// Return the number of active (tracked) keys.
     pub fn active_count(&self) -> usize {
-        self.windows.read().unwrap().len()
+        self.windows.read().unwrap_or_else(|e| e.into_inner()).len()
     }
 }
 

--- a/dataplane/novaedge-dataplane/src/proxy/handler.rs
+++ b/dataplane/novaedge-dataplane/src/proxy/handler.rs
@@ -775,12 +775,25 @@ impl ProxyHandler {
 
                     let primary_fut = self.client.request(upstream_req);
                     let client = &self.client;
+                    let pool = &self.connection_pool;
 
                     tokio::select! {
                         result = primary_fut => result,
                         result = async {
                             tokio::time::sleep(hedge_delay).await;
                             if let Some(req) = hedge_req {
+                                // Acquire a pool guard for the hedge backend before sending.
+                                let _hedge_pool_guard = match pool.acquire(hedge_addr).await {
+                                    Ok(guard) => guard,
+                                    Err(e) => {
+                                        debug!(
+                                            hedge_backend = %hedge_addr,
+                                            error = %e,
+                                            "Hedge request pool limit reached, waiting for primary"
+                                        );
+                                        return std::future::pending().await;
+                                    }
+                                };
                                 debug!(hedge_backend = %hedge_addr, "Sending hedged request");
                                 client.request(req).await
                             } else {


### PR DESCRIPTION
## Summary
- Replace RwLock .unwrap() with poison-safe recovery in cache/ratelimit middleware (#1013)
- Add bcrypt password hashing for BasicAuth (#1020)
- Enforce connection pool limits for hedged requests (#1022)
- Add time-gated cleanup for per-IP rate limiter state (#1023)

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes