### PR TITLE
fix: recursive RLock deadlock in SplitBrainDetector, remove dead code

### DIFF
--- a/internal/agent/mesh/tunnel.go
+++ b/internal/agent/mesh/tunnel.go
@@ -484,47 +484,6 @@ func (tp *TunnelPool) Close() {
 	tp.logger.Info("Tunnel pool closed")
 }
 
-// getOrCreateClient returns an existing HTTP/2 client for the node address
-// or creates a new one. It updates the lastUsed timestamp on every access.
-func (tp *TunnelPool) getOrCreateClient(nodeAddr string) *http.Client {
-	tp.mu.RLock()
-	pc, ok := tp.clients[nodeAddr]
-	tp.mu.RUnlock()
-	if ok {
-		// Update lastUsed under write lock.
-		tp.mu.Lock()
-		pc.lastUsed = time.Now()
-		tp.mu.Unlock()
-		return pc.client
-	}
-
-	tp.mu.Lock()
-	defer tp.mu.Unlock()
-
-	// Double-check after acquiring write lock.
-	if pc, ok = tp.clients[nodeAddr]; ok {
-		pc.lastUsed = time.Now()
-		return pc.client
-	}
-
-	client := &http.Client{
-		Transport: &http2.Transport{
-			TLSClientConfig: tp.tlsConfig,
-		},
-		Timeout: 30 * time.Second,
-	}
-	tp.clients[nodeAddr] = &pooledClient{
-		client:   client,
-		lastUsed: time.Now(),
-	}
-
-	tp.logger.Debug("Created HTTP/2 client for peer",
-		zap.String("node_addr", nodeAddr),
-	)
-
-	return client
-}
-
 // streamConn wraps an HTTP/2 CONNECT stream as a net.Conn.
 // Reads come from the response body and writes go to the request body
 // pipe writer. This allows the tunnel stream to be used as a regular

--- a/internal/agent/mesh/tunnel_test.go
+++ b/internal/agent/mesh/tunnel_test.go
@@ -501,25 +501,6 @@ func TestTunnelPoolDialVia(t *testing.T) {
 	}
 }
 
-func TestTunnelPoolReusesClient(t *testing.T) {
-	pool := NewTunnelPool(zap.NewNop(), &tls.Config{MinVersion: tls.VersionTLS12})
-	defer pool.Close()
-
-	// Getting a client twice for the same address should return the same one.
-	c1 := pool.getOrCreateClient("192.168.1.1:15002")
-	c2 := pool.getOrCreateClient("192.168.1.1:15002")
-
-	if c1 != c2 {
-		t.Error("expected same client instance for same address")
-	}
-
-	// Different address should return different client.
-	c3 := pool.getOrCreateClient("192.168.1.2:15002")
-	if c1 == c3 {
-		t.Error("expected different client for different address")
-	}
-}
-
 func TestStreamConnInterface(t *testing.T) {
 	// Verify streamConn implements net.Conn at compile time.
 	var _ net.Conn = (*streamConn)(nil)

--- a/internal/controller/federation/splitbrain.go
+++ b/internal/controller/federation/splitbrain.go
@@ -317,10 +317,8 @@ func (d *SplitBrainDetector) runDetectionLoop() {
 
 // checkForPartition checks if we're in a network partition
 func (d *SplitBrainDetector) checkForPartition() {
-	d.peersMu.RLock()
 	reachable := d.getReachablePeerNames()
 	unreachable := d.getUnreachablePeerNames()
-	d.peersMu.RUnlock()
 
 	d.stateMu.Lock()
 	defer d.stateMu.Unlock()
@@ -411,12 +409,7 @@ func (d *SplitBrainDetector) checkForPartition() {
 
 // checkPartitionHealing checks if partition is healing
 func (d *SplitBrainDetector) checkPartitionHealing() {
-	// Snapshot peer data first (peersMu before stateMu) to match the lock
-	// acquisition order used in checkForPartition(), preventing an ABBA deadlock
-	// between the two methods when called concurrently.
-	d.peersMu.RLock()
 	unreachable := d.getUnreachablePeerNames()
-	d.peersMu.RUnlock()
 
 	d.stateMu.Lock()
 	defer d.stateMu.Unlock()

--- a/internal/controller/snapshot/server.go
+++ b/internal/controller/snapshot/server.go
@@ -83,9 +83,6 @@ type Server struct {
 	builder *Builder
 	cache   *Cache
 
-	// Channels for notifying clients of updates
-	updateNotifier chan string
-
 	// Agent status tracking
 	statusMap sync.Map // map[string]*AgentStatusInfo
 
@@ -122,7 +119,6 @@ func NewServer(client client.Client) *Server {
 		client:             client,
 		builder:            NewBuilder(client),
 		cache:              NewCache(),
-		updateNotifier:     make(chan string, 100),
 		remoteAgentTracker: NewRemoteAgentTracker(),
 		shutdownCh:         make(chan struct{}),
 	}
@@ -462,11 +458,6 @@ func (s *Server) storeAgentStatus(req *pb.AgentStatus) {
 	if activeConns, ok := req.Metrics["active_connections"]; ok {
 		status.ActiveConnections = activeConns
 	}
-}
-
-// updateAgentConnection updates the connection status of an agent
-func (s *Server) updateAgentConnection(nodeName, agentVersion string, connected bool) {
-	s.updateAgentConnectionWithCluster(nodeName, agentVersion, "", "", "", connected)
 }
 
 // updateAgentConnectionWithCluster updates the connection status of an agent with cluster info

--- a/internal/controller/snapshot/server_status_test.go
+++ b/internal/controller/snapshot/server_status_test.go
@@ -84,7 +84,7 @@ func TestAgentConnectionTracking(t *testing.T) {
 	defer server.Shutdown()
 
 	// Test updateAgentConnection
-	server.updateAgentConnection("test-node-2", "v1.2.3", true)
+	server.updateAgentConnectionWithCluster("test-node-2", "v1.2.3", "", "", "", true)
 
 	status, ok := server.GetAgentStatus("test-node-2")
 	if !ok {
@@ -100,7 +100,7 @@ func TestAgentConnectionTracking(t *testing.T) {
 	}
 
 	// Update to disconnected
-	server.updateAgentConnection("test-node-2", "v1.2.3", false)
+	server.updateAgentConnectionWithCluster("test-node-2", "v1.2.3", "", "", "", false)
 
 	status, ok = server.GetAgentStatus("test-node-2")
 	if !ok {
@@ -120,9 +120,9 @@ func TestGetAllAgentStatuses(t *testing.T) {
 	defer server.Shutdown()
 
 	// Add multiple agents
-	server.updateAgentConnection("node-1", "v1.0.0", true)
-	server.updateAgentConnection("node-2", "v1.0.1", true)
-	server.updateAgentConnection("node-3", "v1.0.2", false)
+	server.updateAgentConnectionWithCluster("node-1", "v1.0.0", "", "", "", true)
+	server.updateAgentConnectionWithCluster("node-2", "v1.0.1", "", "", "", true)
+	server.updateAgentConnectionWithCluster("node-3", "v1.0.2", "", "", "", false)
 
 	// Get all statuses
 	statuses := server.GetAllAgentStatuses()


### PR DESCRIPTION
## Summary
- **Fix recursive RLock deadlock** in `SplitBrainDetector`: `checkForPartition()` and `checkPartitionHealing()` acquired `peersMu.RLock()` then called helper methods (`getReachablePeerNames()`, `getUnreachablePeerNames()`, `HaveQuorum()`) that each internally acquire `peersMu.RLock()` again. Go's `sync.RWMutex` is not reentrant, so this would deadlock. Removed the redundant outer locks.
- **Delete dead `TunnelPool.getOrCreateClient()`** method — never called in production code; `DialVia()` creates transports inline.
- **Remove dead snapshot server code**: `updateNotifier` channel (allocated but never read/written) and `updateAgentConnection()` wrapper (all callers use `updateAgentConnectionWithCluster()`).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/controller/federation/...` passes
- [x] `go test ./internal/controller/snapshot/...` passes
- [x] `go test ./internal/agent/mesh/...` passes
- [x] Pre-commit hooks (golangci-lint, cargo fmt, cargo clippy) pass