### PR TITLE
fix: watcher goroutine leak, ACME error propagation, shutdown timeouts, tunnel timeouts, chart labels

### DIFF
--- a/charts/novaedge-operator/templates/_helpers.tpl
+++ b/charts/novaedge-operator/templates/_helpers.tpl
@@ -40,6 +40,7 @@ helm.sh/chart: {{ include "novaedge-operator.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: novaedge
 {{- end }}
 
 {{/*

--- a/charts/novaedge/templates/_helpers.tpl
+++ b/charts/novaedge/templates/_helpers.tpl
@@ -38,6 +38,7 @@ helm.sh/chart: {{ include "novaedge.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: novaedge
 {{- end }}
 
 {{/*

--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -51,6 +51,9 @@ import (
 	_ "github.com/azrtydxb/novaedge/internal/agent/wasm"
 )
 
+// shutdownTimeout is the grace period for orderly shutdown of all subsystems.
+const shutdownTimeout = 10 * time.Second
+
 // Build-time variables set via ldflags.
 var (
 	version = "dev"
@@ -156,7 +159,7 @@ func main() {
 		logger.Fatal("Failed to initialize tracing", zap.Error(err))
 	}
 	defer func() {
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer shutdownCancel()
 		if err := tracerProvider.Shutdown(shutdownCtx); err != nil {
 			logger.Error("Failed to shutdown tracer provider", zap.Error(err))
@@ -480,7 +483,7 @@ func closeIfNotNil(logger *zap.Logger, name string, c interface{ Close() error }
 
 // shutdownAgent performs graceful shutdown of all agent subsystems.
 func shutdownAgent(logger *zap.Logger, comp *agentComponents) {
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer shutdownCancel()
 
 	if comp.meshManager != nil {

--- a/internal/acme/client.go
+++ b/internal/acme/client.go
@@ -226,9 +226,10 @@ func (c *Client) registerAccount(ctx context.Context, _ *User, privateKey crypto
 		PrivateKeyPEM: keyPEM,
 	}
 
-	// Save account
+	// Save account — return on error to prevent silent rate-limit exhaustion
+	// if storage is broken (re-registration would consume ACME rate limits).
 	if err := c.storage.SaveAccount(ctx, c.account); err != nil {
-		c.logger.Warn("Failed to save account", zap.Error(err))
+		return fmt.Errorf("failed to save ACME account: %w", err)
 	}
 
 	c.logger.Info("Registered new ACME account",
@@ -290,9 +291,10 @@ func (c *Client) ObtainCertificate(ctx context.Context, req *CertificateRequest)
 		Issuer:               certData.Issuer.CommonName,
 	}
 
-	// Save certificate
+	// Save certificate — return on error to prevent silent rate-limit exhaustion
+	// if storage is broken (re-issuance would consume ACME rate limits).
 	if err := c.storage.SaveCertificate(ctx, result); err != nil {
-		c.logger.Warn("Failed to save certificate", zap.Error(err))
+		return nil, fmt.Errorf("failed to save certificate: %w", err)
 	}
 
 	c.logger.Info("Certificate obtained",

--- a/internal/agent/config/watcher.go
+++ b/internal/agent/config/watcher.go
@@ -299,8 +299,14 @@ func (w *Watcher) streamConfig(client pb.ConfigServiceClient, applyFunc ApplyFun
 		ClusterLabels:      w.clusterLabels,
 	}
 
+	// Derive a cancellable context so we can stop the recv goroutine when
+	// streamConfig returns (e.g. on force-resync). Without this the
+	// goroutine would leak until the parent context is cancelled.
+	streamCtx, streamCancel := context.WithCancel(w.ctx)
+	defer streamCancel()
+
 	// Start streaming
-	stream, err := client.StreamConfig(w.ctx, req)
+	stream, err := client.StreamConfig(streamCtx, req)
 	if err != nil {
 		return fmt.Errorf("failed to start config stream: %w", err)
 	}

--- a/internal/agent/mesh/tunnel.go
+++ b/internal/agent/mesh/tunnel.go
@@ -439,7 +439,7 @@ func (tp *TunnelPool) DialVia(ctx context.Context, nodeAddr, backendAddr, source
 		},
 	}
 
-	connectClient := &http.Client{Transport: transport}
+	connectClient := &http.Client{Transport: transport, Timeout: 30 * time.Second}
 
 	resp, err := connectClient.Do(req) //nolint:gosec // G704: URL validated via url.ParseRequestURI above
 	if err != nil {
@@ -508,6 +508,7 @@ func (tp *TunnelPool) getOrCreateClient(nodeAddr string) *http.Client {
 		Transport: &http2.Transport{
 			TLSClientConfig: tp.tlsConfig,
 		},
+		Timeout: 30 * time.Second,
 	}
 	tp.clients[nodeAddr] = &pooledClient{
 		client:   client,

--- a/internal/agent/server/admin.go
+++ b/internal/agent/server/admin.go
@@ -184,7 +184,7 @@ func (a *AdminServer) Start(ctx context.Context) error {
 
 	<-ctx.Done()
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 	defer cancel()
 
 	a.logger.Info("Shutting down admin API server")

--- a/internal/agent/server/constants.go
+++ b/internal/agent/server/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 NovaEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import "time"
+
+// serverShutdownTimeout is the grace period for HTTP server shutdown.
+const serverShutdownTimeout = 10 * time.Second

--- a/internal/agent/server/health.go
+++ b/internal/agent/server/health.go
@@ -100,7 +100,7 @@ func (h *HealthServer) Start(ctx context.Context) error {
 		// Stop rate limiter cleanup routine
 		h.rateLimiter.Stop()
 
-		shutdownCtx, cancel := context.WithTimeout(detachedCtx, 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(detachedCtx, serverShutdownTimeout)
 		defer cancel()
 		if err := h.server.Shutdown(shutdownCtx); err != nil {
 			h.logger.Error("Health server shutdown error", zap.Error(err))

--- a/internal/agent/server/metrics.go
+++ b/internal/agent/server/metrics.go
@@ -105,7 +105,7 @@ func (m *MetricsServer) Start(ctx context.Context) error {
 	m.rateLimiter.Stop()
 
 	// Graceful shutdown
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 	defer cancel()
 
 	m.logger.Info("Shutting down metrics server")


### PR DESCRIPTION
## Summary
- **Config watcher**: Cancel stream context on all exit paths to prevent goroutine leak
- **ACME storage**: Return errors from SaveAccount/SaveCertificate instead of swallowing
- **Shutdown timeouts**: Define named constants (10s), replace magic literals
- **Tunnel HTTP clients**: Add 30s Timeout to prevent indefinite hangs
- **Chart labels**: Add app.kubernetes.io/part-of to operator and umbrella charts

Closes #1086

## Test plan
- [ ] Go build passes
- [ ] Go tests pass
- [ ] Helm lint passes