### PR TITLE
fix: prober goroutine leak, iptables context, duplicate headers and errors

### DIFF
--- a/internal/acme/client.go
+++ b/internal/acme/client.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	errConfigIsRequired                = errors.New("config is required")
+	errConfigIsRequired                = errors.New("ACME config is required")
 	errStorageIsRequired               = errors.New("storage is required")
 	errFailedToDecodeAccountPrivateKey = errors.New("failed to decode account private key")
 	errUnsupportedPrivateKeyType       = errors.New("unsupported private key type")

--- a/internal/agent/mesh/manager.go
+++ b/internal/agent/mesh/manager.go
@@ -242,7 +242,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		m.tproxy = NewTPROXYManager(m.logger, m.tproxyPort)
 	}
 
-	if err := m.tproxy.Setup(); err != nil {
+	if err := m.tproxy.Setup(ctx); err != nil {
 		return fmt.Errorf("TPROXY setup failed: %w", err)
 	}
 
@@ -326,7 +326,7 @@ func (m *Manager) ApplyConfig(ctx context.Context, services []*pb.InternalServic
 	}
 
 	// Reconcile iptables rules
-	if err := m.tproxy.ApplyRules(targets); err != nil {
+	if err := m.tproxy.ApplyRules(ctx, targets); err != nil {
 		return fmt.Errorf("failed to apply TPROXY rules: %w", err)
 	}
 
@@ -622,7 +622,7 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	}
 
 	if m.tproxy != nil {
-		if err := m.tproxy.Cleanup(); err != nil {
+		if err := m.tproxy.Cleanup(ctx); err != nil {
 			m.logger.Error("TPROXY cleanup failed", zap.Error(err))
 		}
 	}

--- a/internal/agent/mesh/tproxy.go
+++ b/internal/agent/mesh/tproxy.go
@@ -115,6 +115,7 @@ limitations under the License.
 package mesh
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -129,18 +130,18 @@ import (
 type RuleBackend interface {
 	// Setup initialises chains/tables needed for NAT REDIRECT interception.
 	// It is called once before the first ApplyRules call.
-	Setup() error
+	Setup(ctx context.Context) error
 
 	// ApplyRules reconciles the set of intercepted targets so that, after
 	// the call returns, only the given targets are matched. The nftables
 	// backend applies changes atomically via a single netlink batch; the
 	// iptables backend applies per-rule changes and may partially fail
 	// (errors are aggregated and returned).
-	ApplyRules(targets []InterceptTarget, tproxyPort int32) error
+	ApplyRules(ctx context.Context, targets []InterceptTarget, tproxyPort int32) error
 
 	// Cleanup removes all rules, chains/tables, and routing entries
 	// created by Setup/ApplyRules.
-	Cleanup() error
+	Cleanup(ctx context.Context) error
 
 	// Name returns a human-readable backend identifier (e.g. "nftables").
 	Name() string
@@ -200,11 +201,11 @@ func NewTPROXYManagerWithBackend(logger *zap.Logger, tproxyPort int32, backend R
 
 // Setup initializes the backend (chains/tables and routing rules).
 // Must be called before ApplyRules.
-func (m *TPROXYManager) Setup() error {
+func (m *TPROXYManager) Setup(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if err := m.backend.Setup(); err != nil {
+	if err := m.backend.Setup(ctx); err != nil {
 		return fmt.Errorf("TPROXY backend setup failed (%s): %w", m.backend.Name(), err)
 	}
 	return nil
@@ -212,11 +213,11 @@ func (m *TPROXYManager) Setup() error {
 
 // ApplyRules reconciles TPROXY rules to match the desired set of
 // intercepted ClusterIP:port pairs.
-func (m *TPROXYManager) ApplyRules(desired []InterceptTarget) error {
+func (m *TPROXYManager) ApplyRules(ctx context.Context, desired []InterceptTarget) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if err := m.backend.ApplyRules(desired, m.tproxyPort); err != nil {
+	if err := m.backend.ApplyRules(ctx, desired, m.tproxyPort); err != nil {
 		return fmt.Errorf("TPROXY apply rules failed (%s): %w", m.backend.Name(), err)
 	}
 
@@ -233,11 +234,11 @@ func (m *TPROXYManager) ApplyRules(desired []InterceptTarget) error {
 }
 
 // Cleanup removes all TPROXY rules and routing entries.
-func (m *TPROXYManager) Cleanup() error {
+func (m *TPROXYManager) Cleanup(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if err := m.backend.Cleanup(); err != nil {
+	if err := m.backend.Cleanup(ctx); err != nil {
 		m.logger.Error("TPROXY cleanup failed",
 			zap.String("backend", m.backend.Name()),
 			zap.Error(err))

--- a/internal/agent/mesh/tproxy_iptables.go
+++ b/internal/agent/mesh/tproxy_iptables.go
@@ -16,22 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-Copyright 2024 NovaEdge Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package mesh
 
 import (
@@ -72,14 +56,14 @@ func (b *iptablesBackend) Name() string { return "iptables" }
 // PREROUTING jump. The chain is inserted at the top of PREROUTING to
 // fire before kube-proxy's KUBE-SERVICES chain, preserving the original
 // ClusterIP destination in conntrack for SO_ORIGINAL_DST retrieval.
-func (b *iptablesBackend) Setup() error {
+func (b *iptablesBackend) Setup(ctx context.Context) error {
 	// Verify route_localnet is enabled (set by the sysctl-setup init container in k8s,
 	// or written directly in standalone/privileged mode).
 	if err := ensureRouteLocalnet(); err != nil {
 		return err
 	}
 
-	if err := b.ensureChain(); err != nil {
+	if err := b.ensureChain(ctx); err != nil {
 		return fmt.Errorf("failed to create iptables chain: %w", err)
 	}
 	return nil
@@ -89,7 +73,7 @@ func (b *iptablesBackend) Setup() error {
 // desired set. Rules for removed services are deleted; rules for new
 // services are added. Errors from individual rule operations are
 // aggregated and returned so callers can detect partial failures.
-func (b *iptablesBackend) ApplyRules(targets []InterceptTarget, tproxyPort int32) error {
+func (b *iptablesBackend) ApplyRules(ctx context.Context, targets []InterceptTarget, tproxyPort int32) error {
 	desired := make(map[string]InterceptTarget, len(targets))
 	for _, t := range targets {
 		desired[t.Key()] = t
@@ -107,7 +91,7 @@ func (b *iptablesBackend) ApplyRules(targets []InterceptTarget, tproxyPort int32
 				delete(b.currentRules, key)
 				continue
 			}
-			if err := b.removeRule(parts[0], parts[1], tproxyPort); err != nil {
+			if err := b.removeRule(ctx, parts[0], parts[1], tproxyPort); err != nil {
 				b.logger.Error("Failed to remove iptables DNAT rule",
 					zap.String("key", key), zap.Error(err))
 				errs = append(errs, fmt.Errorf("remove %s: %w", key, err))
@@ -121,7 +105,7 @@ func (b *iptablesBackend) ApplyRules(targets []InterceptTarget, tproxyPort int32
 	// Add rules for newly desired services.
 	for key, t := range desired {
 		if !b.currentRules[key] {
-			if err := b.addRule(t.ClusterIP, t.Port, tproxyPort); err != nil {
+			if err := b.addRule(ctx, t.ClusterIP, t.Port, tproxyPort); err != nil {
 				b.logger.Error("Failed to add iptables DNAT rule",
 					zap.String("clusterIP", t.ClusterIP),
 					zap.Int32("port", t.Port),
@@ -137,11 +121,11 @@ func (b *iptablesBackend) ApplyRules(targets []InterceptTarget, tproxyPort int32
 
 // Cleanup removes all DNAT rules, the custom chain, and the
 // PREROUTING jump.
-func (b *iptablesBackend) Cleanup() error {
+func (b *iptablesBackend) Cleanup(ctx context.Context) error {
 	if b.chainCreated {
-		_ = b.run("-t", "nat", "-D", "PREROUTING", "-j", novaedgeChain)
-		_ = b.run("-t", "nat", "-F", novaedgeChain)
-		_ = b.run("-t", "nat", "-X", novaedgeChain)
+		_ = b.run(ctx, "-t", "nat", "-D", "PREROUTING", "-j", novaedgeChain)
+		_ = b.run(ctx, "-t", "nat", "-F", novaedgeChain)
+		_ = b.run(ctx, "-t", "nat", "-X", novaedgeChain)
 		b.chainCreated = false
 	}
 
@@ -151,23 +135,23 @@ func (b *iptablesBackend) Cleanup() error {
 
 // ensureChain creates the NOVAEDGE_MESH chain in the nat table and
 // inserts it at the top of PREROUTING so it fires before kube-proxy.
-func (b *iptablesBackend) ensureChain() error {
+func (b *iptablesBackend) ensureChain(ctx context.Context) error {
 	// Create chain. The -N command returns an error if the chain already
 	// exists, which is expected on restart -- only propagate unexpected errors.
-	if err := b.run("-t", "nat", "-N", novaedgeChain); err != nil {
+	if err := b.run(ctx, "-t", "nat", "-N", novaedgeChain); err != nil {
 		if !strings.Contains(err.Error(), "Chain already exists") {
 			return fmt.Errorf("create chain %s: %w", novaedgeChain, err)
 		}
 	}
 
 	// Check if jump already exists.
-	out, err := b.output("-t", "nat", "-S", "PREROUTING")
+	out, err := b.output(ctx, "-t", "nat", "-S", "PREROUTING")
 	if err != nil {
 		return fmt.Errorf("list PREROUTING rules: %w", err)
 	}
 	if !strings.Contains(out, novaedgeChain) {
 		// Insert at position 1 to fire before kube-proxy KUBE-SERVICES.
-		if err := b.run("-t", "nat", "-I", "PREROUTING", "1", "-j", novaedgeChain); err != nil {
+		if err := b.run(ctx, "-t", "nat", "-I", "PREROUTING", "1", "-j", novaedgeChain); err != nil {
 			return fmt.Errorf("insert PREROUTING jump: %w", err)
 		}
 	}
@@ -176,8 +160,8 @@ func (b *iptablesBackend) ensureChain() error {
 	return nil
 }
 
-func (b *iptablesBackend) addRule(clusterIP string, port int32, tproxyPort int32) error {
-	return b.run(
+func (b *iptablesBackend) addRule(ctx context.Context, clusterIP string, port int32, tproxyPort int32) error {
+	return b.run(ctx,
 		"-t", "nat",
 		"-A", novaedgeChain,
 		"-p", "tcp",
@@ -188,8 +172,8 @@ func (b *iptablesBackend) addRule(clusterIP string, port int32, tproxyPort int32
 	)
 }
 
-func (b *iptablesBackend) removeRule(clusterIP string, dport string, tproxyPort int32) error {
-	return b.run(
+func (b *iptablesBackend) removeRule(ctx context.Context, clusterIP string, dport string, tproxyPort int32) error {
+	return b.run(ctx,
 		"-t", "nat",
 		"-D", novaedgeChain,
 		"-p", "tcp",
@@ -200,8 +184,8 @@ func (b *iptablesBackend) removeRule(clusterIP string, dport string, tproxyPort 
 	)
 }
 
-func (b *iptablesBackend) run(args ...string) error {
-	cmd := exec.CommandContext(context.Background(), "iptables", args...) //nolint:gosec // args are constructed internally
+func (b *iptablesBackend) run(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "iptables", args...) //nolint:gosec // args are constructed internally
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("iptables %s: %s: %w", strings.Join(args, " "), string(out), err)
@@ -209,8 +193,8 @@ func (b *iptablesBackend) run(args ...string) error {
 	return nil
 }
 
-func (b *iptablesBackend) output(args ...string) (string, error) {
-	cmd := exec.CommandContext(context.Background(), "iptables", args...) //nolint:gosec // args are constructed internally
+func (b *iptablesBackend) output(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "iptables", args...) //nolint:gosec // args are constructed internally
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("iptables %s: %s: %w", strings.Join(args, " "), string(out), err)

--- a/internal/agent/mesh/tproxy_nftables.go
+++ b/internal/agent/mesh/tproxy_nftables.go
@@ -16,25 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-Copyright 2024 NovaEdge Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package mesh
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -95,7 +80,7 @@ func (b *nftablesBackend) Name() string { return "nftables" }
 // The priority of -101 (NF_IP_PRI_NAT_DST - 1) ensures our DNAT fires
 // before kube-proxy's DNAT rules at priority -100, so the original ClusterIP
 // destination is preserved in conntrack for SO_ORIGINAL_DST retrieval.
-func (b *nftablesBackend) Setup() error {
+func (b *nftablesBackend) Setup(_ context.Context) error {
 	// Verify route_localnet is enabled (set by the sysctl-setup init container in k8s,
 	// or written directly in standalone/privileged mode).
 	if err := ensureRouteLocalnet(); err != nil {
@@ -133,7 +118,7 @@ func (b *nftablesBackend) Setup() error {
 
 // ApplyRules atomically replaces all DNAT rules: flush the chain, add
 // one DNAT rule per target, then commit in a single netlink batch.
-func (b *nftablesBackend) ApplyRules(targets []InterceptTarget, tproxyPort int32) error {
+func (b *nftablesBackend) ApplyRules(_ context.Context, targets []InterceptTarget, tproxyPort int32) error {
 	b.conn.FlushChain(b.chain)
 
 	for _, t := range targets {
@@ -151,7 +136,7 @@ func (b *nftablesBackend) ApplyRules(targets []InterceptTarget, tproxyPort int32
 }
 
 // Cleanup removes the entire novaedge_mesh table and all its chains/rules.
-func (b *nftablesBackend) Cleanup() error {
+func (b *nftablesBackend) Cleanup(_ context.Context) error {
 	if b.table != nil {
 		b.conn.DelTable(b.table)
 		if err := b.conn.Flush(); err != nil {

--- a/internal/agent/mesh/tproxy_nolinux.go
+++ b/internal/agent/mesh/tproxy_nolinux.go
@@ -16,25 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-Copyright 2024 NovaEdge Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package mesh
 
 import (
+	"context"
 	"errors"
 
 	"go.uber.org/zap"
@@ -49,15 +34,15 @@ type stubBackend struct{}
 
 func (s *stubBackend) Name() string { return "stub" }
 
-func (s *stubBackend) Setup() error {
+func (s *stubBackend) Setup(_ context.Context) error {
 	return errTPROXYIsOnlySupportedOnLinux
 }
 
-func (s *stubBackend) ApplyRules(_ []InterceptTarget, _ int32) error {
+func (s *stubBackend) ApplyRules(_ context.Context, _ []InterceptTarget, _ int32) error {
 	return errTPROXYIsOnlySupportedOnLinux
 }
 
-func (s *stubBackend) Cleanup() error { return nil }
+func (s *stubBackend) Cleanup(_ context.Context) error { return nil }
 
 // detectBackend returns a stub backend on non-Linux platforms.
 func detectBackend(_ *zap.Logger) RuleBackend {

--- a/internal/agent/mesh/tproxy_test.go
+++ b/internal/agent/mesh/tproxy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mesh
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -42,14 +43,14 @@ func newFakeBackend() *fakeBackend {
 
 func (f *fakeBackend) Name() string { return "fake" }
 
-func (f *fakeBackend) Setup() error {
+func (f *fakeBackend) Setup(_ context.Context) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.setupCalled = true
 	return nil
 }
 
-func (f *fakeBackend) ApplyRules(targets []InterceptTarget, _ int32) error {
+func (f *fakeBackend) ApplyRules(_ context.Context, targets []InterceptTarget, _ int32) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.applyCnt++
@@ -65,7 +66,7 @@ func (f *fakeBackend) ApplyRules(targets []InterceptTarget, _ int32) error {
 	return nil
 }
 
-func (f *fakeBackend) Cleanup() error {
+func (f *fakeBackend) Cleanup(_ context.Context) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.cleanupCnt++
@@ -93,13 +94,14 @@ func newTestManager(backend *fakeBackend) *TPROXYManager {
 func TestApplyRulesAddsNewRules(t *testing.T) {
 	backend := newFakeBackend()
 	mgr := newTestManager(backend)
+	ctx := context.Background()
 
 	targets := []InterceptTarget{
 		{ClusterIP: "10.96.0.10", Port: 80},
 		{ClusterIP: "10.96.0.20", Port: 443},
 	}
 
-	if err := mgr.ApplyRules(targets); err != nil {
+	if err := mgr.ApplyRules(ctx, targets); err != nil {
 		t.Fatalf("ApplyRules failed: %v", err)
 	}
 
@@ -118,9 +120,10 @@ func TestApplyRulesAddsNewRules(t *testing.T) {
 func TestApplyRulesRemovesOldRules(t *testing.T) {
 	backend := newFakeBackend()
 	mgr := newTestManager(backend)
+	ctx := context.Background()
 
 	// Apply initial rules.
-	if err := mgr.ApplyRules([]InterceptTarget{
+	if err := mgr.ApplyRules(ctx, []InterceptTarget{
 		{ClusterIP: "10.96.0.10", Port: 80},
 		{ClusterIP: "10.96.0.20", Port: 443},
 	}); err != nil {
@@ -128,7 +131,7 @@ func TestApplyRulesRemovesOldRules(t *testing.T) {
 	}
 
 	// Apply with one removed.
-	if err := mgr.ApplyRules([]InterceptTarget{
+	if err := mgr.ApplyRules(ctx, []InterceptTarget{
 		{ClusterIP: "10.96.0.10", Port: 80},
 	}); err != nil {
 		t.Fatalf("ApplyRules failed: %v", err)
@@ -146,17 +149,18 @@ func TestApplyRulesRemovesOldRules(t *testing.T) {
 func TestApplyRulesIdempotent(t *testing.T) {
 	backend := newFakeBackend()
 	mgr := newTestManager(backend)
+	ctx := context.Background()
 
 	targets := []InterceptTarget{
 		{ClusterIP: "10.96.0.10", Port: 80},
 	}
 
 	// Apply twice.
-	if err := mgr.ApplyRules(targets); err != nil {
+	if err := mgr.ApplyRules(ctx, targets); err != nil {
 		t.Fatalf("ApplyRules failed: %v", err)
 	}
 
-	if err := mgr.ApplyRules(targets); err != nil {
+	if err := mgr.ApplyRules(ctx, targets); err != nil {
 		t.Fatalf("ApplyRules failed: %v", err)
 	}
 
@@ -172,16 +176,17 @@ func TestApplyRulesIdempotent(t *testing.T) {
 func TestApplyRulesEmptyDesired(t *testing.T) {
 	backend := newFakeBackend()
 	mgr := newTestManager(backend)
+	ctx := context.Background()
 
 	// Add a rule.
-	if err := mgr.ApplyRules([]InterceptTarget{
+	if err := mgr.ApplyRules(ctx, []InterceptTarget{
 		{ClusterIP: "10.96.0.10", Port: 80},
 	}); err != nil {
 		t.Fatalf("ApplyRules failed: %v", err)
 	}
 
 	// Apply empty → should remove all.
-	if err := mgr.ApplyRules(nil); err != nil {
+	if err := mgr.ApplyRules(ctx, nil); err != nil {
 		t.Fatalf("ApplyRules failed: %v", err)
 	}
 
@@ -192,6 +197,7 @@ func TestApplyRulesEmptyDesired(t *testing.T) {
 
 func TestApplyRulesReturnsErrorOnFailure(t *testing.T) {
 	backend := newFakeBackend()
+	ctx := context.Background()
 	backend.failOn = "10.96.0.20:443"
 	mgr := newTestManager(backend)
 
@@ -200,7 +206,7 @@ func TestApplyRulesReturnsErrorOnFailure(t *testing.T) {
 		{ClusterIP: "10.96.0.20", Port: 443}, // This will fail
 	}
 
-	err := mgr.ApplyRules(targets)
+	err := mgr.ApplyRules(ctx, targets)
 	if err == nil {
 		t.Fatal("Expected error from ApplyRules")
 	}

--- a/internal/agent/metrics/otel_exporter.go
+++ b/internal/agent/metrics/otel_exporter.go
@@ -34,7 +34,7 @@ import (
 var (
 	errOtelExporterAlreadyStarted  = errors.New("otel exporter already started")
 	errOtelExporterHasBeenShutDown = errors.New("otel exporter has been shut down")
-	errUnsupportedProtocol         = errors.New("unsupported protocol")
+	errUnsupportedProtocol         = errors.New("unsupported OTel export protocol")
 )
 
 // OTelExporter manages the OpenTelemetry metrics pipeline that exports

--- a/internal/agent/sdwan/prober.go
+++ b/internal/agent/sdwan/prober.go
@@ -199,6 +199,7 @@ type probeTarget struct {
 	remoteSite string
 	addr       string
 	sla        *WANLinkSLA
+	cancel     context.CancelFunc // per-target cancellation
 }
 
 // Prober performs periodic quality measurements for WAN links using
@@ -255,15 +256,21 @@ func (p *Prober) AddTarget(linkName, remoteSite, addr string, sla *WANLinkSLA) {
 
 	// If the prober is already running, start a probe loop for this target
 	if p.started {
+		targetCtx, targetCancel := context.WithCancel(p.ctx)
+		p.targets[linkName].cancel = targetCancel
 		p.wg.Add(1)
-		go p.probeLoop(p.targets[linkName])
+		go p.probeLoop(targetCtx, p.targets[linkName])
 	}
 }
 
-// RemoveTarget unregisters a probe target.
+// RemoveTarget unregisters a probe target and stops its probe loop.
 func (p *Prober) RemoveTarget(linkName string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	if target, ok := p.targets[linkName]; ok && target.cancel != nil {
+		target.cancel()
+	}
 
 	delete(p.targets, linkName)
 	delete(p.qualities, linkName)
@@ -281,8 +288,10 @@ func (p *Prober) Start(ctx context.Context) {
 	p.started = true
 	// Start a probe loop for each existing target
 	for _, target := range p.targets {
+		targetCtx, targetCancel := context.WithCancel(p.ctx)
+		target.cancel = targetCancel
 		p.wg.Add(1)
-		go p.probeLoop(target)
+		go p.probeLoop(targetCtx, target)
 	}
 	p.mu.Unlock()
 
@@ -327,7 +336,7 @@ func (p *Prober) GetAllQualities() map[string]*LinkQuality {
 }
 
 // probeLoop runs the continuous probe cycle for a single target.
-func (p *Prober) probeLoop(target *probeTarget) {
+func (p *Prober) probeLoop(ctx context.Context, target *probeTarget) {
 	defer p.wg.Done()
 
 	ticker := time.NewTicker(defaultProbeInterval)
@@ -340,7 +349,7 @@ func (p *Prober) probeLoop(target *probeTarget) {
 
 	for {
 		select {
-		case <-p.ctx.Done():
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			p.performProbe(target)

--- a/internal/controller/gatewayapi_translator.go
+++ b/internal/controller/gatewayapi_translator.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	errGatewayClass                                   = errors.New("gateway class")
-	errUnsupportedProtocol                            = errors.New("unsupported protocol")
+	errUnsupportedProtocol                            = errors.New("unsupported gateway protocol")
 	errListener                                       = errors.New("listener")
 	errRuleHasNoBackendRefs                           = errors.New("rule has no backend refs")
 	errUnsupportedPathMatchType                       = errors.New("unsupported path match type")

--- a/internal/controller/meshca/ca.go
+++ b/internal/controller/meshca/ca.go
@@ -45,7 +45,7 @@ import (
 var (
 	errMeshCANotInitialized           = errors.New("mesh CA not initialized")
 	errFailedToDecodeCSRPEM           = errors.New("failed to decode CSR PEM")
-	errSecret                         = errors.New("secret")
+	errSecret                         = errors.New("mesh CA secret")
 	errFailedToDecodeCACertificatePEM = errors.New("failed to decode CA certificate PEM")
 	errFailedToDecodeCAPrivateKeyPEM  = errors.New("failed to decode CA private key PEM")
 	errCSRURISANMismatch              = errors.New("CSR URI SANs do not contain expected SPIFFE ID")

--- a/internal/controller/snapshot/builder_auth.go
+++ b/internal/controller/snapshot/builder_auth.go
@@ -28,7 +28,7 @@ import (
 var (
 	errBasicAuthSpecIsNil = errors.New("basicAuth spec is nil")
 	errHtpasswdSecret     = errors.New("htpasswd secret")
-	errSecret             = errors.New("secret")
+	errSecret             = errors.New("auth secret")
 	errOidcSpecIsNil      = errors.New("oidc spec is nil")
 )
 

--- a/internal/operator/webhook/federation_webhook.go
+++ b/internal/operator/webhook/federation_webhook.go
@@ -35,7 +35,7 @@ import (
 var (
 	errFederationIDIsImmutableCannotChangeFrom    = errors.New("federation ID is immutable: cannot change from")
 	errLocalMemberNameIsImmutableCannotChangeFrom = errors.New("local member name is immutable: cannot change from")
-	errValidationFailed                           = errors.New("validation failed")
+	errValidationFailed                           = errors.New("webhook validation failed")
 	errInvalidName                                = errors.New("invalid name")
 	errName                                       = errors.New("name")
 	errInvalidEndpoint                            = errors.New("invalid endpoint")

--- a/internal/standalone/cert_manager.go
+++ b/internal/standalone/cert_manager.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	errConfigIsRequired             = errors.New("config is required")
+	errConfigIsRequired             = errors.New("certificate manager config is required")
 	errUnsupportedIssuerType        = errors.New("unsupported issuer type")
 	errCertificateNotFound          = errors.New("certificate not found")
 	errCertificateNotLoaded         = errors.New("certificate not loaded")


### PR DESCRIPTION
## Summary
- Fix SD-WAN prober goroutine leak (#1034) — per-target context.CancelFunc
- Fix iptables commands using context.Background() (#1039) — propagate context
- Remove duplicate license headers (#1040)
- Differentiate duplicate sentinel errors (#1041)

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes