### PR TITLE
fix: P2C connection tracking, health threshold, circuit breaker race, WAF rules

### DIFF
--- a/dataplane/novaedge-dataplane/src/health/checker.rs
+++ b/dataplane/novaedge-dataplane/src/health/checker.rs
@@ -16,6 +16,9 @@ use super::types::*;
 pub struct HealthChecker {
     config: HealthCheckConfig,
     states: Arc<RwLock<HashMap<SocketAddr, HealthState>>>,
+    /// Tracks consecutive failure count before the unhealthy threshold is met.
+    /// Once threshold is reached, the count moves into `HealthState::Unhealthy`.
+    failure_counts: Arc<RwLock<HashMap<SocketAddr, u32>>>,
 }
 
 impl HealthChecker {
@@ -24,6 +27,7 @@ impl HealthChecker {
         Self {
             config,
             states: Arc::new(RwLock::new(HashMap::new())),
+            failure_counts: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -103,9 +107,13 @@ impl HealthChecker {
     async fn update_state(&self, addr: SocketAddr, result: Result<(), String>) -> bool {
         let mut states = self.states.write().await;
         let state = states.entry(addr).or_insert(HealthState::Unknown);
+        let mut failure_counts = self.failure_counts.write().await;
 
         match result {
             Ok(()) => {
+                // Reset consecutive failure counter on success.
+                failure_counts.remove(&addr);
+
                 let count = match state {
                     HealthState::Healthy {
                         consecutive_successes,
@@ -119,19 +127,23 @@ impl HealthChecker {
                 is_healthy
             }
             Err(err) => {
-                let count = match state {
-                    HealthState::Unhealthy {
-                        consecutive_failures,
-                        ..
-                    } => *consecutive_failures + 1,
-                    _ => 1,
-                };
-                warn!(%addr, error = %err, consecutive = count, "backend unhealthy");
-                *state = HealthState::Unhealthy {
-                    consecutive_failures: count,
-                    last_error: err,
-                };
-                false
+                let count = failure_counts.entry(addr).or_insert(0);
+                *count += 1;
+                let consecutive = *count;
+
+                warn!(%addr, error = %err, consecutive = consecutive, "backend unhealthy");
+
+                // Only transition to Unhealthy once the threshold is met.
+                if consecutive >= self.config.unhealthy_threshold {
+                    *state = HealthState::Unhealthy {
+                        consecutive_failures: consecutive,
+                        last_error: err,
+                    };
+                    false
+                } else {
+                    // Below threshold — keep previous state, backend still considered OK.
+                    !matches!(state, HealthState::Unhealthy { .. })
+                }
             }
         }
     }

--- a/dataplane/novaedge-dataplane/src/lb/p2c.rs
+++ b/dataplane/novaedge-dataplane/src/lb/p2c.rs
@@ -86,19 +86,17 @@ impl LoadBalancer for PowerOfTwoChoices {
         let wb = backends[b].weight.max(1) as u32;
 
         // Weight-normalized: compare ca/wa vs cb/wb via cross-multiply.
-        if ca * wb <= cb * wa {
-            Some(a)
-        } else {
-            Some(b)
-        }
+        let chosen = if ca * wb <= cb * wa { a } else { b };
+
+        // Increment connection count when a request starts.
+        self.increment(chosen);
+
+        Some(chosen)
     }
 
-    fn report(&self, backend_idx: usize, _latency: Duration, success: bool) {
-        if success {
-            self.increment(backend_idx);
-        } else {
-            self.decrement(backend_idx);
-        }
+    fn report(&self, backend_idx: usize, _latency: Duration, _success: bool) {
+        // Request completed — always decrement regardless of success/failure.
+        self.decrement(backend_idx);
     }
 
     fn name(&self) -> &'static str {

--- a/dataplane/novaedge-dataplane/src/middleware/waf.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/waf.rs
@@ -130,7 +130,23 @@ impl CompiledRules {
 }
 
 /// URL-decode a string (handles %XX sequences).
+///
+/// Decodes iteratively (up to 3 passes) to defeat double/triple encoding
+/// evasion attacks (e.g. `%2525` → `%25` → `%`).
 fn url_decode(input: &str) -> String {
+    let mut current = input.to_string();
+    for _ in 0..3 {
+        let decoded = url_decode_single(&current);
+        if decoded == current {
+            break;
+        }
+        current = decoded;
+    }
+    current
+}
+
+/// Single-pass URL decode (handles %XX sequences).
+fn url_decode_single(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let mut chars = input.bytes();
     while let Some(b) = chars.next() {
@@ -220,6 +236,53 @@ impl WafEngine {
                 target: WafTarget::UserAgent,
                 pattern: r"nikto".into(),
                 severity: WafSeverity::Medium,
+            },
+            // Command injection patterns (shell metacharacters).
+            WafRule {
+                id: 932100,
+                description: "Command Injection: Shell Metacharacters".into(),
+                target: WafTarget::QueryString,
+                pattern: r"[;|`]\s*\w+".into(),
+                severity: WafSeverity::Critical,
+            },
+            // Log4Shell / JNDI injection.
+            WafRule {
+                id: 944100,
+                description: "Log4Shell: JNDI Injection".into(),
+                target: WafTarget::Headers,
+                pattern: r"\$\{jndi:".into(),
+                severity: WafSeverity::Critical,
+            },
+            WafRule {
+                id: 944110,
+                description: "Log4Shell: JNDI Injection in Query".into(),
+                target: WafTarget::QueryString,
+                pattern: r"\$\{jndi:".into(),
+                severity: WafSeverity::Critical,
+            },
+            // XXE: External entity declaration.
+            WafRule {
+                id: 934100,
+                description: "XXE: External Entity Declaration".into(),
+                target: WafTarget::Body,
+                pattern: r"<!ENTITY".into(),
+                severity: WafSeverity::Critical,
+            },
+            // Path traversal in query string.
+            WafRule {
+                id: 930110,
+                description: "Path Traversal in Query String".into(),
+                target: WafTarget::QueryString,
+                pattern: r"\.\.[\\/]".into(),
+                severity: WafSeverity::High,
+            },
+            // SSRF: Internal IP patterns in query values.
+            WafRule {
+                id: 934110,
+                description: "SSRF: Internal Network Address".into(),
+                target: WafTarget::QueryString,
+                pattern: r"(?:https?://)?(?:127\.|10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.|0\.0\.0\.0|localhost|\[::1\])".into(),
+                severity: WafSeverity::High,
             },
         ];
         Self::new(WafConfig { mode, rules })
@@ -545,7 +608,7 @@ mod tests {
     #[test]
     fn rule_count() {
         let waf = WafEngine::with_default_rules(WafMode::Block);
-        assert!(waf.rule_count() >= 7);
+        assert!(waf.rule_count() >= 13);
     }
 
     #[test]

--- a/dataplane/novaedge-dataplane/src/upstream/circuit_breaker.rs
+++ b/dataplane/novaedge-dataplane/src/upstream/circuit_breaker.rs
@@ -90,17 +90,33 @@ impl CircuitBreaker {
                 let now_ms = current_time_ms();
                 let last = self.last_failure_ms.load(Ordering::Relaxed);
                 if now_ms.saturating_sub(last) >= self.config.open_duration.as_millis() as u64 {
-                    // Transition to half-open with limited probe permits.
-                    // The transition itself counts as the first probe, so set
-                    // remaining permits to (max - 1).
-                    self.state
-                        .store(CircuitState::HalfOpen as u8, Ordering::Release);
-                    self.successes.store(0, Ordering::Relaxed);
-                    self.half_open_permits.store(
-                        self.config.half_open_max_requests.max(1).saturating_sub(1),
-                        Ordering::Relaxed,
-                    );
-                    true
+                    // Use compare_exchange to ensure only one thread transitions
+                    // from Open to HalfOpen, preventing a race where multiple
+                    // threads all observe the elapsed time and transition.
+                    if self
+                        .state
+                        .compare_exchange(
+                            CircuitState::Open as u8,
+                            CircuitState::HalfOpen as u8,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        // We won the race — set up half-open state.
+                        // The transition itself counts as the first probe, so set
+                        // remaining permits to (max - 1).
+                        self.successes.store(0, Ordering::Relaxed);
+                        self.half_open_permits.store(
+                            self.config.half_open_max_requests.max(1).saturating_sub(1),
+                            Ordering::Relaxed,
+                        );
+                        true
+                    } else {
+                        // Another thread already transitioned; fall through to
+                        // HalfOpen permit logic on the next call.
+                        false
+                    }
                 } else {
                     false
                 }


### PR DESCRIPTION
## Summary
- Fix P2C LB inverted connection tracking (#1036)
- Fix health checker ignoring unhealthy_threshold (#1037)
- Fix circuit breaker Open→HalfOpen race with compare_exchange (#1038)
- Expand WAF ruleset and fix single-pass URL decode (#1044)

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes