### PR TITLE
fix: gossip HMAC auth, peer cap, operator nil-pointer, cert manager robustness

### DIFF
--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -303,7 +303,7 @@ func initAgentComponents(ctx context.Context, logger *zap.Logger, atomicLevel za
 
 	comp.watcher = initConfigWatcher(ctx, logger.Named("config"))
 
-	comp.gossiper = gossip.NewConfigGossiper(nodeName, comp.watcher.ForceResync, logger)
+	comp.gossiper = gossip.NewConfigGossiper(nodeName, comp.watcher.ForceResync, logger, nil)
 	if err := comp.gossiper.Start(ctx); err != nil {
 		logger.Warn("Failed to start config gossiper", zap.Error(err))
 	}

--- a/internal/agent/gossip/gossip.go
+++ b/internal/agent/gossip/gossip.go
@@ -21,6 +21,9 @@ package gossip
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -66,6 +69,9 @@ const (
 
 	// messagePrefix identifies config gossip messages.
 	messagePrefix = "config_version"
+
+	// maxPeers is the maximum number of peers tracked in the peer table.
+	maxPeers = 256
 )
 
 // peerState tracks the last known config generation time and heartbeat of a peer.
@@ -78,9 +84,11 @@ type peerState struct {
 type ConfigGossiper struct {
 	nodeName        string
 	multicastAddr   string
+	psk             []byte // Pre-shared key for HMAC-SHA256 authentication (nil = disabled)
 	conn            *net.UDPConn
 	currentGenTime  atomic.Int64
 	peerVersions    sync.Map // map[string]peerState
+	peerCount       atomic.Int32
 	forceResyncFunc func()
 	lastResyncTime  atomic.Int64 // Unix nano timestamp of last force resync
 	logger          *zap.Logger
@@ -91,10 +99,13 @@ type ConfigGossiper struct {
 
 // NewConfigGossiper creates a new config version gossiper.
 // forceResyncFunc is called when quorum detects this agent is behind.
-func NewConfigGossiper(nodeName string, forceResyncFunc func(), logger *zap.Logger) *ConfigGossiper {
+// psk is an optional pre-shared key for HMAC-SHA256 message authentication;
+// pass nil or empty to disable authentication (backward compatible).
+func NewConfigGossiper(nodeName string, forceResyncFunc func(), logger *zap.Logger, psk []byte) *ConfigGossiper {
 	return &ConfigGossiper{
 		nodeName:        nodeName,
 		multicastAddr:   fmt.Sprintf("%s:%d", MulticastAddr, GossipPort),
+		psk:             psk,
 		forceResyncFunc: forceResyncFunc,
 		logger:          logger.Named("gossip"),
 	}
@@ -178,6 +189,12 @@ func (g *ConfigGossiper) broadcastLoop(addr *net.UDPAddr) {
 			msg := fmt.Sprintf("%s|%s|%d|%d",
 				messagePrefix, g.nodeName, genTime, time.Now().UnixNano())
 
+			if len(g.psk) > 0 {
+				mac := hmac.New(sha256.New, g.psk)
+				mac.Write([]byte(msg))
+				msg = msg + "|" + hex.EncodeToString(mac.Sum(nil))
+			}
+
 			if _, err := g.conn.WriteToUDP([]byte(msg), addr); err != nil {
 				g.logger.Debug("Failed to broadcast config version", zap.Error(err))
 			}
@@ -222,8 +239,28 @@ func (g *ConfigGossiper) receiveLoop() {
 }
 
 // handleMessage parses and processes a received gossip message.
-// Format: config_version|<nodeName>|<genTime>|<timestamp>
+// Format: config_version|<nodeName>|<genTime>|<timestamp>[|<hmac>]
 func (g *ConfigGossiper) handleMessage(data string) {
+	if len(g.psk) > 0 {
+		// Expect HMAC as 5th field
+		lastPipe := strings.LastIndex(data, "|")
+		if lastPipe < 0 {
+			return
+		}
+		payload := data[:lastPipe]
+		receivedMAC, err := hex.DecodeString(data[lastPipe+1:])
+		if err != nil {
+			return
+		}
+		mac := hmac.New(sha256.New, g.psk)
+		mac.Write([]byte(payload))
+		if !hmac.Equal(mac.Sum(nil), receivedMAC) {
+			g.logger.Debug("Gossip message HMAC verification failed, dropping")
+			return
+		}
+		data = payload
+	}
+
 	parts := strings.SplitN(data, "|", 4)
 	if len(parts) != 4 || parts[0] != messagePrefix {
 		return
@@ -240,10 +277,28 @@ func (g *ConfigGossiper) handleMessage(data string) {
 		return
 	}
 
-	g.peerVersions.Store(peerName, peerState{
+	// Cap peer table at maxPeers entries
+	if _, loaded := g.peerVersions.Load(peerName); !loaded {
+		if g.peerCount.Load() >= maxPeers {
+			g.logger.Debug("Peer table full, dropping message",
+				zap.String("peer", peerName))
+			return
+		}
+	}
+
+	if _, loaded := g.peerVersions.LoadOrStore(peerName, peerState{
 		genTime:  peerGenTime,
 		lastSeen: time.Now(),
-	})
+	}); loaded {
+		// Existing peer: just update
+		g.peerVersions.Store(peerName, peerState{
+			genTime:  peerGenTime,
+			lastSeen: time.Now(),
+		})
+	} else {
+		// New peer: increment counter
+		g.peerCount.Add(1)
+	}
 }
 
 // quorumCheckLoop periodically checks if a quorum of peers have a newer
@@ -297,6 +352,7 @@ func (g *ConfigGossiper) checkQuorum() {
 		// Expire peers not seen in PeerExpiry
 		if now.Sub(peer.lastSeen) > PeerExpiry {
 			g.peerVersions.Delete(key)
+			g.peerCount.Add(-1)
 			return true
 		}
 

--- a/internal/agent/gossip/gossip_test.go
+++ b/internal/agent/gossip/gossip_test.go
@@ -32,7 +32,7 @@ func TestNewConfigGossiper(t *testing.T) {
 	resyncFunc := func() { resyncCalled = true }
 	_ = resyncCalled
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 
 	require.NotNil(t, g)
 	assert.Equal(t, "test-node", g.nodeName)
@@ -43,7 +43,7 @@ func TestNewConfigGossiper(t *testing.T) {
 
 func TestConfigGossiper_UpdateGenTime(t *testing.T) {
 	logger := zap.NewNop()
-	g := NewConfigGossiper("test-node", func() {}, logger)
+	g := NewConfigGossiper("test-node", func() {}, logger, nil)
 
 	assert.Equal(t, int64(0), g.currentGenTime.Load())
 
@@ -56,7 +56,7 @@ func TestConfigGossiper_UpdateGenTime(t *testing.T) {
 
 func TestConfigGossiper_handleMessage(t *testing.T) {
 	logger := zap.NewNop()
-	g := NewConfigGossiper("test-node", func() {}, logger)
+	g := NewConfigGossiper("test-node", func() {}, logger, nil)
 
 	tests := []struct {
 		name        string
@@ -115,6 +115,7 @@ func TestConfigGossiper_handleMessage(t *testing.T) {
 				g.peerVersions.Delete(key)
 				return true
 			})
+			g.peerCount.Store(0)
 
 			g.handleMessage(tt.data)
 
@@ -138,7 +139,7 @@ func TestConfigGossiper_handleMessage(t *testing.T) {
 
 func TestConfigGossiper_handleMessage_UpdatesExistingPeer(t *testing.T) {
 	logger := zap.NewNop()
-	g := NewConfigGossiper("test-node", func() {}, logger)
+	g := NewConfigGossiper("test-node", func() {}, logger, nil)
 
 	// First message
 	g.handleMessage("config_version|peer-node|100|1609459200000000000")
@@ -166,7 +167,7 @@ func TestConfigGossiper_checkQuorum_NoConfig(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 
 	// No config applied (genTime = 0)
 	g.checkQuorum()
@@ -180,7 +181,7 @@ func TestConfigGossiper_checkQuorum_Cooldown(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Set last resync time to recent
@@ -201,7 +202,7 @@ func TestConfigGossiper_checkQuorum_ExpiredPeers(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Add expired peer
@@ -225,7 +226,7 @@ func TestConfigGossiper_checkQuorum_NoQuorum(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Add peers but not majority with newer genTime
@@ -244,7 +245,7 @@ func TestConfigGossiper_checkQuorum_QuorumTriggersResync(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Add peers where majority have significantly newer genTime
@@ -267,7 +268,7 @@ func TestConfigGossiper_checkQuorum_ExactlyHalfNotQuorum(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Add 4 peers, exactly2 are newer (not majority)
@@ -287,7 +288,7 @@ func TestConfigGossiper_checkQuorum_SingleNewerPeer(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Single peer that is newer
@@ -304,7 +305,7 @@ func TestConfigGossiper_checkQuorum_GenTimeThreshold(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Peer with genTime within threshold (1000 + 60 = 1060)
@@ -352,7 +353,7 @@ func TestConfigGossiper_checkQuorum_MultipleResyncs(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Add majority newer peers
@@ -379,7 +380,7 @@ func TestConfigGossiper_checkQuorum_InvalidPeerState(t *testing.T) {
 	resyncCalled := int32(0)
 	resyncFunc := func() { atomic.AddInt32(&resyncCalled, 1) }
 
-	g := NewConfigGossiper("test-node", resyncFunc, logger)
+	g := NewConfigGossiper("test-node", resyncFunc, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Store invalid peer state (not peerState type)
@@ -395,7 +396,7 @@ func TestConfigGossiper_checkQuorum_InvalidPeerState(t *testing.T) {
 // Benchmark tests
 func BenchmarkConfigGossiper_handleMessage(b *testing.B) {
 	logger := zap.NewNop()
-	g := NewConfigGossiper("test-node", func() {}, logger)
+	g := NewConfigGossiper("test-node", func() {}, logger, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -405,7 +406,7 @@ func BenchmarkConfigGossiper_handleMessage(b *testing.B) {
 
 func BenchmarkConfigGossiper_checkQuorum(b *testing.B) {
 	logger := zap.NewNop()
-	g := NewConfigGossiper("test-node", func() {}, logger)
+	g := NewConfigGossiper("test-node", func() {}, logger, nil)
 	g.UpdateGenTime(1000)
 
 	// Add some peers
@@ -421,7 +422,7 @@ func BenchmarkConfigGossiper_checkQuorum(b *testing.B) {
 
 func BenchmarkConfigGossiper_UpdateGenTime(b *testing.B) {
 	logger := zap.NewNop()
-	g := NewConfigGossiper("test-node", func() {}, logger)
+	g := NewConfigGossiper("test-node", func() {}, logger, nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/operator/controller/novaedgecluster_controller.go
+++ b/internal/operator/controller/novaedgecluster_controller.go
@@ -909,15 +909,24 @@ func isWebUIEnabled(cluster *novaedgev1alpha1.NovaEdgeCluster) bool {
 	return cluster.Spec.WebUI != nil && (cluster.Spec.WebUI.Enabled == nil || *cluster.Spec.WebUI.Enabled)
 }
 
+// replicasOrDefault safely dereferences a *int32 replica count, returning 1 if nil.
+func replicasOrDefault(r *int32) int32 {
+	if r == nil {
+		return 1
+	}
+	return *r
+}
+
 // fetchComponentStatuses fetches and sets the component statuses on the cluster object.
 func (r *NovaEdgeClusterReconciler) fetchComponentStatuses(ctx context.Context, cluster *novaedgev1alpha1.NovaEdgeCluster) {
 	controllerDeploy := &appsv1.Deployment{}
 	if err := r.Get(ctx, types.NamespacedName{
 		Name: fmt.Sprintf("%s-controller", cluster.Name), Namespace: cluster.Namespace,
 	}, controllerDeploy); err == nil {
+		replicas := replicasOrDefault(controllerDeploy.Spec.Replicas)
 		cluster.Status.Controller = &novaedgev1alpha1.ComponentStatus{
-			Ready:           controllerDeploy.Status.ReadyReplicas == *controllerDeploy.Spec.Replicas,
-			Replicas:        *controllerDeploy.Spec.Replicas,
+			Ready:           controllerDeploy.Status.ReadyReplicas == replicas,
+			Replicas:        replicas,
 			ReadyReplicas:   controllerDeploy.Status.ReadyReplicas,
 			UpdatedReplicas: controllerDeploy.Status.UpdatedReplicas,
 			Version:         cluster.Spec.Version,
@@ -942,9 +951,10 @@ func (r *NovaEdgeClusterReconciler) fetchComponentStatuses(ctx context.Context, 
 		if err := r.Get(ctx, types.NamespacedName{
 			Name: fmt.Sprintf("%s-webui", cluster.Name), Namespace: cluster.Namespace,
 		}, webUIDeploy); err == nil {
+			replicas := replicasOrDefault(webUIDeploy.Spec.Replicas)
 			cluster.Status.WebUI = &novaedgev1alpha1.ComponentStatus{
-				Ready:           webUIDeploy.Status.ReadyReplicas == *webUIDeploy.Spec.Replicas,
-				Replicas:        *webUIDeploy.Spec.Replicas,
+				Ready:           webUIDeploy.Status.ReadyReplicas == replicas,
+				Replicas:        replicas,
 				ReadyReplicas:   webUIDeploy.Status.ReadyReplicas,
 				UpdatedReplicas: webUIDeploy.Status.UpdatedReplicas,
 				Version:         cluster.Spec.Version,

--- a/internal/standalone/cert_manager.go
+++ b/internal/standalone/cert_manager.go
@@ -59,6 +59,7 @@ type CertificateManager struct {
 
 	renewalTicker *time.Ticker
 	stopCh        chan struct{}
+	stopOnce      sync.Once
 }
 
 // ManagedCertificate represents a managed certificate with hot-reload support.
@@ -405,84 +406,130 @@ func (m *CertificateManager) Start(ctx context.Context) {
 	m.logger.Info("Certificate manager started")
 }
 
-// Stop stops the certificate manager.
+// Stop stops the certificate manager. It is safe to call multiple times.
 func (m *CertificateManager) Stop() {
-	close(m.stopCh)
-	if m.renewalTicker != nil {
-		m.renewalTicker.Stop()
-	}
-	m.logger.Info("Certificate manager stopped")
+	m.stopOnce.Do(func() {
+		close(m.stopCh)
+		if m.renewalTicker != nil {
+			m.renewalTicker.Stop()
+		}
+		m.logger.Info("Certificate manager stopped")
+	})
+}
+
+// renewCandidate holds the information needed to renew a single certificate
+// outside the lock.
+type renewCandidate struct {
+	name    string
+	client  *acme.Client
+	domains []string
 }
 
 // checkRenewals checks for certificates needing renewal.
+// It collects candidates under a read lock, releases the lock for network I/O
+// (ACME operations), then re-acquires a write lock to update state.
 func (m *CertificateManager) checkRenewals(ctx context.Context) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	renewThreshold := 30 * 24 * time.Hour // 30 days
 
+	// Phase 1: collect candidates under read lock.
+	var candidates []renewCandidate
+	m.mu.RLock()
 	for name, mc := range m.certificates {
 		if mc.IssuerType != issuerTypeACME {
 			continue
 		}
-
-		if time.Until(mc.NotAfter) < renewThreshold {
-			m.logger.Info("Certificate needs renewal",
-				zap.String("name", name),
-				zap.Time("expires", mc.NotAfter),
-			)
-
-			client, ok := m.acmeClients[name]
-			if !ok {
-				m.logger.Warn("ACME client not found for certificate", zap.String("name", name))
-				continue
-			}
-
-			// Find the certificate config
-			var certConfig *CertificateConfig
-			for i := range m.config.Certificates {
-				if m.config.Certificates[i].Name == name {
-					certConfig = &m.config.Certificates[i]
-					break
-				}
-			}
-
-			if certConfig == nil {
-				m.logger.Warn("Certificate config not found", zap.String("name", name))
-				continue
-			}
-
-			// Renew certificate
-			cert, err := client.ObtainCertificate(ctx, &acme.CertificateRequest{
-				Domains: certConfig.Domains,
-			})
-			if err != nil {
-				m.logger.Error("Failed to renew certificate",
-					zap.String("name", name),
-					zap.Error(err),
-				)
-				continue
-			}
-
-			// Load new certificate
-			tlsCert, err := cert.TLSCertificate()
-			if err != nil {
-				m.logger.Error("Failed to load renewed certificate",
-					zap.String("name", name),
-					zap.Error(err),
-				)
-				continue
-			}
-
-			mc.certificate.Store(tlsCert)
-			mc.NotBefore = cert.NotBefore
-			mc.NotAfter = cert.NotAfter
-
-			m.logger.Info("Certificate renewed",
-				zap.String("name", name),
-				zap.Time("newExpiry", cert.NotAfter),
-			)
+		if time.Until(mc.NotAfter) >= renewThreshold {
+			continue
 		}
+
+		m.logger.Info("Certificate needs renewal",
+			zap.String("name", name),
+			zap.Time("expires", mc.NotAfter),
+		)
+
+		client, ok := m.acmeClients[name]
+		if !ok {
+			m.logger.Warn("ACME client not found for certificate", zap.String("name", name))
+			continue
+		}
+
+		var certConfig *CertificateConfig
+		for i := range m.config.Certificates {
+			if m.config.Certificates[i].Name == name {
+				certConfig = &m.config.Certificates[i]
+				break
+			}
+		}
+		if certConfig == nil {
+			m.logger.Warn("Certificate config not found", zap.String("name", name))
+			continue
+		}
+
+		candidates = append(candidates, renewCandidate{
+			name:    name,
+			client:  client,
+			domains: certConfig.Domains,
+		})
+	}
+	m.mu.RUnlock()
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	// Phase 2: perform ACME renewals without holding any lock.
+	type renewResult struct {
+		name    string
+		cert    *acme.Certificate
+		tlsCert *tls.Certificate
+	}
+	var results []renewResult
+
+	for _, c := range candidates {
+		cert, err := c.client.ObtainCertificate(ctx, &acme.CertificateRequest{
+			Domains: c.domains,
+		})
+		if err != nil {
+			m.logger.Error("Failed to renew certificate",
+				zap.String("name", c.name),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		tlsCert, err := cert.TLSCertificate()
+		if err != nil {
+			m.logger.Error("Failed to load renewed certificate",
+				zap.String("name", c.name),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		results = append(results, renewResult{name: c.name, cert: cert, tlsCert: tlsCert})
+	}
+
+	if len(results) == 0 {
+		return
+	}
+
+	// Phase 3: update state under write lock.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, r := range results {
+		mc, ok := m.certificates[r.name]
+		if !ok {
+			continue
+		}
+		mc.certificate.Store(r.tlsCert)
+		mc.NotBefore = r.cert.NotBefore
+		mc.NotAfter = r.cert.NotAfter
+
+		m.logger.Info("Certificate renewed",
+			zap.String("name", r.name),
+			zap.Time("newExpiry", r.cert.NotAfter),
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Gossip HMAC-SHA256**: Add PSK-based message authentication to prevent forgery/impersonation
- **Gossip peer cap**: Limit peer table to 256 entries to prevent memory exhaustion DoS
- **Operator nil-pointer**: Safe dereference of Deployment.Spec.Replicas with replicasOrDefault helper
- **CertManager double-close**: Protect Stop() with sync.Once
- **CertManager lock during I/O**: Collect renewal candidates under lock, perform ACME operations without lock

Closes #1078

## Test plan
- [ ] Go build passes
- [ ] Go tests pass
- [ ] golangci-lint passes