### PR TITLE
fix(dataplane): cache WAF engine per mode, cap sticky affinity map

### DIFF
--- a/dataplane/novaedge-dataplane/src/lb/sticky.rs
+++ b/dataplane/novaedge-dataplane/src/lb/sticky.rs
@@ -16,6 +16,9 @@ use super::{healthy_indices, healthy_weighted, Backend, LoadBalancer, RequestCon
 /// backend index. This ensures that after a config rebuild that reorders
 /// the backend slice, the cookie still routes to the correct backend
 /// by address match rather than a stale index. (#869)
+/// Maximum number of entries in the affinity map before new inserts are skipped.
+const MAX_AFFINITY_ENTRIES: usize = 10_000;
+
 pub struct StickySession {
     /// Cookie value → backend (addr, port).
     affinity: RwLock<HashMap<String, (IpAddr, u16)>>,
@@ -72,10 +75,13 @@ impl LoadBalancer for StickySession {
         let selected = weighted[pos];
 
         // Cache the selection by (addr, port) if a cookie is present.
+        // Skip insert when the map is at capacity to prevent unbounded growth.
         if let Some(cookie) = &ctx.sticky_cookie {
             let b = &backends[selected];
             let mut map = self.affinity.write().unwrap();
-            map.insert(cookie.clone(), (b.addr, b.port));
+            if map.len() < MAX_AFFINITY_ENTRIES {
+                map.insert(cookie.clone(), (b.addr, b.port));
+            }
         }
 
         Some(selected)

--- a/dataplane/novaedge-dataplane/src/middleware/pipeline.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/pipeline.rs
@@ -549,7 +549,16 @@ fn run_waf(policy_name: &str, config_json: &str, req: &Request) -> MiddlewareRes
         super::waf::WafMode::Block
     };
 
-    let waf = super::waf::WafEngine::with_default_rules(mode);
+    use std::sync::OnceLock;
+    static BLOCK_WAF: OnceLock<super::waf::WafEngine> = OnceLock::new();
+    static DETECT_WAF: OnceLock<super::waf::WafEngine> = OnceLock::new();
+
+    let waf = match mode {
+        super::waf::WafMode::Block => BLOCK_WAF
+            .get_or_init(|| super::waf::WafEngine::with_default_rules(super::waf::WafMode::Block)),
+        super::waf::WafMode::Detect => DETECT_WAF
+            .get_or_init(|| super::waf::WafEngine::with_default_rules(super::waf::WafMode::Detect)),
+    };
     match waf.check(req) {
         super::waf::WafDecision::Allow => MiddlewareResult::Continue(req.clone()),
         super::waf::WafDecision::Block {


### PR DESCRIPTION
## Summary
- **WAF engine caching**: Use static OnceLock to compile regex rules once per mode instead of per-request
- **Sticky session cap**: Limit affinity map to 10K entries to prevent unbounded memory growth

Closes #1079 (Rust parts)

## Test plan
- [ ] Cargo build passes
- [ ] Cargo test passes (410 tests)
- [ ] Cargo clippy clean