### PR TITLE
fix: XML injection, secret overfetch, mesh conn leak, Vault TLS warning

### DIFF
--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -102,6 +102,7 @@ type agentComponents struct {
 	gossiper      *gossip.ConfigGossiper
 	novanetClient *novanet.Client
 	meshManager   *mesh.Manager
+	meshConn      *grpc.ClientConn
 	sdwanManager  *sdwan.Manager
 	dpClient      *dpctl.Client
 	dpTranslator  *dpctl.Translator
@@ -346,6 +347,7 @@ func startAgentManagers(ctx context.Context, logger *zap.Logger, comp *agentComp
 		if meshConnErr != nil {
 			logger.Fatal("Failed to create gRPC connection for mesh cert requester", zap.Error(meshConnErr))
 		}
+		comp.meshConn = meshConn
 		comp.meshManager.StartCertRequester(ctx, nodeName, meshConn)
 	}
 
@@ -484,6 +486,11 @@ func shutdownAgent(logger *zap.Logger, comp *agentComponents) {
 	if comp.meshManager != nil {
 		if err := comp.meshManager.Shutdown(shutdownCtx); err != nil {
 			logger.Error("Error during mesh manager shutdown", zap.Error(err))
+		}
+	}
+	if comp.meshConn != nil {
+		if err := comp.meshConn.Close(); err != nil {
+			logger.Error("Error closing mesh gRPC connection", zap.Error(err))
 		}
 	}
 	if comp.dpClient != nil {

--- a/internal/acme/dns/route53.go
+++ b/internal/acme/dns/route53.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
@@ -108,6 +109,11 @@ func (p *Route53Provider) changeRecord(ctx context.Context, action, fqdn, value 
 		recordName += "."
 	}
 
+	// Escape interpolated values to prevent XML injection.
+	safeAction := html.EscapeString(action)
+	safeRecordName := html.EscapeString(recordName)
+	safeValue := html.EscapeString(value)
+
 	// Build Route53 XML payload
 	payload := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
@@ -129,7 +135,7 @@ func (p *Route53Provider) changeRecord(ctx context.Context, action, fqdn, value 
       </Change>
     </Changes>
   </ChangeBatch>
-</ChangeResourceRecordSetsRequest>`, action, recordName, value)
+</ChangeResourceRecordSetsRequest>`, safeAction, safeRecordName, safeValue)
 
 	apiURL := fmt.Sprintf("%s/2013-04-01/hostedzone/%s/rrset",
 		route53APIBase, url.PathEscape(p.hostedZoneID))

--- a/internal/agent/mesh/tproxy_nolinux.go
+++ b/internal/agent/mesh/tproxy_nolinux.go
@@ -16,25 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-Copyright 2024 NovaEdge Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package mesh
 
 import (
+	"context"
 	"errors"
 
 	"go.uber.org/zap"
@@ -49,15 +34,15 @@ type stubBackend struct{}
 
 func (s *stubBackend) Name() string { return "stub" }
 
-func (s *stubBackend) Setup() error {
+func (s *stubBackend) Setup(_ context.Context) error {
 	return errTPROXYIsOnlySupportedOnLinux
 }
 
-func (s *stubBackend) ApplyRules(_ []InterceptTarget, _ int32) error {
+func (s *stubBackend) ApplyRules(_ context.Context, _ []InterceptTarget, _ int32) error {
 	return errTPROXYIsOnlySupportedOnLinux
 }
 
-func (s *stubBackend) Cleanup() error { return nil }
+func (s *stubBackend) Cleanup(_ context.Context) error { return nil }
 
 // detectBackend returns a stub backend on non-Linux platforms.
 func detectBackend(_ *zap.Logger) RuleBackend {

--- a/internal/controller/snapshot/builder.go
+++ b/internal/controller/snapshot/builder.go
@@ -174,14 +174,18 @@ func (b *Builder) prefetch(ctx context.Context) (*buildContext, error) {
 		bc.nodes[nodeList.Items[i].Name] = &nodeList.Items[i]
 	}
 
-	// --- Secrets: batch-fetch all TLS and auth secrets ---
-	secretList := &corev1.SecretList{}
-	if err := b.client.List(ctx, secretList); err != nil {
-		return nil, fmt.Errorf("failed to list secrets: %w", err)
-	}
-	for i := range secretList.Items {
-		key := secretList.Items[i].Namespace + "/" + secretList.Items[i].Name
-		bc.secrets[key] = &secretList.Items[i]
+	// --- Secrets: fetch only those referenced by gateways, backends, and policies ---
+	secretRefs := collectReferencedSecrets(bc)
+	prefetchLog := log.FromContext(ctx)
+	for ref := range secretRefs {
+		secret := &corev1.Secret{}
+		if err := b.client.Get(ctx, ref, secret); err != nil {
+			prefetchLog.V(1).Info("Referenced secret not found",
+				"namespace", ref.Namespace, "name", ref.Name)
+			continue
+		}
+		key := secret.Namespace + "/" + secret.Name
+		bc.secrets[key] = secret
 	}
 
 	// --- ConfigMaps: batch-fetch for WAF rules and WASM binaries ---
@@ -210,6 +214,84 @@ func (b *Builder) prefetch(ctx context.Context) (*buildContext, error) {
 	}
 
 	return bc, nil
+}
+
+// secretRefSet accumulates unique secret references.
+type secretRefSet map[client.ObjectKey]struct{}
+
+func (s secretRefSet) add(ns, name string) {
+	if name != "" {
+		s[client.ObjectKey{Namespace: ns, Name: name}] = struct{}{}
+	}
+}
+
+// collectReferencedSecrets scans the already-fetched CRDs (gateways, backends,
+// policies) and returns the set of secret object keys they reference via TLS,
+// mTLS CA, backend TLS, and auth configurations.
+func collectReferencedSecrets(bc *buildContext) secretRefSet {
+	refs := make(secretRefSet)
+	collectGatewaySecretRefs(bc.gateways, refs)
+	collectBackendSecretRefs(bc.backends, refs)
+	collectPolicySecretRefs(bc.policies, refs)
+	return refs
+}
+
+// collectGatewaySecretRefs adds secret references from gateway listeners.
+func collectGatewaySecretRefs(gateways []novaedgev1alpha1.ProxyGateway, refs secretRefSet) {
+	for i := range gateways {
+		gw := &gateways[i]
+		for _, l := range gw.Spec.Listeners {
+			if l.TLS != nil && l.TLS.SecretRef != nil {
+				refs.add(secretRefNS(l.TLS.SecretRef.Namespace, gw.Namespace), l.TLS.SecretRef.Name)
+			}
+			for _, tlsCfg := range l.TLSCertificates {
+				if tlsCfg.SecretRef != nil {
+					refs.add(secretRefNS(tlsCfg.SecretRef.Namespace, gw.Namespace), tlsCfg.SecretRef.Name)
+				}
+			}
+			if l.ClientAuth != nil && l.ClientAuth.CACertRef != nil {
+				refs.add(secretRefNS(l.ClientAuth.CACertRef.Namespace, gw.Namespace), l.ClientAuth.CACertRef.Name)
+			}
+		}
+	}
+}
+
+// collectBackendSecretRefs adds secret references from backend TLS configs.
+func collectBackendSecretRefs(backends []novaedgev1alpha1.ProxyBackend, refs secretRefSet) {
+	for i := range backends {
+		b := &backends[i]
+		if b.Spec.TLS == nil {
+			continue
+		}
+		if b.Spec.TLS.CACertSecretRef != nil && *b.Spec.TLS.CACertSecretRef != "" {
+			refs.add(b.Namespace, *b.Spec.TLS.CACertSecretRef)
+		}
+		if b.Spec.TLS.ClientCertSecretRef != nil && *b.Spec.TLS.ClientCertSecretRef != "" {
+			refs.add(b.Namespace, *b.Spec.TLS.ClientCertSecretRef)
+		}
+	}
+}
+
+// collectPolicySecretRefs adds secret references from policy auth configs.
+func collectPolicySecretRefs(policies []novaedgev1alpha1.ProxyPolicy, refs secretRefSet) {
+	for i := range policies {
+		p := &policies[i]
+		if p.Spec.BasicAuth != nil {
+			refs.add(p.Namespace, p.Spec.BasicAuth.SecretRef.Name)
+		}
+		if p.Spec.OIDC != nil {
+			refs.add(p.Namespace, p.Spec.OIDC.ClientSecretRef.Name)
+			refs.add(p.Namespace, p.Spec.OIDC.SessionSecretRef.Name)
+		}
+	}
+}
+
+// secretRefNS returns ns if non-empty, otherwise defaultNS.
+func secretRefNS(ns, defaultNS string) string {
+	if ns == "" {
+		return defaultNS
+	}
+	return ns
 }
 
 // getSecret returns a pre-fetched Secret from the build context.

--- a/internal/controller/vault/client.go
+++ b/internal/controller/vault/client.go
@@ -139,6 +139,7 @@ type vaultHTTPClient struct {
 	namespace  string
 	caCert     string
 	skipTLS    bool
+	logger     *zap.Logger
 	client     *http.Client
 	clientOnce sync.Once
 }
@@ -167,6 +168,7 @@ func NewClient(config *Config, logger *zap.Logger) (*Client, error) {
 			namespace: config.Namespace,
 			caCert:    config.CACert,
 			skipTLS:   config.TLSSkipVerify,
+			logger:    logger,
 		},
 	}
 

--- a/internal/controller/vault/http.go
+++ b/internal/controller/vault/http.go
@@ -31,6 +31,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 var (
@@ -192,6 +194,11 @@ func (c *vaultHTTPClient) cachedHTTPClient() (*http.Client, error) {
 // Call cachedHTTPClient() instead to reuse the client across requests.
 func (c *vaultHTTPClient) newHTTPClient() (*http.Client, error) {
 	transport := &http.Transport{}
+
+	if c.skipTLS {
+		c.logger.Warn("Vault TLS verification is disabled (InsecureSkipVerify=true) -- this is insecure and should only be used in dev/test environments",
+			zap.String("vault_address", c.address))
+	}
 
 	//nolint:gosec // G402: InsecureSkipVerify is user-configurable via ProxyVaultConfig CRD for dev/test environments
 	tlsConfig := &tls.Config{


### PR DESCRIPTION
## Summary
- Fix XML injection in Route53 DNS API (#1032) — html.EscapeString on interpolated values
- Fix snapshot builder prefetching all cluster Secrets (#1033) — fetch only referenced secrets
- Fix mesh gRPC connection leak in agent (#1035) — store and close in shutdown
- Add warning log for Vault InsecureSkipVerify (#1046)

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes