### PR TITLE
fix(dataplane): redact WireGuard keys, fix pool semaphore, improve cache, standardize tracing

### DIFF
--- a/dataplane/novaedge-dataplane/src/config.rs
+++ b/dataplane/novaedge-dataplane/src/config.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
+use tracing::debug;
 
 use crate::lb::{self, LoadBalancer};
 
@@ -493,7 +494,7 @@ impl RuntimeConfig {
             for ep in &mut cluster_state.endpoints {
                 if ep.address == addr && ep.port == port {
                     if ep.healthy != healthy {
-                        tracing::debug!(
+                        debug!(
                             cluster,
                             endpoint = %format!("{}:{}", addr, port),
                             healthy,
@@ -523,7 +524,7 @@ impl RuntimeConfig {
                 }
             });
             if cluster.endpoints.len() < before {
-                tracing::debug!(
+                debug!(
                     cluster = %cluster.name,
                     removed = before - cluster.endpoints.len(),
                     "Cleaned up expired draining endpoints"

--- a/dataplane/novaedge-dataplane/src/listener.rs
+++ b/dataplane/novaedge-dataplane/src/listener.rs
@@ -287,7 +287,7 @@ impl ListenerManager {
                                         let tls_stream = match acceptor.accept(stream).await {
                                             Ok(s) => s,
                                             Err(e) => {
-                                                tracing::debug!(error = %e, "TLS handshake failed");
+                                                debug!(error = %e, "TLS handshake failed");
                                                 return;
                                             }
                                         };
@@ -304,7 +304,7 @@ impl ListenerManager {
                                             )
                                             .await
                                         {
-                                            tracing::debug!(error = %e, "HTTPS connection ended");
+                                            debug!(error = %e, "HTTPS connection ended");
                                         }
                                     });
                                 } else {
@@ -323,7 +323,7 @@ impl ListenerManager {
                                             )
                                             .await
                                         {
-                                            tracing::debug!(error = %e, "HTTP connection ended");
+                                            debug!(error = %e, "HTTP connection ended");
                                         }
                                     });
                                 }
@@ -430,12 +430,12 @@ impl ListenerManager {
                                                 let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
                                             }
                                             Err(e) => {
-                                                tracing::debug!(backend = %backend, error = %e, "L4 backend connection failed");
+                                                debug!(backend = %backend, error = %e, "L4 backend connection failed");
                                             }
                                         }
                                     });
                                 } else {
-                                    tracing::debug!(gateway = %gw_name, "No backend for L4 connection");
+                                    debug!(gateway = %gw_name, "No backend for L4 connection");
                                     drop(client);
                                 }
                             }

--- a/dataplane/novaedge-dataplane/src/mesh/mtls.rs
+++ b/dataplane/novaedge-dataplane/src/mesh/mtls.rs
@@ -1,5 +1,7 @@
 use std::time::{Duration, Instant};
 
+use tracing::info;
+
 /// Mesh mTLS configuration.
 #[derive(Debug, Clone)]
 pub struct MeshTlsConfig {
@@ -50,7 +52,7 @@ impl MeshTlsProvider {
         }
         self.initialized = true;
         self.initialized_at = Some(Instant::now());
-        tracing::info!(spiffe_id = %self.config.spiffe_id, "mTLS provider initialized");
+        info!(spiffe_id = %self.config.spiffe_id, "mTLS provider initialized");
         Ok(())
     }
 
@@ -77,7 +79,7 @@ impl MeshTlsProvider {
         self.config.workload_cert_pem = cert_pem;
         self.config.workload_key_pem = key_pem;
         self.initialized_at = Some(Instant::now());
-        tracing::info!("Mesh certificates updated");
+        info!("Mesh certificates updated");
     }
 
     pub fn spiffe_id(&self) -> &str {

--- a/dataplane/novaedge-dataplane/src/mesh/tproxy.rs
+++ b/dataplane/novaedge-dataplane/src/mesh/tproxy.rs
@@ -1,3 +1,7 @@
+use tracing::info;
+#[cfg(target_os = "linux")]
+use tracing::{debug, warn};
+
 /// TPROXY interception configuration.
 #[derive(Debug, Clone)]
 pub struct TproxyConfig {
@@ -44,7 +48,7 @@ impl TproxyInterceptor {
     /// Install TPROXY interception rules.
     #[cfg(target_os = "linux")]
     pub fn install(&mut self) -> anyhow::Result<()> {
-        tracing::info!(
+        info!(
             inbound_port = self.config.inbound_port,
             outbound_port = self.config.outbound_port,
             "Installing TPROXY rules"
@@ -59,14 +63,14 @@ impl TproxyInterceptor {
                 .output();
             match output {
                 Ok(out) if out.status.success() => {
-                    tracing::debug!(cmd = %cmd_str, "iptables rule applied");
+                    debug!(cmd = %cmd_str, "iptables rule applied");
                 }
                 Ok(out) => {
                     let stderr = String::from_utf8_lossy(&out.stderr);
-                    tracing::warn!(cmd = %cmd_str, stderr = %stderr, "iptables rule failed (may already exist)");
+                    warn!(cmd = %cmd_str, stderr = %stderr, "iptables rule failed (may already exist)");
                 }
                 Err(e) => {
-                    tracing::warn!(cmd = %cmd_str, error = %e, "failed to execute iptables");
+                    warn!(cmd = %cmd_str, error = %e, "failed to execute iptables");
                 }
             }
         }
@@ -76,7 +80,7 @@ impl TproxyInterceptor {
 
     #[cfg(not(target_os = "linux"))]
     pub fn install(&mut self) -> anyhow::Result<()> {
-        tracing::info!("TPROXY interception not available on non-Linux (mock mode)");
+        info!("TPROXY interception not available on non-Linux (mock mode)");
         self.active = true;
         Ok(())
     }
@@ -84,7 +88,7 @@ impl TproxyInterceptor {
     /// Remove TPROXY interception rules.
     #[cfg(target_os = "linux")]
     pub fn uninstall(&mut self) -> anyhow::Result<()> {
-        tracing::info!("Removing TPROXY rules");
+        info!("Removing TPROXY rules");
         // Remove rules by changing -A (append) / -I (insert) to -D (delete).
         for cmd_str in self.iptables_commands() {
             let del_cmd = cmd_str.replace(" -A ", " -D ").replace(" -I ", " -D ");
@@ -97,14 +101,14 @@ impl TproxyInterceptor {
                 .output();
             match output {
                 Ok(out) if out.status.success() => {
-                    tracing::debug!(cmd = %del_cmd, "iptables rule removed");
+                    debug!(cmd = %del_cmd, "iptables rule removed");
                 }
                 Ok(out) => {
                     let stderr = String::from_utf8_lossy(&out.stderr);
-                    tracing::warn!(cmd = %del_cmd, stderr = %stderr, "iptables rule removal failed (may not exist)");
+                    warn!(cmd = %del_cmd, stderr = %stderr, "iptables rule removal failed (may not exist)");
                 }
                 Err(e) => {
-                    tracing::warn!(cmd = %del_cmd, error = %e, "failed to execute iptables");
+                    warn!(cmd = %del_cmd, error = %e, "failed to execute iptables");
                 }
             }
         }
@@ -115,7 +119,7 @@ impl TproxyInterceptor {
     #[cfg(not(target_os = "linux"))]
     pub fn uninstall(&mut self) -> anyhow::Result<()> {
         self.active = false;
-        tracing::info!("TPROXY rules removed (mock mode)");
+        info!("TPROXY rules removed (mock mode)");
         Ok(())
     }
 

--- a/dataplane/novaedge-dataplane/src/middleware/cache.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/cache.rs
@@ -1,6 +1,7 @@
 //! HTTP response caching middleware.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
@@ -37,12 +38,16 @@ struct CacheEntry {
     ttl: Duration,
     #[allow(dead_code)]
     etag: Option<String>,
+    /// Monotonic insertion order for eviction. Lower values are older.
+    order: u64,
 }
 
 /// In-memory HTTP response cache.
 pub struct ResponseCache {
     config: CacheConfig,
     entries: RwLock<HashMap<String, CacheEntry>>,
+    /// Monotonic counter for insertion order tracking.
+    insert_counter: AtomicU64,
 }
 
 #[allow(dead_code)]
@@ -52,6 +57,7 @@ impl ResponseCache {
         Self {
             config,
             entries: RwLock::new(HashMap::new()),
+            insert_counter: AtomicU64::new(0),
         }
     }
 
@@ -89,16 +95,20 @@ impl ResponseCache {
         let mut entries = self.entries.write().unwrap_or_else(|e| e.into_inner());
 
         // Evict oldest entry if at capacity.
+        // NOTE: This is O(n) over all entries. A proper LRU data structure
+        // (e.g. `lru` crate) would make eviction O(1) and is the natural
+        // next improvement.
         if entries.len() >= self.config.max_entries {
             if let Some(oldest_key) = entries
                 .iter()
-                .min_by_key(|(_, e)| e.inserted)
+                .min_by_key(|(_, e)| e.order)
                 .map(|(k, _)| k.clone())
             {
                 entries.remove(&oldest_key);
             }
         }
 
+        let order = self.insert_counter.fetch_add(1, Ordering::Relaxed);
         entries.insert(
             key,
             CacheEntry {
@@ -106,6 +116,7 @@ impl ResponseCache {
                 inserted: Instant::now(),
                 ttl,
                 etag,
+                order,
             },
         );
     }

--- a/dataplane/novaedge-dataplane/src/sdwan/wireguard.rs
+++ b/dataplane/novaedge-dataplane/src/sdwan/wireguard.rs
@@ -1,8 +1,9 @@
+use std::fmt;
 use std::net::SocketAddr;
 use std::time::Duration;
 
 /// WireGuard peer configuration.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WireGuardPeer {
     pub public_key: String,
     pub endpoint: Option<SocketAddr>,
@@ -11,14 +12,38 @@ pub struct WireGuardPeer {
     pub preshared_key: Option<String>,
 }
 
+impl fmt::Debug for WireGuardPeer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WireGuardPeer")
+            .field("public_key", &self.public_key)
+            .field("endpoint", &self.endpoint)
+            .field("allowed_ips", &self.allowed_ips)
+            .field("keepalive_interval", &self.keepalive_interval)
+            .field("preshared_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
 /// WireGuard tunnel configuration.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WireGuardConfig {
     pub interface_name: String,
     pub private_key: String,
     pub listen_port: u16,
     pub peers: Vec<WireGuardPeer>,
     pub mtu: u32,
+}
+
+impl fmt::Debug for WireGuardConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WireGuardConfig")
+            .field("interface_name", &self.interface_name)
+            .field("private_key", &"[REDACTED]")
+            .field("listen_port", &self.listen_port)
+            .field("peers", &self.peers)
+            .field("mtu", &self.mtu)
+            .finish()
+    }
 }
 
 impl Default for WireGuardConfig {

--- a/dataplane/novaedge-dataplane/src/upstream/pool.rs
+++ b/dataplane/novaedge-dataplane/src/upstream/pool.rs
@@ -322,11 +322,10 @@ impl ConnectionPool {
             host_pool.idle.retain(|c| {
                 now.duration_since(c.last_used) < timeout && c.created.elapsed() < MAX_CONN_AGE
             });
-            let removed = before - host_pool.idle.len();
-            // Return permits for removed idle connections.
-            if removed > 0 {
-                host_pool.semaphore.add_permits(removed);
-            }
+            let _removed = before - host_pool.idle.len();
+            // Note: permits are NOT returned here because idle connections
+            // already had their permits returned via `release()` when they
+            // transitioned from active to idle.
         }
     }
 }


### PR DESCRIPTION
## Summary
- **WireGuard key redaction**: Custom Debug impl that shows [REDACTED] for private_key and preshared_key
- **Pool semaphore double-add**: Remove extra add_permits in cleanup_idle (permits already returned on release)
- **Cache eviction**: Use insertion counter for deterministic FIFO eviction instead of timestamp comparison
- **Tracing imports**: Standardize on `use tracing::{...}` imports across all Rust files

Closes #1071 (Rust parts), closes #1073 (Rust parts)

## Test plan
- [ ] Cargo build passes
- [ ] Cargo test passes (410 tests)
- [ ] Cargo clippy clean