### PR TITLE
fix: IPv6 CIDR default, rate limiter cleanup, forward auth TLS warning

### DIFF
--- a/dataplane/novaedge-dataplane/src/middleware/auth/forward.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/auth/forward.rs
@@ -40,6 +40,13 @@ impl ForwardAuth {
     /// Check a request by forwarding it to the external auth service.
     #[allow(dead_code)]
     pub async fn check(&self, req: &super::super::Request) -> super::AuthResult {
+        if self.config.auth_url.starts_with("https://") {
+            warn!(
+                url = %self.config.auth_url,
+                "forward auth URL uses https:// but TLS is not yet supported; request sent as plaintext"
+            );
+        }
+
         let (host, port, path) = parse_url(&self.config.auth_url);
 
         // Reject CR/LF in host or path to prevent HTTP request smuggling via

--- a/dataplane/novaedge-dataplane/src/middleware/ratelimit.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/ratelimit.rs
@@ -1,8 +1,15 @@
 //! Rate limiting middleware using token bucket algorithm.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
+
+/// Maximum number of tracked rate-limit keys before triggering automatic cleanup.
+const MAX_ENTRIES: usize = 100_000;
+
+/// Stale entries older than this are removed during automatic cleanup.
+const AUTO_CLEANUP_MAX_AGE: Duration = Duration::from_secs(300);
 
 /// Rate limit key extraction strategy.
 #[derive(Debug, Clone)]
@@ -34,6 +41,7 @@ pub struct RateLimitConfig {
 pub struct TokenBucket {
     config: RateLimitConfig,
     buckets: RwLock<HashMap<String, BucketState>>,
+    check_count: AtomicU64,
 }
 
 struct BucketState {
@@ -47,6 +55,7 @@ impl TokenBucket {
         Self {
             config,
             buckets: RwLock::new(HashMap::new()),
+            check_count: AtomicU64::new(0),
         }
     }
 
@@ -67,6 +76,15 @@ impl TokenBucket {
 
     /// Check whether a request identified by `key` is allowed.
     pub fn check(&self, key: &str) -> RateLimitResult {
+        // Periodically clean up stale entries to bound memory usage.
+        let count = self.check_count.fetch_add(1, Ordering::Relaxed);
+        if count.is_multiple_of(1000) {
+            let len = self.buckets.read().unwrap_or_else(|e| e.into_inner()).len();
+            if len > MAX_ENTRIES {
+                self.cleanup(AUTO_CLEANUP_MAX_AGE);
+            }
+        }
+
         let now = Instant::now();
         let mut buckets = self.buckets.write().unwrap_or_else(|e| e.into_inner());
         let state = buckets.entry(key.to_string()).or_insert(BucketState {

--- a/dataplane/novaedge-dataplane/src/server.rs
+++ b/dataplane/novaedge-dataplane/src/server.rs
@@ -133,10 +133,17 @@ impl DataplaneService {
     /// Parse an IP address with optional CIDR prefix (e.g. "10.0.0.1/32" -> (10.0.0.1, 32)).
     #[allow(clippy::result_large_err)]
     fn parse_cidr_address(addr: &str) -> Result<(std::net::IpAddr, u8), Status> {
-        let (ip_str, prefix_str) = addr.split_once('/').unwrap_or((addr, "32"));
+        let (ip_str, explicit_prefix) = match addr.split_once('/') {
+            Some((ip, pfx)) => (ip, Some(pfx)),
+            None => (addr, None),
+        };
         let ip: std::net::IpAddr = ip_str
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address '{addr}': {e}")))?;
+        let prefix_str = explicit_prefix.unwrap_or(match ip {
+            std::net::IpAddr::V4(_) => "32",
+            std::net::IpAddr::V6(_) => "128",
+        });
         let prefix: u8 = prefix_str
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid prefix length: {e}")))?;


### PR DESCRIPTION
## Summary
- **IPv6 CIDR default**: `parse_cidr_address` now defaults to `/128` for IPv6 addresses instead of `/32`
- **Rate limiter cleanup**: `TokenBucket::check()` automatically triggers cleanup of stale entries when the bucket map exceeds 100,000 entries (checked every 1000 calls)
- **Forward auth TLS warning**: `ForwardAuth::check()` logs a warning when the auth URL uses `https://` since TLS is not yet supported and the request is sent as plaintext

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (410 tests)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes