### PR TITLE
fix: controller shutdown ordering, Helm dataplane image/probe/federation wiring

### DIFF
--- a/charts/novaedge-agent/templates/daemonset.yaml
+++ b/charts/novaedge-agent/templates/daemonset.yaml
@@ -199,7 +199,7 @@ spec:
             {{- end }}
       {{- if and .Values.dataplane .Values.dataplane.enabled }}
         - name: novaedge-dataplane
-          image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag }}"
+          image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.dataplane.image.pullPolicy }}
           args:
             - --socket={{ .Values.dataplane.socketPath }}

--- a/charts/novaedge/templates/agent-daemonset.yaml
+++ b/charts/novaedge/templates/agent-daemonset.yaml
@@ -215,7 +215,7 @@ spec:
         {{- end }}
       {{- if and .Values.dataplane .Values.dataplane.enabled }}
       - name: novaedge-dataplane
-        image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag }}"
+        image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.dataplane.image.pullPolicy }}
         args:
         - --socket={{ .Values.dataplane.socketPath }}
@@ -244,6 +244,15 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 2
+          failureThreshold: 3
+        livenessProbe:
+          exec:
+            command:
+            - test
+            - -S
+            - /tmp/novaedge-dataplane.sock
+          initialDelaySeconds: 10
+          periodSeconds: 10
           failureThreshold: 3
         resources:
           {{- toYaml .Values.dataplane.resources | nindent 10 }}

--- a/charts/novaedge/templates/controller-deployment.yaml
+++ b/charts/novaedge/templates/controller-deployment.yaml
@@ -102,6 +102,10 @@ spec:
         - --mesh-ca-cert-lifetime={{ .Values.controller.meshCA.certLifetime }}
         - --mesh-ca-validity={{ .Values.controller.meshCA.caValidity }}
         {{- end }}
+        {{- if .Values.federation.enabled }}
+        - --federation-id={{ .Values.federation.federationID | default "default" }}
+        - --federation-local-member={{ .Values.federation.localMember.name | default (include "novaedge.fullname" .) }}
+        {{- end }}
         {{- with .Values.controller.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/cmd/novaedge-controller/main.go
+++ b/cmd/novaedge-controller/main.go
@@ -22,10 +22,12 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec // G108: pprof is served on localhost:6060 only, not publicly exposed
 	"os"
+	"time"
 
 	uberzap "go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -241,7 +243,8 @@ func initVaultIntegration(f *controllerFlags, reconciler *controller.ProxyGatewa
 }
 
 // initConfigServer creates the config server, wires mesh CA and federation, and starts the gRPC server.
-func initConfigServer(mgr ctrl.Manager, f *controllerFlags, zapLogger *uberzap.Logger) (*grpc.Server, *snapshot.Server) {
+// It returns the gRPC server, the snapshot server, and an error channel that receives any gRPC serve errors.
+func initConfigServer(mgr ctrl.Manager, f *controllerFlags, zapLogger *uberzap.Logger) (*grpc.Server, *snapshot.Server, <-chan error) {
 	configServer := snapshot.NewServer(mgr.GetClient())
 	configServer.Start()
 
@@ -301,22 +304,22 @@ func initConfigServer(mgr ctrl.Manager, f *controllerFlags, zapLogger *uberzap.L
 
 	configServer.RegisterServer(grpcServer)
 
-	// Start gRPC server in a goroutine
+	// Start gRPC server in a goroutine, sending errors to a channel instead of calling os.Exit.
+	grpcErrCh := make(chan error, 1)
 	go func() {
 		var lc net.ListenConfig
 		lis, lisErr := lc.Listen(context.Background(), "tcp", f.grpcAddr)
 		if lisErr != nil {
-			setupLog.Error(lisErr, "failed to listen for gRPC")
-			os.Exit(1)
+			grpcErrCh <- fmt.Errorf("failed to listen for gRPC: %w", lisErr)
+			return
 		}
 		setupLog.Info("starting gRPC config server", "address", f.grpcAddr)
 		if serveErr := grpcServer.Serve(lis); serveErr != nil {
-			setupLog.Error(serveErr, "failed to serve gRPC")
-			os.Exit(1)
+			grpcErrCh <- fmt.Errorf("failed to serve gRPC: %w", serveErr)
 		}
 	}()
 
-	return grpcServer, configServer
+	return grpcServer, configServer, grpcErrCh
 }
 
 func main() {
@@ -363,7 +366,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	grpcServer, configServer := initConfigServer(mgr, f, zapLogger)
+	grpcServer, configServer, grpcErrCh := initConfigServer(mgr, f, zapLogger)
 
 	proxyGatewayReconciler := registerReconcilers(mgr, f, configServer)
 
@@ -379,13 +382,37 @@ func main() {
 	initCertManagerIntegration(mgr, f.enableCertManager, proxyGatewayReconciler)
 	initVaultIntegration(f, proxyGatewayReconciler, zapLogger)
 
+	// Start manager and monitor both it and the gRPC server for errors.
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+	mgrCtx := ctrl.SetupSignalHandler()
+	mgrErrCh := make(chan error, 1)
+	go func() {
+		mgrErrCh <- mgr.Start(mgrCtx)
+	}()
+
+	select {
+	case err := <-grpcErrCh:
+		setupLog.Error(err, "gRPC server failed, shutting down")
+	case err := <-mgrErrCh:
+		if err != nil {
+			setupLog.Error(err, "problem running manager")
+		}
 	}
 
-	// Graceful shutdown: stop the snapshot server and gRPC server.
+	// Graceful shutdown: stop the snapshot server and gRPC server with a timeout.
 	configServer.Shutdown()
-	grpcServer.GracefulStop()
+
+	const grpcShutdownTimeout = 15 * time.Second
+	shutdownDone := make(chan struct{})
+	go func() {
+		grpcServer.GracefulStop()
+		close(shutdownDone)
+	}()
+	select {
+	case <-shutdownDone:
+		setupLog.Info("gRPC server stopped gracefully")
+	case <-time.After(grpcShutdownTimeout):
+		setupLog.Info("gRPC graceful stop timed out, forcing stop")
+		grpcServer.Stop()
+	}
 }


### PR DESCRIPTION
## Summary
- **Controller shutdown**: Replace os.Exit in goroutine with error channel; add 15s timeout on GracefulStop with hard-stop fallback
- **Dataplane image tag**: Fall back to Chart.AppVersion when tag is empty (prevents invalid `repo:` reference)
- **Dataplane livenessProbe**: Add socket-check livenessProbe to dataplane sidecar
- **Federation wiring**: Pass --federation-id and --federation-local-member to controller when federation.enabled

Closes #1085

## Test plan
- [ ] Go build passes
- [ ] Helm lint passes
- [ ] CI pipeline green