### PR TITLE
fix: data races in splitbrain/OTel, security hardening, minor bugs

### DIFF
--- a/cmd/novactl/pkg/webui/auth/auth.go
+++ b/cmd/novactl/pkg/webui/auth/auth.go
@@ -7,10 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -41,7 +43,13 @@ const (
 //
 // This value can be adjusted at runtime using SetMaxSessions. If it is not
 // changed, the default limit of 1000 sessions is used.
-var maxSessions = defaultMaxSessions
+var maxSessions = newMaxSessions()
+
+func newMaxSessions() *atomic.Int32 {
+	v := &atomic.Int32{}
+	v.Store(int32(defaultMaxSessions))
+	return v
+}
 
 // SetMaxSessions sets the global maximum number of concurrent sessions allowed.
 //
@@ -49,10 +57,13 @@ var maxSessions = defaultMaxSessions
 // is less than or equal to zero, the default value of 1000 is used.
 func SetMaxSessions(limit int) {
 	if limit <= 0 {
-		maxSessions = defaultMaxSessions
+		maxSessions.Store(int32(defaultMaxSessions))
 		return
 	}
-	maxSessions = limit
+	if limit > math.MaxInt32 {
+		limit = math.MaxInt32
+	}
+	maxSessions.Store(int32(limit))
 }
 
 // Config holds authentication configuration.
@@ -155,7 +166,8 @@ func (m *Manager) evictExcessSessions() {
 		return true
 	})
 
-	if len(entries) <= maxSessions {
+	limit := int(maxSessions.Load())
+	if len(entries) <= limit {
 		return
 	}
 
@@ -164,7 +176,7 @@ func (m *Manager) evictExcessSessions() {
 		return entries[i].expiry.Before(entries[j].expiry)
 	})
 
-	excess := len(entries) - maxSessions
+	excess := len(entries) - limit
 	for i := 0; i < excess; i++ {
 		m.sessions.Delete(entries[i].token)
 	}

--- a/cmd/novactl/pkg/webui/auth/auth_test.go
+++ b/cmd/novactl/pkg/webui/auth/auth_test.go
@@ -221,24 +221,24 @@ func TestMiddlewareAllowsValidSession(t *testing.T) {
 
 func TestSetMaxSessions(t *testing.T) {
 	// Save original and restore after test.
-	orig := maxSessions
-	defer func() { maxSessions = orig }()
+	orig := maxSessions.Load()
+	defer maxSessions.Store(orig)
 
 	SetMaxSessions(50)
-	if maxSessions != 50 {
-		t.Fatalf("expected maxSessions=50, got %d", maxSessions)
+	if maxSessions.Load() != 50 {
+		t.Fatalf("expected maxSessions=50, got %d", maxSessions.Load())
 	}
 
 	// Zero resets to default.
 	SetMaxSessions(0)
-	if maxSessions != defaultMaxSessions {
-		t.Fatalf("expected maxSessions=%d after zero, got %d", defaultMaxSessions, maxSessions)
+	if maxSessions.Load() != int32(defaultMaxSessions) {
+		t.Fatalf("expected maxSessions=%d after zero, got %d", defaultMaxSessions, maxSessions.Load())
 	}
 
 	// Negative resets to default.
 	SetMaxSessions(-1)
-	if maxSessions != defaultMaxSessions {
-		t.Fatalf("expected maxSessions=%d after negative, got %d", defaultMaxSessions, maxSessions)
+	if maxSessions.Load() != int32(defaultMaxSessions) {
+		t.Fatalf("expected maxSessions=%d after negative, got %d", defaultMaxSessions, maxSessions.Load())
 	}
 }
 
@@ -280,8 +280,8 @@ func TestEvictExpiredSessions(t *testing.T) {
 
 func TestEvictExcessSessionsDeterministic(t *testing.T) {
 	// Save original and restore after test.
-	orig := maxSessions
-	defer func() { maxSessions = orig }()
+	orig := maxSessions.Load()
+	defer maxSessions.Store(orig)
 
 	SetMaxSessions(3)
 

--- a/cmd/novactl/pkg/webui/server.go
+++ b/cmd/novactl/pkg/webui/server.go
@@ -252,7 +252,7 @@ func (s *Server) Start() error {
 
 	s.server = &http.Server{
 		Addr:              s.addr,
-		Handler:           corsMiddleware(handler),
+		Handler:           corsMiddleware(handler, s.authManager != nil && s.authManager.Enabled()),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -292,7 +292,7 @@ func (s *Server) setupTLS(cfg Config) error {
 		}
 		s.tlsConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS12,
+			MinVersion:   tls.VersionTLS13,
 		}
 		return nil
 	}
@@ -320,7 +320,7 @@ func (s *Server) setupTLS(cfg Config) error {
 
 		s.tlsConfig = &tls.Config{
 			Certificates: []tls.Certificate{*tlsCert},
-			MinVersion:   tls.VersionTLS12,
+			MinVersion:   tls.VersionTLS13,
 		}
 		return nil
 	}
@@ -333,10 +333,32 @@ func (s *Server) IsTLSEnabled() bool {
 	return s.tlsConfig != nil
 }
 
-// corsMiddleware adds CORS headers for development
-func corsMiddleware(next http.Handler) http.Handler {
+// corsMiddleware adds CORS headers. When authEnabled is true, only the
+// server's own origin is allowed; otherwise "*" is permitted for development.
+func corsMiddleware(next http.Handler, authEnabled bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		origin := r.Header.Get("Origin")
+		if authEnabled {
+			// Only reflect the Origin when it matches the server's own host.
+			if origin != "" {
+				requestHost := r.Host
+				if requestHost == "" {
+					requestHost = r.URL.Host
+				}
+				// Origin is scheme://host — extract host portion for comparison.
+				originHost := origin
+				if idx := strings.Index(origin, "://"); idx >= 0 {
+					originHost = origin[idx+3:]
+				}
+				if originHost == requestHost {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Set("Vary", "Origin")
+				}
+				// If no match, omit the CORS header entirely.
+			}
+		} else {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+		}
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 

--- a/internal/acme/storage.go
+++ b/internal/acme/storage.go
@@ -225,37 +225,37 @@ func (s *FileStorage) DeleteCertificate(_ context.Context, domain string) error 
 
 // ListCertificates returns all stored certificates.
 func (s *FileStorage) ListCertificates(ctx context.Context) ([]*Certificate, error) {
+	// Collect domain names under RLock, then release before loading each cert.
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	certsDir := filepath.Join(s.basePath, "certs")
 	entries, err := os.ReadDir(certsDir)
 	if err != nil {
+		s.mu.RUnlock()
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to list certificates: %w", err)
 	}
 
-	certs := make([]*Certificate, 0, len(entries))
+	domains := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-
-		// Reconstruct domain from directory name
 		domain := strings.ReplaceAll(entry.Name(), "_", ".")
 		domain = strings.ReplaceAll(domain, "wildcard", "*")
+		domains = append(domains, domain)
+	}
+	s.mu.RUnlock()
 
-		// Need to release lock to call LoadCertificate
-		s.mu.RUnlock()
-		cert, err := s.LoadCertificate(ctx, domain)
-		s.mu.RLock()
-
-		if err != nil {
+	// Load each certificate without holding the lock.
+	certs := make([]*Certificate, 0, len(domains))
+	for _, domain := range domains {
+		cert, loadErr := s.LoadCertificate(ctx, domain)
+		if loadErr != nil {
 			s.logger.Warn("Failed to load certificate",
 				zap.String("domain", domain),
-				zap.Error(err),
+				zap.Error(loadErr),
 			)
 			continue
 		}

--- a/internal/agent/mesh/manager.go
+++ b/internal/agent/mesh/manager.go
@@ -688,7 +688,7 @@ func (m *Manager) proxyTCP(ctx context.Context, clientConn io.ReadWriteCloser, b
 	defer func() { _ = backendConn.Close() }()
 
 	// Bidirectional copy
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		if _, err := io.Copy(backendConn, clientConn); err != nil {
 			m.logger.Debug("io.Copy client->backend finished with error", zap.Error(err))

--- a/internal/agent/metrics/otel_exporter.go
+++ b/internal/agent/metrics/otel_exporter.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -52,8 +53,8 @@ type OTelExporter struct {
 	upstreamRequestDurationSecs otelmetric.Float64Histogram
 
 	mu       sync.Mutex
-	started  bool
-	shutdown bool
+	started  atomic.Bool
+	shutdown atomic.Bool
 }
 
 // NewOTelExporter creates a new OTelExporter with the supplied configuration.
@@ -76,10 +77,10 @@ func (e *OTelExporter) Start(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	if e.started {
+	if e.started.Load() {
 		return errOtelExporterAlreadyStarted
 	}
-	if e.shutdown {
+	if e.shutdown.Load() {
 		return errOtelExporterHasBeenShutDown
 	}
 
@@ -107,7 +108,7 @@ func (e *OTelExporter) Start(ctx context.Context) error {
 		return fmt.Errorf("creating OTel metric instruments: %w", err)
 	}
 
-	e.started = true
+	e.started.Store(true)
 	return nil
 }
 
@@ -117,11 +118,11 @@ func (e *OTelExporter) Shutdown(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	if !e.started || e.shutdown {
+	if !e.started.Load() || e.shutdown.Load() {
 		return nil
 	}
 
-	e.shutdown = true
+	e.shutdown.Store(true)
 	if e.provider != nil {
 		return e.provider.Shutdown(ctx)
 	}
@@ -138,7 +139,7 @@ func (e *OTelExporter) MeterProvider() *metric.MeterProvider {
 // This should be called alongside the Prometheus RecordHTTPRequest function
 // so that both exporters receive the same data.
 func (e *OTelExporter) RecordHTTPRequest(ctx context.Context, method, statusClass, cluster string, duration float64) {
-	if !e.started || e.shutdown {
+	if !e.started.Load() || e.shutdown.Load() {
 		return
 	}
 
@@ -158,7 +159,7 @@ func (e *OTelExporter) RecordHTTPRequest(ctx context.Context, method, statusClas
 
 // RecordInFlightChange adjusts the in-flight request gauge by delta (+1 or -1).
 func (e *OTelExporter) RecordInFlightChange(ctx context.Context, delta int64) {
-	if !e.started || e.shutdown {
+	if !e.started.Load() || e.shutdown.Load() {
 		return
 	}
 	e.httpRequestsInFlight.Add(ctx, delta)
@@ -166,7 +167,7 @@ func (e *OTelExporter) RecordInFlightChange(ctx context.Context, delta int64) {
 
 // RecordUpstreamDuration records an upstream (backend) request duration.
 func (e *OTelExporter) RecordUpstreamDuration(ctx context.Context, cluster, endpoint string, duration float64) {
-	if !e.started || e.shutdown {
+	if !e.started.Load() || e.shutdown.Load() {
 		return
 	}
 	attrs := otelmetric.WithAttributes(

--- a/internal/agent/server/runtime_api.go
+++ b/internal/agent/server/runtime_api.go
@@ -75,6 +75,11 @@ func NewRuntimeAPI(logger *zap.Logger) *RuntimeAPI {
 }
 
 // registerRoutes sets up the HTTP routing for the runtime API.
+//
+// Security: These endpoints have no authentication middleware because they are
+// only registered on the admin loopback interface (127.0.0.1), which is not
+// reachable from outside the node. The AdminServer binds exclusively to a
+// loopback address, so network-level isolation provides the access control.
 func (api *RuntimeAPI) registerRoutes() {
 	api.mux.HandleFunc("/api/v1/clusters/", api.handleClusters)
 	api.mux.HandleFunc("/api/v1/overrides", api.handleOverrides)
@@ -169,8 +174,7 @@ func (api *RuntimeAPI) handleAddEndpoint(w http.ResponseWriter, r *http.Request,
 		zap.Int32("weight", req.Weight),
 	)
 
-	w.WriteHeader(http.StatusCreated)
-	writeJSON(w, http.StatusOK, map[string]string{"status": "added", "endpoint": key})
+	writeJSON(w, http.StatusCreated, map[string]string{"status": "added", "endpoint": key})
 }
 
 // handleRemoveEndpoint handles DELETE /api/v1/clusters/{cluster}/endpoints/{endpoint}.

--- a/internal/controller/federation/splitbrain.go
+++ b/internal/controller/federation/splitbrain.go
@@ -650,6 +650,9 @@ func (d *SplitBrainDetector) checkQuorum() {
 
 // countReachablePeers counts peers contacted within timeout
 func (d *SplitBrainDetector) countReachablePeers() int {
+	d.peersMu.RLock()
+	defer d.peersMu.RUnlock()
+
 	cutoff := time.Now().Add(-d.config.PartitionTimeout)
 	count := 0
 	for _, lastSeen := range d.reachablePeers {
@@ -662,6 +665,9 @@ func (d *SplitBrainDetector) countReachablePeers() int {
 
 // getReachablePeerNames returns names of reachable peers
 func (d *SplitBrainDetector) getReachablePeerNames() []string {
+	d.peersMu.RLock()
+	defer d.peersMu.RUnlock()
+
 	cutoff := time.Now().Add(-d.config.PartitionTimeout)
 	var names []string
 	for peer, lastSeen := range d.reachablePeers {
@@ -674,13 +680,15 @@ func (d *SplitBrainDetector) getReachablePeerNames() []string {
 
 // getUnreachablePeerNames returns names of unreachable peers
 func (d *SplitBrainDetector) getUnreachablePeerNames() []string {
-	cutoff := time.Now().Add(-d.config.PartitionTimeout)
+	d.peersMu.RLock()
 	reachable := make(map[string]bool)
+	cutoff := time.Now().Add(-d.config.PartitionTimeout)
 	for peer, lastSeen := range d.reachablePeers {
 		if lastSeen.After(cutoff) {
 			reachable[peer] = true
 		}
 	}
+	d.peersMu.RUnlock()
 
 	// Get all known peers from server
 	var unreachable []string

--- a/internal/controller/vault/http.go
+++ b/internal/controller/vault/http.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -116,11 +117,18 @@ func (c *vaultHTTPClient) Delete(ctx context.Context, path string) (*Response, e
 }
 
 // buildURL constructs the full Vault API URL and validates it.
-func (c *vaultHTTPClient) buildURL(path string) string {
+func (c *vaultHTTPClient) buildURL(vaultPath string) string {
 	// Ensure path doesn't start with /v1/ (we'll add it)
-	path = strings.TrimPrefix(path, "/")
-	path = strings.TrimPrefix(path, "v1/")
-	result := fmt.Sprintf("%s/v1/%s", strings.TrimRight(c.address, "/"), path)
+	vaultPath = strings.TrimPrefix(vaultPath, "/")
+	vaultPath = strings.TrimPrefix(vaultPath, "v1/")
+
+	// Reject path traversal attempts
+	cleaned := path.Clean(vaultPath)
+	if strings.HasPrefix(cleaned, "..") || strings.Contains(cleaned, "/../") {
+		return ""
+	}
+
+	result := fmt.Sprintf("%s/v1/%s", strings.TrimRight(c.address, "/"), cleaned)
 	// Validate the URL to satisfy SSRF taint analysis
 	if _, err := url.ParseRequestURI(result); err != nil {
 		return ""


### PR DESCRIPTION
## Summary
- **countReachablePeers data race**: Add RLock in methods that iterate reachablePeers map
- **OTelExporter race**: Change started/shutdown to atomic.Bool for lock-free reads on hot path
- **CORS wildcard**: Restrict Access-Control-Allow-Origin to matching Host when auth is enabled
- **TLS 1.3**: Upgrade WebUI MinVersion from TLS 1.2 to TLS 1.3
- **Vault path traversal**: Reject `../` sequences in vault path parameter
- **proxyTCP goroutine leak**: Buffer the done channel
- **ListCertificates lock**: Collect domains first, release lock, then load certs
- **maxSessions race**: Use atomic.Int32 instead of plain int
- **Double WriteHeader**: Pass StatusCreated to writeJSON instead of separate WriteHeader

Closes #1070, closes #1071 (Go parts)

## Test plan
- [ ] Go build passes
- [ ] Go tests pass
- [ ] golangci-lint passes