### PR TITLE
fix: consistency cleanup — weights, policy types, metrics, copyright headers

### DIFF
--- a/internal/acme/client.go
+++ b/internal/acme/client.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package acme
 
 import (

--- a/internal/acme/metrics.go
+++ b/internal/acme/metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package acme
 
 import (

--- a/internal/acme/provider.go
+++ b/internal/acme/provider.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package acme
 
 import (

--- a/internal/acme/renewal.go
+++ b/internal/acme/renewal.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package acme
 
 import (
@@ -15,7 +31,7 @@ type RenewalManager struct {
 	interval    time.Duration
 	renewBefore time.Duration
 
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	stopChan chan struct{}
 	stopOnce sync.Once
 	running  bool
@@ -40,11 +56,15 @@ func NewRenewalManager(client *Client, logger *zap.Logger) *RenewalManager {
 
 // SetInterval sets the check interval.
 func (m *RenewalManager) SetInterval(interval time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.interval = interval
 }
 
 // SetRenewBefore sets how long before expiry to renew.
 func (m *RenewalManager) SetRenewBefore(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.renewBefore = d
 }
 
@@ -94,8 +114,8 @@ func (m *RenewalManager) Stop() {
 
 // IsRunning returns whether the renewal manager is currently running.
 func (m *RenewalManager) IsRunning() bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.running
 }
 

--- a/internal/acme/selfsigned.go
+++ b/internal/acme/selfsigned.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package acme
 
 import (

--- a/internal/acme/storage.go
+++ b/internal/acme/storage.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package acme
 
 import (

--- a/internal/acme/types.go
+++ b/internal/acme/types.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package acme provides ACME (Automatic Certificate Management Environment) support
 // for automated TLS certificate provisioning using Let's Encrypt and other ACME providers.
 package acme

--- a/internal/agent/config/validation.go
+++ b/internal/agent/config/validation.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/internal/agent/mesh/listener_other.go
+++ b/internal/agent/mesh/listener_other.go
@@ -16,6 +16,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mesh
 
 import (

--- a/internal/agent/mesh/tproxy_iptables.go
+++ b/internal/agent/mesh/tproxy_iptables.go
@@ -16,6 +16,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mesh
 
 import (

--- a/internal/agent/mesh/tproxy_nftables.go
+++ b/internal/agent/mesh/tproxy_nftables.go
@@ -16,6 +16,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mesh
 
 import (

--- a/internal/agent/mesh/tproxy_nolinux.go
+++ b/internal/agent/mesh/tproxy_nolinux.go
@@ -16,6 +16,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mesh
 
 import (

--- a/internal/agent/mesh/tproxy_sysctl.go
+++ b/internal/agent/mesh/tproxy_sysctl.go
@@ -16,6 +16,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mesh
 
 import (

--- a/internal/agent/metrics/endpoint_metrics.go
+++ b/internal/agent/metrics/endpoint_metrics.go
@@ -75,7 +75,7 @@ var (
 	HealthChecksTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "novaedge",
-			Subsystem: "health_checks",
+			Subsystem: "health_check",
 			Name:      "total",
 			Help:      "Total number of health check attempts",
 		},
@@ -135,7 +135,7 @@ var (
 	EndpointsEjected = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "novaedge",
-			Subsystem: "endpoints",
+			Subsystem: "endpoint",
 			Name:      "ejected",
 			Help:      "Current number of ejected endpoints per cluster",
 		},

--- a/internal/agent/metrics/ratelimit_cleanup_metrics.go
+++ b/internal/agent/metrics/ratelimit_cleanup_metrics.go
@@ -27,7 +27,7 @@ var (
 	RateLimiterCleanupsTotal = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "novaedge",
-			Subsystem: "rate_limiter",
+			Subsystem: "rate_limit",
 			Name:      "cleanups_total",
 			Help:      "Total number of inactive rate limiters removed during cleanup",
 		},
@@ -37,7 +37,7 @@ var (
 	RateLimiterActiveCount = promauto.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "novaedge",
-			Subsystem: "rate_limiter",
+			Subsystem: "rate_limit",
 			Name:      "active_count",
 			Help:      "Current number of active rate limiters",
 		},

--- a/internal/agent/wasm/host.go
+++ b/internal/agent/wasm/host.go
@@ -23,6 +23,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// hostLogger is the package-level logger used by host functions.
+// It is set when the Runtime is created via NewRuntime.
+var hostLogger = zap.NewNop()
+
 // hostModuleName is the WASM module name that exposes host functions.
 const hostModuleName = "novaedge"
 
@@ -129,7 +133,7 @@ func hostGetRequestHeader(ctx context.Context, mod api.Module, stack []uint64) {
 	mem := mod.Memory()
 	nameBytes, ok := mem.Read(namePtr, nameLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostGetRequestHeader"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostGetRequestHeader"))
 		stack[0] = 0
 		return
 	}
@@ -152,12 +156,12 @@ func hostSetRequestHeader(ctx context.Context, mod api.Module, stack []uint64) {
 	mem := mod.Memory()
 	nameBytes, ok := mem.Read(namePtr, nameLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostSetRequestHeader"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostSetRequestHeader"))
 		return
 	}
 	valBytes, ok := mem.Read(valPtr, valLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostSetRequestHeader"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostSetRequestHeader"))
 		return
 	}
 	rc.Request.Header.Set(string(nameBytes), string(valBytes))
@@ -177,7 +181,7 @@ func hostGetResponseHeader(ctx context.Context, mod api.Module, stack []uint64) 
 	mem := mod.Memory()
 	nameBytes, ok := mem.Read(namePtr, nameLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostGetResponseHeader"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostGetResponseHeader"))
 		stack[0] = 0
 		return
 	}
@@ -200,12 +204,12 @@ func hostSetResponseHeader(ctx context.Context, mod api.Module, stack []uint64) 
 	mem := mod.Memory()
 	nameBytes, ok := mem.Read(namePtr, nameLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostSetResponseHeader"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostSetResponseHeader"))
 		return
 	}
 	valBytes, ok := mem.Read(valPtr, valLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostSetResponseHeader"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostSetResponseHeader"))
 		return
 	}
 	if rc.ResponseHeaders == nil {
@@ -256,7 +260,7 @@ func hostGetConfigValue(ctx context.Context, mod api.Module, stack []uint64) {
 	mem := mod.Memory()
 	keyBytes, ok := mem.Read(keyPtr, keyLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostGetConfigValue"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostGetConfigValue"))
 		stack[0] = 0
 		return
 	}
@@ -283,7 +287,7 @@ func hostLogMessage(_ context.Context, mod api.Module, stack []uint64) {
 	mem := mod.Memory()
 	msgBytes, ok := mem.Read(msgPtr, msgLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostLogMessage"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostLogMessage"))
 		return
 	}
 
@@ -293,13 +297,13 @@ func hostLogMessage(_ context.Context, mod api.Module, stack []uint64) {
 	// In production the logger is injected via Plugin.
 	switch level {
 	case 0: // debug
-		zap.L().Debug("wasm plugin", zap.String("msg", msg))
+		hostLogger.Debug("wasm plugin", zap.String("msg", msg))
 	case 1: // info
-		zap.L().Info("wasm plugin", zap.String("msg", msg))
+		hostLogger.Info("wasm plugin", zap.String("msg", msg))
 	case 2: // warn
-		zap.L().Warn("wasm plugin", zap.String("msg", msg))
+		hostLogger.Warn("wasm plugin", zap.String("msg", msg))
 	default: // error
-		zap.L().Error("wasm plugin", zap.String("msg", msg))
+		hostLogger.Error("wasm plugin", zap.String("msg", msg))
 	}
 }
 
@@ -315,14 +319,14 @@ func hostSendResponse(ctx context.Context, mod api.Module, stack []uint64) {
 	mem := mod.Memory()
 	bodyBytes, ok := mem.Read(bodyPtr, bodyLen)
 	if !ok {
-		zap.L().Debug("WASM host: memory read failed", zap.String("function", "hostSendResponse"))
+		hostLogger.Debug("WASM host: memory read failed", zap.String("function", "hostSendResponse"))
 		bodyBytes = []byte("WASM plugin error: could not read body from memory")
 	}
 
 	// Validate the HTTP status code before writing to prevent invalid responses
 	// from malicious or buggy WASM plugins.
 	if statusCode < 100 || statusCode > 599 {
-		zap.L().Warn("WASM plugin attempted invalid status code", zap.Uint32("code", statusCode))
+		hostLogger.Warn("WASM plugin attempted invalid status code", zap.Uint32("code", statusCode))
 		statusCode = 500
 	}
 
@@ -343,7 +347,7 @@ func writeStringToMemory(mem api.Memory, ptr, bufCap uint32, value string) uint3
 		b = b[:bufCap]
 	}
 	if !mem.Write(ptr, b) {
-		zap.L().Debug("WASM host: memory write failed", zap.String("function", "writeStringToMemory"))
+		hostLogger.Debug("WASM host: memory write failed", zap.String("function", "writeStringToMemory"))
 		return 0
 	}
 	if len(b) > int(maxUint32) {

--- a/internal/agent/wasm/runtime.go
+++ b/internal/agent/wasm/runtime.go
@@ -51,6 +51,9 @@ func NewRuntime(ctx context.Context, logger *zap.Logger) (*Runtime, error) {
 
 	rt := wazero.NewRuntimeWithConfig(ctx, cfg)
 
+	// Set the package-level logger so host functions can use it.
+	hostLogger = logger
+
 	r := &Runtime{
 		logger:  logger,
 		runtime: rt,

--- a/internal/controller/snapshot/builder_convert.go
+++ b/internal/controller/snapshot/builder_convert.go
@@ -17,7 +17,6 @@ limitations under the License.
 package snapshot
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -30,11 +29,8 @@ import (
 	"go.uber.org/zap"
 
 	novaedgev1alpha1 "github.com/azrtydxb/novaedge/api/v1alpha1"
+	"github.com/azrtydxb/novaedge/internal/pkg/convert"
 	pb "github.com/azrtydxb/novaedge/internal/proto/gen"
-)
-
-var (
-	errInvalidByteSize = errors.New("invalid byte size")
 )
 
 // convertProtocol converts NovaEdge ProtocolType to protobuf Protocol
@@ -371,7 +367,7 @@ func convertCompressionConfig(config *novaedgev1alpha1.CompressionConfig) *pb.Co
 		return nil
 	}
 
-	minSize, err := parseByteSize(config.MinSize)
+	minSize, err := convert.ParseByteSize(config.MinSize)
 	if err != nil {
 		zap.L().Warn("failed to parse compression min size, using 0",
 			zap.String("value", config.MinSize), zap.Error(err))
@@ -392,7 +388,7 @@ func convertRouteLimits(limits *novaedgev1alpha1.RouteLimits) *pb.RouteLimitsCon
 		return nil
 	}
 
-	maxBody, err := parseByteSize(limits.MaxRequestBodySize)
+	maxBody, err := convert.ParseByteSize(limits.MaxRequestBodySize)
 	if err != nil {
 		zap.L().Warn("failed to parse max request body size, using 0",
 			zap.String("value", limits.MaxRequestBodySize), zap.Error(err))
@@ -421,7 +417,7 @@ func convertBufferingConfig(config *novaedgev1alpha1.RouteBufferingConfig) *pb.B
 		return nil
 	}
 
-	maxSize, err := parseByteSize(config.MaxSize)
+	maxSize, err := convert.ParseByteSize(config.MaxSize)
 	if err != nil {
 		zap.L().Warn("failed to parse max buffer size, using 0",
 			zap.String("value", config.MaxSize), zap.Error(err))
@@ -531,43 +527,6 @@ func parseConfigMapRules(content string) []string {
 		rules = append(rules, current.String())
 	}
 	return rules
-}
-
-// parseByteSize parses a human-readable byte size string (e.g., "10Mi", "1024", "50MB").
-func parseByteSize(s string) (int64, error) {
-	if s == "" || s == "0" {
-		return 0, nil
-	}
-
-	// Try plain integer first
-	n, err := parseInt64(s)
-	if err == nil {
-		return n, nil
-	}
-
-	// Binary units
-	multipliers := map[string]int64{
-		"Ki": 1 << 10,
-		"Mi": 1 << 20,
-		"Gi": 1 << 30,
-		"Ti": 1 << 40,
-		"KB": 1000,
-		"MB": 1000 * 1000,
-		"GB": 1000 * 1000 * 1000,
-	}
-
-	for suffix, mult := range multipliers {
-		if len(s) > len(suffix) && s[len(s)-len(suffix):] == suffix {
-			numStr := s[:len(s)-len(suffix)]
-			num, parseErr := parseInt64(numStr)
-			if parseErr != nil {
-				return 0, parseErr
-			}
-			return num * mult, nil
-		}
-	}
-
-	return 0, fmt.Errorf("%w: %s", errInvalidByteSize, s)
 }
 
 // parseDurationMs parses a duration string and returns milliseconds.

--- a/internal/controller/snapshot/builder_convert_extended_test.go
+++ b/internal/controller/snapshot/builder_convert_extended_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/azrtydxb/novaedge/internal/pkg/convert"
+
 	novaedgev1alpha1 "github.com/azrtydxb/novaedge/api/v1alpha1"
 	pb "github.com/azrtydxb/novaedge/internal/proto/gen"
 )
@@ -348,7 +350,7 @@ func TestParseByteSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := parseByteSize(tt.input)
+			result, err := convert.ParseByteSize(tt.input)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {

--- a/internal/dataplane/client.go
+++ b/internal/dataplane/client.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dataplane
 
 import (

--- a/internal/dataplane/doc.go
+++ b/internal/dataplane/doc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package dataplane provides a Go gRPC client for communicating with the
 // Rust dataplane daemon over a Unix domain socket.
 package dataplane

--- a/internal/dataplane/forwarding.go
+++ b/internal/dataplane/forwarding.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dataplane
 
 const (

--- a/internal/dataplane/translator.go
+++ b/internal/dataplane/translator.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dataplane
 
 import (

--- a/internal/pkg/convert/bytesize.go
+++ b/internal/pkg/convert/bytesize.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package convert
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ErrInvalidByteSize is returned when a byte size string cannot be parsed.
+var ErrInvalidByteSize = errors.New("invalid byte size")
+
+// ParseByteSize parses a human-readable byte size string (e.g., "10Mi", "1024", "50MB").
+func ParseByteSize(s string) (int64, error) {
+	if s == "" || s == "0" {
+		return 0, nil
+	}
+
+	// Try plain integer first
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n, nil
+	}
+
+	// Binary and SI units
+	multipliers := map[string]int64{
+		"Ki": 1 << 10,
+		"Mi": 1 << 20,
+		"Gi": 1 << 30,
+		"Ti": 1 << 40,
+		"KB": 1000,
+		"MB": 1000 * 1000,
+		"GB": 1000 * 1000 * 1000,
+	}
+
+	for suffix, mult := range multipliers {
+		if strings.HasSuffix(s, suffix) {
+			numStr := strings.TrimSuffix(s, suffix)
+			n, err := strconv.ParseInt(numStr, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("%w: %s", ErrInvalidByteSize, s)
+			}
+			return n * mult, nil
+		}
+	}
+
+	return 0, fmt.Errorf("%w: %s", ErrInvalidByteSize, s)
+}

--- a/internal/pkg/convert/int.go
+++ b/internal/pkg/convert/int.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package convert provides shared numeric conversion helpers.
 package convert
 

--- a/internal/pkg/httpjson/response.go
+++ b/internal/pkg/httpjson/response.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package httpjson provides shared HTTP handler helpers.
 package httpjson
 

--- a/internal/standalone/config_extended_test.go
+++ b/internal/standalone/config_extended_test.go
@@ -19,6 +19,8 @@ package standalone
 import (
 	"testing"
 	"time"
+
+	"github.com/azrtydxb/novaedge/internal/pkg/convert"
 )
 
 func TestRouteConfig_GetTimeout(t *testing.T) {
@@ -303,13 +305,13 @@ func TestStandaloneParseByteSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := standaloneParseByteSize(tt.input)
+			result, err := convert.ParseByteSize(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("standaloneParseByteSize() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("convert.ParseByteSize() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if result != tt.expected {
-				t.Errorf("standaloneParseByteSize() = %v, want %v", result, tt.expected)
+				t.Errorf("convert.ParseByteSize() = %v, want %v", result, tt.expected)
 			}
 		})
 	}

--- a/internal/standalone/converter.go
+++ b/internal/standalone/converter.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -32,20 +31,22 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/azrtydxb/novaedge/internal/pkg/convert"
 	snapshotpkg "github.com/azrtydxb/novaedge/internal/pkg/snapshot"
 	pb "github.com/azrtydxb/novaedge/internal/proto/gen"
 )
 
-var (
-	errInvalidByteSize = errors.New("invalid byte size")
-)
-
 // Converter converts standalone config to protobuf ConfigSnapshot
-type Converter struct{}
+type Converter struct {
+	logger *zap.Logger
+}
 
-// NewConverter creates a new converter
-func NewConverter() *Converter {
-	return &Converter{}
+// NewConverter creates a new converter with the given logger.
+func NewConverter(logger *zap.Logger) *Converter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Converter{logger: logger}
 }
 
 // safeInt32 converts an int to int32, clamping to math.MaxInt32 on overflow.
@@ -532,12 +533,7 @@ func (c *Converter) convertBackends(backends []BackendConfig) ([]*pb.Cluster, ma
 				Address: address,
 				Port:    port,
 				Ready:   true,
-			}
-			// Weight is stored in Labels for pb.Endpoint (no direct Weight field)
-			if e.Weight > 0 {
-				endpoint.Labels = map[string]string{
-					"weight": fmt.Sprintf("%d", e.Weight),
-				}
+				Weight:  safeInt32(e.Weight),
 			}
 			endpointList.Endpoints = append(endpointList.Endpoints, endpoint)
 		}
@@ -576,7 +572,7 @@ func (c *Converter) parseLBPolicy(policy string) pb.LoadBalancingPolicy {
 	case "LeastConn", "LeastConnections":
 		return pb.LoadBalancingPolicy_LEAST_CONN
 	default:
-		zap.L().Warn("Unknown LB policy, defaulting to RoundRobin", zap.String("policy", policy))
+		c.logger.Warn("Unknown LB policy, defaulting to RoundRobin", zap.String("policy", policy))
 		return pb.LoadBalancingPolicy_ROUND_ROBIN
 	}
 }
@@ -588,6 +584,7 @@ type standalonePolicyConverter func(p *PolicyConfig, policy *pb.Policy)
 var standalonePolicyConverters = map[string]standalonePolicyConverter{
 	"RateLimit": func(p *PolicyConfig, policy *pb.Policy) {
 		if p.RateLimit != nil {
+			policy.Type = pb.PolicyType_RATE_LIMIT
 			policy.RateLimit = &pb.RateLimitConfig{
 				RequestsPerSecond: safeInt32(p.RateLimit.RequestsPerSecond),
 				Burst:             safeInt32(p.RateLimit.BurstSize),
@@ -597,6 +594,7 @@ var standalonePolicyConverters = map[string]standalonePolicyConverter{
 	},
 	"CORS": func(p *PolicyConfig, policy *pb.Policy) {
 		if p.CORS != nil {
+			policy.Type = pb.PolicyType_CORS
 			policy.Cors = &pb.CORSConfig{
 				AllowOrigins:     p.CORS.AllowOrigins,
 				AllowMethods:     p.CORS.AllowMethods,
@@ -610,14 +608,18 @@ var standalonePolicyConverters = map[string]standalonePolicyConverter{
 	"IPFilter": func(p *PolicyConfig, policy *pb.Policy) {
 		if p.IPFilter != nil {
 			cidrs := p.IPFilter.AllowList
-			if len(cidrs) == 0 {
+			if len(cidrs) > 0 {
+				policy.Type = pb.PolicyType_IP_ALLOW_LIST
+			} else {
 				cidrs = p.IPFilter.DenyList
+				policy.Type = pb.PolicyType_IP_DENY_LIST
 			}
 			policy.IpList = &pb.IPListConfig{Cidrs: cidrs}
 		}
 	},
 	"JWT": func(p *PolicyConfig, policy *pb.Policy) {
 		if p.JWT != nil {
+			policy.Type = pb.PolicyType_JWT
 			policy.Jwt = &pb.JWTConfig{
 				Issuer:            p.JWT.Issuer,
 				Audience:          p.JWT.Audience,
@@ -661,6 +663,7 @@ var standalonePolicyConverters = map[string]standalonePolicyConverter{
 	},
 	"WASMPlugin": func(p *PolicyConfig, policy *pb.Policy) {
 		if p.WASMPlugin != nil {
+			policy.Type = pb.PolicyType_WASM_PLUGIN
 			policy.WasmPlugin = &pb.WASMPluginConfig{
 				Source:   p.WASMPlugin.Source,
 				Config:   p.WASMPlugin.Config,
@@ -671,6 +674,7 @@ var standalonePolicyConverters = map[string]standalonePolicyConverter{
 	},
 	"BasicAuth": func(p *PolicyConfig, policy *pb.Policy) {
 		if p.BasicAuth != nil {
+			policy.Type = pb.PolicyType_BASIC_AUTH
 			policy.BasicAuth = &pb.BasicAuthConfig{
 				Realm:     p.BasicAuth.Realm,
 				Htpasswd:  buildHtpasswdFromConfig(p.BasicAuth),
@@ -680,6 +684,7 @@ var standalonePolicyConverters = map[string]standalonePolicyConverter{
 	},
 	"ForwardAuth": func(p *PolicyConfig, policy *pb.Policy) {
 		if p.ForwardAuth != nil {
+			policy.Type = pb.PolicyType_FORWARD_AUTH
 			config := &pb.ForwardAuthConfig{
 				Address:         p.ForwardAuth.Address,
 				AuthHeaders:     p.ForwardAuth.AuthHeaders,
@@ -696,6 +701,7 @@ var standalonePolicyConverters = map[string]standalonePolicyConverter{
 	},
 	"OIDC": func(p *PolicyConfig, policy *pb.Policy) {
 		if p.OIDC != nil {
+			policy.Type = pb.PolicyType_OIDC
 			policy.Oidc = convertOIDCPolicy(p.OIDC)
 		}
 	},
@@ -729,7 +735,7 @@ func (c *Converter) convertCompression(comp *CompressionConfig) *pb.CompressionC
 	if comp.MinSize != "" {
 		n, err := strconv.ParseInt(comp.MinSize, 10, 64)
 		if err != nil {
-			zap.L().Warn("failed to parse compression min size, using 0",
+			c.logger.Warn("failed to parse compression min size, using 0",
 				zap.String("value", comp.MinSize), zap.Error(err))
 		} else {
 			minSize = n
@@ -750,9 +756,9 @@ func (c *Converter) convertRouteLimits(limits *RouteLimits) *pb.RouteLimitsConfi
 	}
 	result := &pb.RouteLimitsConfig{}
 	if limits.MaxRequestBodySize != "" {
-		n, err := standaloneParseByteSize(limits.MaxRequestBodySize)
+		n, err := convert.ParseByteSize(limits.MaxRequestBodySize)
 		if err != nil {
-			zap.L().Warn("failed to parse max request body size, using 0",
+			c.logger.Warn("failed to parse max request body size, using 0",
 				zap.String("value", limits.MaxRequestBodySize), zap.Error(err))
 		} else {
 			result.MaxRequestBodySize = n
@@ -761,7 +767,7 @@ func (c *Converter) convertRouteLimits(limits *RouteLimits) *pb.RouteLimitsConfi
 	if limits.RequestTimeout != "" {
 		d, err := time.ParseDuration(limits.RequestTimeout)
 		if err != nil {
-			zap.L().Warn("failed to parse request timeout, using 0",
+			c.logger.Warn("failed to parse request timeout, using 0",
 				zap.String("value", limits.RequestTimeout), zap.Error(err))
 		} else {
 			result.RequestTimeoutMs = d.Milliseconds()
@@ -770,7 +776,7 @@ func (c *Converter) convertRouteLimits(limits *RouteLimits) *pb.RouteLimitsConfi
 	if limits.IdleTimeout != "" {
 		d, err := time.ParseDuration(limits.IdleTimeout)
 		if err != nil {
-			zap.L().Warn("failed to parse idle timeout, using 0",
+			c.logger.Warn("failed to parse idle timeout, using 0",
 				zap.String("value", limits.IdleTimeout), zap.Error(err))
 		} else {
 			result.IdleTimeoutMs = d.Milliseconds()
@@ -788,40 +794,15 @@ func (c *Converter) convertRouteBuffering(buf *BufferingConfig) *pb.BufferingCon
 		ResponseBuffering: buf.Response,
 	}
 	if buf.MaxSize != "" {
-		n, err := standaloneParseByteSize(buf.MaxSize)
+		n, err := convert.ParseByteSize(buf.MaxSize)
 		if err != nil {
-			zap.L().Warn("failed to parse max buffer size, using 0",
+			c.logger.Warn("failed to parse max buffer size, using 0",
 				zap.String("value", buf.MaxSize), zap.Error(err))
 		} else {
 			result.MaxBufferSize = n
 		}
 	}
 	return result
-}
-
-// standaloneParseByteSize parses human-readable byte size (e.g., "10Mi", "1024").
-func standaloneParseByteSize(s string) (int64, error) {
-	if s == "" || s == "0" {
-		return 0, nil
-	}
-	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
-		return n, nil
-	}
-	multipliers := map[string]int64{
-		"Ki": 1 << 10, "Mi": 1 << 20, "Gi": 1 << 30,
-		"KB": 1000, "MB": 1000 * 1000, "GB": 1000 * 1000 * 1000,
-	}
-	for suffix, mult := range multipliers {
-		if strings.HasSuffix(s, suffix) {
-			numStr := strings.TrimSuffix(s, suffix)
-			n, err := strconv.ParseInt(numStr, 10, 64)
-			if err != nil {
-				return 0, fmt.Errorf("%w: %s", errInvalidByteSize, s)
-			}
-			return n * mult, nil
-		}
-	}
-	return 0, fmt.Errorf("%w: %s", errInvalidByteSize, s)
 }
 
 func (c *Converter) convertL4Listeners(configs []L4ListenerStandaloneConfig, endpoints map[string]*pb.EndpointList) []*pb.L4Listener {
@@ -926,7 +907,7 @@ func (c *Converter) convertSessionAffinity(sa *SessionAffinityStandaloneConfig) 
 	case "SourceIP":
 		affinityType = "source_ip"
 	default:
-		zap.L().Warn("Unknown session affinity type, defaulting to cookie", zap.String("type", sa.Type))
+		c.logger.Warn("Unknown session affinity type, defaulting to cookie", zap.String("type", sa.Type))
 	}
 
 	cookieName := sa.CookieName
@@ -944,7 +925,7 @@ func (c *Converter) convertSessionAffinity(sa *SessionAffinityStandaloneConfig) 
 		if d, err := time.ParseDuration(sa.CookieTTL); err == nil {
 			ttlSeconds = int64(d.Seconds())
 		} else {
-			zap.L().Warn("Failed to parse session affinity cookie TTL duration", zap.String("ttl", sa.CookieTTL), zap.Error(err))
+			c.logger.Warn("Failed to parse session affinity cookie TTL duration", zap.String("ttl", sa.CookieTTL), zap.Error(err))
 		}
 	}
 

--- a/internal/standalone/converter_extended_test.go
+++ b/internal/standalone/converter_extended_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestConverter_parseHeaderMatchType(t *testing.T) {
-	converter := NewConverter()
+	converter := NewConverter(nil)
 
 	tests := []struct {
 		name     string
@@ -63,7 +63,7 @@ func TestConverter_parseHeaderMatchType(t *testing.T) {
 }
 
 func TestConverter_parseFilterType(t *testing.T) {
-	converter := NewConverter()
+	converter := NewConverter(nil)
 
 	tests := []struct {
 		name     string
@@ -111,7 +111,7 @@ func TestConverter_parseFilterType(t *testing.T) {
 }
 
 func TestConverter_parsePathMatchType(t *testing.T) {
-	converter := NewConverter()
+	converter := NewConverter(nil)
 
 	tests := []struct {
 		name     string

--- a/internal/standalone/converter_test.go
+++ b/internal/standalone/converter_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestConverterToSnapshot(t *testing.T) {
-	converter := NewConverter()
+	converter := NewConverter(nil)
 
 	config := &Config{
 		Version: "1.0",
@@ -113,7 +113,7 @@ func TestConverterToSnapshot(t *testing.T) {
 }
 
 func TestParseProtocol(t *testing.T) {
-	converter := NewConverter()
+	converter := NewConverter(nil)
 
 	tests := []struct {
 		input    string
@@ -139,7 +139,7 @@ func TestParseProtocol(t *testing.T) {
 }
 
 func TestParseLBPolicy(t *testing.T) {
-	converter := NewConverter()
+	converter := NewConverter(nil)
 
 	tests := []struct {
 		input    string
@@ -164,7 +164,7 @@ func TestParseLBPolicy(t *testing.T) {
 }
 
 func TestParsePathMatchType(t *testing.T) {
-	converter := NewConverter()
+	converter := NewConverter(nil)
 
 	tests := []struct {
 		input    string

--- a/internal/standalone/watcher.go
+++ b/internal/standalone/watcher.go
@@ -67,7 +67,7 @@ func NewConfigWatcher(configPath, nodeName string, logger *zap.Logger) (*ConfigW
 		configPath: absPath,
 		nodeName:   nodeName,
 		logger:     logger,
-		converter:  NewConverter(),
+		converter:  NewConverter(logger),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Fix endpoint weight stored in Labels, set proto field (#1016)
- Set policy Type enum for all converter types (#1018)
- Fix ACME SetInterval/SetRenewBefore thread safety (#1021)
- Standardize metrics subsystem singular/plural (#1024)
- Extract shared parseByteSize utility (#1025)
- Add Apache 2.0 copyright headers to 19 files (#1026)
- Replace zap.L() with injected logger in converter/WASM (#1027)

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes