### PR TITLE
fix: gateway class lookup, introspection security, resource bounds, race fixes

### DIFF
--- a/cmd/novaedge-agent/main.go
+++ b/cmd/novaedge-agent/main.go
@@ -328,8 +328,8 @@ func initAgentComponents(ctx context.Context, logger *zap.Logger, atomicLevel za
 	comp.dpTranslator = dpctl.NewTranslator(dpClient, logger.Named("dataplane"))
 	logger.Info("Rust forwarding plane active: delegating all forwarding to dataplane daemon")
 
-	comp.metricsServer = server.NewMetricsServer(logger, metricsPort)
-	comp.healthServer = server.NewHealthServer(logger, healthProbePort)
+	comp.metricsServer = server.NewMetricsServer(ctx, logger, metricsPort)
+	comp.healthServer = server.NewHealthServer(ctx, logger, healthProbePort)
 	adminSrv, err := server.NewAdminServer("", logger)
 	if err != nil {
 		logger.Fatal("Failed to create admin server", zap.Error(err))

--- a/cmd/novaedge-standalone/main.go
+++ b/cmd/novaedge-standalone/main.go
@@ -76,7 +76,7 @@ func parseFlags() {
 }
 
 // initComponents creates all standalone agent components.
-func initComponents(logger *zap.Logger) *standaloneComponents {
+func initComponents(ctx context.Context, logger *zap.Logger) *standaloneComponents {
 	c := &standaloneComponents{logger: logger}
 
 	// Create dataplane client for Rust forwarding plane
@@ -90,8 +90,8 @@ func initComponents(logger *zap.Logger) *standaloneComponents {
 	c.dpTranslator = dpctl.NewTranslator(dpClient, logger.Named("dataplane"))
 	logger.Info("Rust forwarding plane active: delegating all forwarding to dataplane daemon")
 
-	c.metricsServer = server.NewMetricsServer(logger, metricsPort)
-	c.healthServer = server.NewHealthServer(logger, healthProbePort)
+	c.metricsServer = server.NewMetricsServer(ctx, logger, metricsPort)
+	c.healthServer = server.NewHealthServer(ctx, logger, healthProbePort)
 
 	cw, cwErr := standalone.NewConfigWatcher(configFile, nodeName, logger)
 	if cwErr != nil {
@@ -153,7 +153,7 @@ func main() {
 		cancel()
 	}()
 
-	c := initComponents(logger)
+	c := initComponents(ctx, logger)
 
 	// Start config watcher
 	configChan := make(chan error, 1)

--- a/internal/agent/introspection/server.go
+++ b/internal/agent/introspection/server.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net"
 
+	"github.com/azrtydxb/novaedge/internal/pkg/grpclimits"
 	pb "github.com/azrtydxb/novaedge/internal/proto/gen"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -106,7 +107,7 @@ func (s *Server) Start(ctx context.Context, addr string) error {
 	if err != nil {
 		return err
 	}
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(grpclimits.ServerOptions(s.logger)...)
 	pb.RegisterConfigServiceServer(grpcServer, s)
 	go func() {
 		<-ctx.Done()

--- a/internal/agent/mesh/tunnel.go
+++ b/internal/agent/mesh/tunnel.go
@@ -227,7 +227,7 @@ func (ts *TunnelServer) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// We wrap the ResponseWriter in a bufferedFlushWriter that batches
 	// writes into a 32KB buffer with periodic 1ms flush to reduce
 	// per-write Flush() system call overhead.
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		defer func() { done <- struct{}{} }()
 		if _, err := io.Copy(backendConn, r.Body); err != nil {

--- a/internal/agent/server/health.go
+++ b/internal/agent/server/health.go
@@ -36,12 +36,13 @@ type HealthServer struct {
 	rateLimiter *IPRateLimiter
 }
 
-// NewHealthServer creates a new health probe server
-func NewHealthServer(logger *zap.Logger, port int) *HealthServer {
+// NewHealthServer creates a new health probe server.
+// The provided context controls the lifetime of background goroutines (e.g. rate-limiter cleanup).
+func NewHealthServer(ctx context.Context, logger *zap.Logger, port int) *HealthServer {
 	return &HealthServer{
 		logger:      logger,
 		port:        port,
-		rateLimiter: NewIPRateLimiter(DefaultObservabilityRateLimitConfig()),
+		rateLimiter: NewIPRateLimiter(ctx, DefaultObservabilityRateLimitConfig()),
 	}
 }
 

--- a/internal/agent/server/health_test.go
+++ b/internal/agent/server/health_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,7 +31,7 @@ func TestNewHealthServer(t *testing.T) {
 	logger := zap.NewNop()
 	port := 8080
 
-	hs := NewHealthServer(logger, port)
+	hs := NewHealthServer(context.Background(), logger, port)
 
 	require.NotNil(t, hs)
 	assert.Equal(t, logger, hs.logger)
@@ -40,7 +41,7 @@ func TestNewHealthServer(t *testing.T) {
 
 func TestHealthServer_SetReady(t *testing.T) {
 	logger := zap.NewNop()
-	hs := NewHealthServer(logger, 8080)
+	hs := NewHealthServer(context.Background(), logger, 8080)
 
 	// Initially not ready
 	assert.False(t, hs.ready.Load())
@@ -73,7 +74,7 @@ func TestHealthServer_HealthzEndpoint(t *testing.T) {
 
 func TestHealthServer_ReadyEndpoint(t *testing.T) {
 	logger := zap.NewNop()
-	hs := NewHealthServer(logger, 8080)
+	hs := NewHealthServer(context.Background(), logger, 8080)
 
 	t.Run("not ready", func(t *testing.T) {
 		hs.SetReady(false)
@@ -121,7 +122,7 @@ func TestHealthServer_ReadyEndpoint(t *testing.T) {
 }
 
 func TestIPRateLimiter(t *testing.T) {
-	rl := NewIPRateLimiter(DefaultObservabilityRateLimitConfig())
+	rl := NewIPRateLimiter(context.Background(), DefaultObservabilityRateLimitConfig())
 
 	require.NotNil(t, rl)
 }

--- a/internal/agent/server/metrics.go
+++ b/internal/agent/server/metrics.go
@@ -42,8 +42,9 @@ type MetricsServer struct {
 	rateLimiter *IPRateLimiter
 }
 
-// NewMetricsServer creates a new metrics server
-func NewMetricsServer(logger *zap.Logger, port int) *MetricsServer {
+// NewMetricsServer creates a new metrics server.
+// The provided context controls the lifetime of background goroutines (e.g. rate-limiter cleanup).
+func NewMetricsServer(ctx context.Context, logger *zap.Logger, port int) *MetricsServer {
 	if port == 0 {
 		port = DefaultMetricsPort
 	}
@@ -51,7 +52,7 @@ func NewMetricsServer(logger *zap.Logger, port int) *MetricsServer {
 	return &MetricsServer{
 		logger:      logger,
 		port:        port,
-		rateLimiter: NewIPRateLimiter(DefaultObservabilityRateLimitConfig()),
+		rateLimiter: NewIPRateLimiter(ctx, DefaultObservabilityRateLimitConfig()),
 	}
 }
 

--- a/internal/agent/server/metrics_test.go
+++ b/internal/agent/server/metrics_test.go
@@ -58,7 +58,7 @@ func TestNewMetricsServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewMetricsServer(logger, tt.port)
+			server := NewMetricsServer(context.Background(), logger, tt.port)
 			require.NotNil(t, server)
 			assert.Equal(t, tt.expectedPort, server.port)
 			assert.NotNil(t, server.logger)
@@ -74,7 +74,7 @@ func TestMetricsServer_StartAndShutdown(t *testing.T) {
 	logger := zap.NewNop()
 
 	// Use a random available port
-	server := NewMetricsServer(logger, 0) // Will use default port
+	server := NewMetricsServer(context.Background(), logger, 0) // Will use default port
 	require.NotNil(t, server)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -111,7 +111,7 @@ func TestMetricsServer_Shutdown(t *testing.T) {
 	})
 
 	t.Run("running server", func(t *testing.T) {
-		server := NewMetricsServer(logger, 0)
+		server := NewMetricsServer(context.Background(), logger, 0)
 		require.NotNil(t, server)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -138,7 +138,7 @@ func TestMetricsServer_HTTPEndpoints(t *testing.T) {
 	logger := zap.NewNop()
 
 	// Find available port
-	server := NewMetricsServer(logger, 0)
+	server := NewMetricsServer(context.Background(), logger, 0)
 	require.NotNil(t, server)
 
 	// Manually create server for testing
@@ -184,7 +184,7 @@ func TestMetricsServer_HTTPEndpoints(t *testing.T) {
 func TestMetricsServer_RateLimitIntegration(t *testing.T) {
 	logger := zap.NewNop()
 
-	server := NewMetricsServer(logger, 0)
+	server := NewMetricsServer(context.Background(), logger, 0)
 	require.NotNil(t, server)
 	defer server.rateLimiter.Stop()
 
@@ -200,7 +200,7 @@ func TestMetricsServer_RateLimitIntegration(t *testing.T) {
 func TestMetricsServer_ConcurrentAccess(t *testing.T) {
 	logger := zap.NewNop()
 
-	server := NewMetricsServer(logger, 0)
+	server := NewMetricsServer(context.Background(), logger, 0)
 	require.NotNil(t, server)
 	defer server.rateLimiter.Stop()
 
@@ -222,7 +222,7 @@ func TestMetricsServer_ConcurrentAccess(t *testing.T) {
 
 func TestMetricsServer_StructFields(t *testing.T) {
 	logger := zap.NewNop()
-	server := NewMetricsServer(logger, 9091)
+	server := NewMetricsServer(context.Background(), logger, 9091)
 
 	require.NotNil(t, server)
 	assert.Equal(t, 9091, server.port)
@@ -235,7 +235,7 @@ func TestMetricsServer_StructFields(t *testing.T) {
 
 func TestMetricsServer_DefaultRateLimitConfig(t *testing.T) {
 	logger := zap.NewNop()
-	server := NewMetricsServer(logger, 0)
+	server := NewMetricsServer(context.Background(), logger, 0)
 	require.NotNil(t, server)
 	defer server.rateLimiter.Stop()
 
@@ -251,14 +251,14 @@ func BenchmarkNewMetricsServer(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		server := NewMetricsServer(logger, 9090)
+		server := NewMetricsServer(context.Background(), logger, 9090)
 		server.rateLimiter.Stop()
 	}
 }
 
 func BenchmarkMetricsServer_RateLimiter(b *testing.B) {
 	logger := zap.NewNop()
-	server := NewMetricsServer(logger, 9090)
+	server := NewMetricsServer(context.Background(), logger, 9090)
 	defer server.rateLimiter.Stop()
 
 	b.ResetTimer()

--- a/internal/agent/server/ratelimit.go
+++ b/internal/agent/server/ratelimit.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"sync"
@@ -59,8 +60,10 @@ type IPRateLimiter struct {
 	cleanupCh chan struct{}
 }
 
-// NewIPRateLimiter creates a new IP-based rate limiter
-func NewIPRateLimiter(config RateLimiterConfig) *IPRateLimiter {
+// NewIPRateLimiter creates a new IP-based rate limiter.
+// The provided context controls the lifetime of the cleanup goroutine;
+// when the context is cancelled, the goroutine exits.
+func NewIPRateLimiter(ctx context.Context, config RateLimiterConfig) *IPRateLimiter {
 	rl := &IPRateLimiter{
 		limiters:  make(map[string]*limiterEntry),
 		config:    config,
@@ -68,7 +71,7 @@ func NewIPRateLimiter(config RateLimiterConfig) *IPRateLimiter {
 	}
 
 	// Start cleanup goroutine to remove stale limiters
-	go rl.cleanupRoutine()
+	go rl.cleanupRoutine(ctx)
 
 	return rl
 }
@@ -96,7 +99,7 @@ func (rl *IPRateLimiter) getLimiter(ip string) *rate.Limiter {
 }
 
 // cleanupRoutine periodically removes stale limiters to prevent memory leaks
-func (rl *IPRateLimiter) cleanupRoutine() {
+func (rl *IPRateLimiter) cleanupRoutine(ctx context.Context) {
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 
@@ -104,6 +107,8 @@ func (rl *IPRateLimiter) cleanupRoutine() {
 		select {
 		case <-ticker.C:
 			rl.cleanup()
+		case <-ctx.Done():
+			return
 		case <-rl.cleanupCh:
 			return
 		}

--- a/internal/agent/server/ratelimit_test.go
+++ b/internal/agent/server/ratelimit_test.go
@@ -50,7 +50,7 @@ func TestNewIPRateLimiter(t *testing.T) {
 		Burst:             5,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	require.NotNil(t, limiter)
 	assert.NotNil(t, limiter.limiters)
 	assert.Equal(t, config, limiter.config)
@@ -65,7 +65,7 @@ func TestIPRateLimiter_GetLimiter(t *testing.T) {
 		Burst:             5,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	// Get limiter for new IP
@@ -92,7 +92,7 @@ func TestIPRateLimiter_GetLimiter_Concurrent(t *testing.T) {
 		Burst:             5,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	// Concurrent access to same IP
@@ -117,7 +117,7 @@ func TestIPRateLimiter_Cleanup(t *testing.T) {
 		Burst:             5,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	// Add many limiters
@@ -154,7 +154,7 @@ func TestIPRateLimiter_Cleanup_SmallMap(t *testing.T) {
 		Burst:             5,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	// Add few limiters
@@ -182,7 +182,7 @@ func TestIPRateLimiter_Stop(t *testing.T) {
 		Burst:             5,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 
 	// Stop should not panic
 	assert.NotPanics(t, func() {
@@ -199,7 +199,7 @@ func TestRateLimitMiddleware_Allow(t *testing.T) {
 		Burst:             2,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	middleware := RateLimitMiddleware(limiter)
@@ -230,7 +230,7 @@ func TestRateLimitMiddleware_RateLimited(t *testing.T) {
 		Burst:             1,  // Very low burst
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	middleware := RateLimitMiddleware(limiter)
@@ -268,7 +268,7 @@ func TestRateLimitMiddleware_DifferentIPs(t *testing.T) {
 		Burst:             1,  // Very low burst
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	middleware := RateLimitMiddleware(limiter)
@@ -297,7 +297,7 @@ func TestRateLimitMiddleware_IPExtraction(t *testing.T) {
 		Burst:             10,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	middleware := RateLimitMiddleware(limiter)
@@ -358,7 +358,7 @@ func TestRateLimiterConfig_Values(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			limiter := NewIPRateLimiter(tt.config)
+			limiter := NewIPRateLimiter(context.Background(), tt.config)
 			defer limiter.Stop()
 
 			l := limiter.getLimiter("192.168.1.1")
@@ -373,7 +373,7 @@ func TestRateLimitMiddleware_ResponseFormat(t *testing.T) {
 		Burst:             1,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	middleware := RateLimitMiddleware(limiter)
@@ -402,7 +402,7 @@ func BenchmarkIPRateLimiter_GetLimiter(b *testing.B) {
 		Burst:             5,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	b.ResetTimer()
@@ -417,7 +417,7 @@ func BenchmarkIPRateLimiter_GetLimiter_DifferentIPs(b *testing.B) {
 		Burst:             5,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	b.ResetTimer()
@@ -432,7 +432,7 @@ func BenchmarkRateLimitMiddleware(b *testing.B) {
 		Burst:             100,
 	}
 
-	limiter := NewIPRateLimiter(config)
+	limiter := NewIPRateLimiter(context.Background(), config)
 	defer limiter.Stop()
 
 	middleware := RateLimitMiddleware(limiter)

--- a/internal/agent/server/runtime_api.go
+++ b/internal/agent/server/runtime_api.go
@@ -144,6 +144,7 @@ type changeWeightRequest struct {
 
 // handleAddEndpoint handles POST /api/v1/clusters/{cluster}/endpoints.
 func (api *RuntimeAPI) handleAddEndpoint(w http.ResponseWriter, r *http.Request, cluster string) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var req addEndpointRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
@@ -199,6 +200,7 @@ func (api *RuntimeAPI) handleRemoveEndpoint(w http.ResponseWriter, _ *http.Reque
 
 // handleChangeWeight handles PUT /api/v1/clusters/{cluster}/endpoints/{endpoint}/weight.
 func (api *RuntimeAPI) handleChangeWeight(w http.ResponseWriter, r *http.Request, cluster, endpoint string) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var req changeWeightRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -79,13 +79,13 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Verify the GatewayClass exists and is accepted
 	gatewayClass := &gatewayv1.GatewayClass{}
-	if err := r.Get(ctx, types.NamespacedName{Name: NovaEdgeGatewayClassName}, gatewayClass); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: expectedClass}, gatewayClass); err != nil {
 		if apierrors.IsNotFound(err) {
 			return r.updateGatewayStatus(ctx, gateway, metav1.Condition{
 				Type:               string(gatewayv1.GatewayConditionAccepted),
 				Status:             metav1.ConditionFalse,
 				Reason:             string(gatewayv1.GatewayReasonInvalid),
-				Message:            fmt.Sprintf("GatewayClass %s not found", NovaEdgeGatewayClassName),
+				Message:            fmt.Sprintf("GatewayClass %s not found", expectedClass),
 				ObservedGeneration: gateway.Generation,
 				LastTransitionTime: metav1.Now(),
 			})

--- a/internal/controller/vault/kv.go
+++ b/internal/controller/vault/kv.go
@@ -41,6 +41,10 @@ const (
 	KVEngineV1 KVEngine = "kv-v1"
 	// KVEngineV2 is KV secrets engine version 2.
 	KVEngineV2 KVEngine = "kv-v2"
+
+	// maxCacheSize is the maximum number of entries allowed in the secret cache.
+	// When inserting a new entry would exceed this limit, the oldest entry (by fetchedAt) is evicted.
+	maxCacheSize = 10000
 )
 
 // KVManager handles operations with the Vault KV secrets engine.
@@ -143,6 +147,20 @@ func (k *KVManager) ReadSecretCached(ctx context.Context, engine KVEngine, path 
 
 	// Update cache
 	k.mu.Lock()
+	// Evict the oldest entry if the cache is at capacity and this is a new key.
+	if _, exists := k.cache[cacheKey]; !exists && len(k.cache) >= maxCacheSize {
+		var oldestKey string
+		var oldestTime time.Time
+		first := true
+		for key, entry := range k.cache {
+			if first || entry.fetchedAt.Before(oldestTime) {
+				oldestKey = key
+				oldestTime = entry.fetchedAt
+				first = false
+			}
+		}
+		delete(k.cache, oldestKey)
+	}
 	k.cache[cacheKey] = &cachedSecret{
 		data:      data,
 		fetchedAt: time.Now(),

--- a/internal/controller/vault/renewal.go
+++ b/internal/controller/vault/renewal.go
@@ -98,16 +98,22 @@ func (r *RenewalManager) SetCheckInterval(d time.Duration) {
 
 // OnTokenRenewed sets the callback for successful token renewal.
 func (r *RenewalManager) OnTokenRenewed(fn func()) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.onTokenRenewed = fn
 }
 
 // OnCertRenewed sets the callback for successful certificate renewal.
 func (r *RenewalManager) OnCertRenewed(fn func(name string, cert *PKICertificate)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.onCertRenewed = fn
 }
 
 // OnRenewalError sets the callback for renewal errors.
 func (r *RenewalManager) OnRenewalError(fn func(name string, err error)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.onRenewalError = fn
 }
 
@@ -203,15 +209,21 @@ func (r *RenewalManager) checkTokenRenewal(ctx context.Context) {
 	// Renew token by re-authenticating
 	if err := r.client.Authenticate(ctx); err != nil {
 		r.logger.Error("Failed to renew Vault token", zap.Error(err))
-		if r.onRenewalError != nil {
-			r.onRenewalError("vault-token", err)
+		r.mu.Lock()
+		fn := r.onRenewalError
+		r.mu.Unlock()
+		if fn != nil {
+			fn("vault-token", err)
 		}
 		return
 	}
 
 	r.logger.Info("Vault token renewed")
-	if r.onTokenRenewed != nil {
-		r.onTokenRenewed()
+	r.mu.Lock()
+	fn := r.onTokenRenewed
+	r.mu.Unlock()
+	if fn != nil {
+		fn()
 	}
 }
 
@@ -239,8 +251,11 @@ func (r *RenewalManager) checkCertRenewals(ctx context.Context) {
 			r.logger.Error("Failed to renew certificate",
 				zap.String("name", name),
 				zap.Error(err))
-			if r.onRenewalError != nil {
-				r.onRenewalError(name, err)
+			r.mu.Lock()
+			errFn := r.onRenewalError
+			r.mu.Unlock()
+			if errFn != nil {
+				errFn(name, err)
 			}
 			continue
 		}
@@ -250,14 +265,15 @@ func (r *RenewalManager) checkCertRenewals(ctx context.Context) {
 		if t, ok := r.trackedCerts[name]; ok {
 			t.cert = newCert
 		}
+		certFn := r.onCertRenewed
 		r.mu.Unlock()
 
 		r.logger.Info("Certificate renewed",
 			zap.String("name", name),
 			zap.Time("newExpiry", newCert.ExpiresAt))
 
-		if r.onCertRenewed != nil {
-			r.onCertRenewed(name, newCert)
+		if certFn != nil {
+			certFn(name, newCert)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **GatewayReconciler**: Use computed `expectedClass` instead of hard-coded `NovaEdgeGatewayClassName` constant on lines 82/88, so custom gateway class names configured via `r.GatewayClassName` are respected.
- **Introspection gRPC server**: Apply `grpclimits.ServerOptions()` to enforce message size limits and keepalive parameters, matching the pattern used by the controller and agent gRPC servers.
- **Tunnel done channel**: Buffer the `done` channel (cap 1) to prevent goroutine leak when the sender fires after the receiver exits.
- **IPRateLimiter lifecycle**: Add `context.Context` parameter to `NewIPRateLimiter` so the cleanup goroutine exits on context cancellation. Updated `NewHealthServer`, `NewMetricsServer`, and all callers/tests.
- **Runtime API body limits**: Wrap request bodies with `http.MaxBytesReader` (1 MiB) in `handleAddEndpoint` and `handleChangeWeight` to bound memory usage from untrusted input.
- **Vault KV cache cap**: Limit cache to 10,000 entries; evict the oldest entry (by `fetchedAt`) when inserting at capacity to prevent unbounded growth.
- **Vault renewal callback race**: Protect callback field reads/writes in `OnTokenRenewed`, `OnCertRenewed`, `OnRenewalError`, `checkTokenRenewal`, and `checkCertRenewals` with `r.mu` to eliminate data races.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run ./...` passes (pre-commit hook)
- [x] `cargo fmt --check` and `cargo clippy` pass (pre-commit hook)