### PR TITLE
fix: prune stale circuit breaker/outlier maps and detect rate limiter config drift

### DIFF
--- a/dataplane/novaedge-dataplane/src/config.rs
+++ b/dataplane/novaedge-dataplane/src/config.rs
@@ -533,6 +533,11 @@ impl RuntimeConfig {
         }
     }
 
+    /// Return the set of all cluster names currently in the configuration.
+    pub fn cluster_names(&self) -> HashSet<String> {
+        self.clusters.iter().map(|e| e.key().clone()).collect()
+    }
+
     /// Get the current config generation number.
     pub fn generation(&self) -> u64 {
         self.generation.load(Ordering::Relaxed)

--- a/dataplane/novaedge-dataplane/src/middleware/pipeline.rs
+++ b/dataplane/novaedge-dataplane/src/middleware/pipeline.rs
@@ -21,9 +21,17 @@ const MAX_RATE_LIMITERS: usize = 10_000;
 /// Minimum interval between rate-limiter cleanup sweeps (seconds).
 const CLEANUP_INTERVAL_SECS: u64 = 60;
 
+/// A cached rate limiter together with the config parameters used to create it.
+/// When the config changes, the cached entry is replaced with a fresh `TokenBucket`.
+struct CachedRateLimiter {
+    bucket: super::ratelimit::TokenBucket,
+    requests_per_second: f64,
+    burst: u32,
+}
+
 /// Shared cache of rate-limiter instances keyed by policy name.
 /// This ensures rate-limit state is preserved across requests.
-static RATE_LIMITERS: std::sync::LazyLock<DashMap<String, super::ratelimit::TokenBucket>> =
+static RATE_LIMITERS: std::sync::LazyLock<DashMap<String, CachedRateLimiter>> =
     std::sync::LazyLock::new(DashMap::new);
 
 /// Tracks the last time a rate-limiter cleanup was performed.
@@ -260,26 +268,60 @@ fn run_rate_limit(policy_name: &str, config_json: &str, req: &Request) -> Middle
     };
     if needs_cleanup {
         for entry in RATE_LIMITERS.iter() {
-            entry.value().cleanup(std::time::Duration::from_secs(300));
+            entry
+                .value()
+                .bucket
+                .cleanup(std::time::Duration::from_secs(300));
         }
         if let Ok(mut last) = LAST_CLEANUP.lock() {
             *last = Instant::now();
         }
     }
 
+    // Check if the cached rate limiter has matching config; replace if stale.
+    let config_changed = RATE_LIMITERS
+        .get(policy_name)
+        .map(|entry| {
+            (entry.value().requests_per_second - rps).abs() > f64::EPSILON
+                || entry.value().burst != burst
+        })
+        .unwrap_or(false);
+    if config_changed {
+        debug!(
+            policy = %policy_name,
+            rps,
+            burst,
+            "Rate limiter config changed, replacing cached instance"
+        );
+        RATE_LIMITERS.insert(
+            policy_name.to_string(),
+            CachedRateLimiter {
+                bucket: super::ratelimit::TokenBucket::new(super::ratelimit::RateLimitConfig {
+                    requests_per_second: rps,
+                    burst,
+                    key_type: super::ratelimit::RateLimitKeyType::SourceIP,
+                }),
+                requests_per_second: rps,
+                burst,
+            },
+        );
+    }
+
     // Get or create a cached TokenBucket for this policy.
     let limiter = RATE_LIMITERS
         .entry(policy_name.to_string())
-        .or_insert_with(|| {
-            super::ratelimit::TokenBucket::new(super::ratelimit::RateLimitConfig {
+        .or_insert_with(|| CachedRateLimiter {
+            bucket: super::ratelimit::TokenBucket::new(super::ratelimit::RateLimitConfig {
                 requests_per_second: rps,
                 burst,
                 key_type: super::ratelimit::RateLimitKeyType::SourceIP,
-            })
+            }),
+            requests_per_second: rps,
+            burst,
         });
 
     let key = &req.client_ip;
-    match limiter.check(key) {
+    match limiter.bucket.check(key) {
         super::ratelimit::RateLimitResult::Allowed { .. } => {
             MiddlewareResult::Continue(req.clone())
         }

--- a/dataplane/novaedge-dataplane/src/proxy/handler.rs
+++ b/dataplane/novaedge-dataplane/src/proxy/handler.rs
@@ -1,8 +1,8 @@
 //! HTTP proxy handler that routes requests to backend endpoints via hyper.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -48,6 +48,8 @@ pub struct ProxyHandler {
     response_header_actions: Vec<HeaderAction>,
     /// When true, include X-Route debug headers in responses.
     debug_headers: bool,
+    /// Config generation at which stale circuit breakers/outlier detectors were last pruned.
+    last_cleanup_generation: AtomicU64,
 }
 
 impl ProxyHandler {
@@ -75,6 +77,7 @@ impl ProxyHandler {
             error_pages: Vec::new(),
             response_header_actions: Vec::new(),
             debug_headers: false,
+            last_cleanup_generation: AtomicU64::new(0),
         }
     }
 
@@ -82,6 +85,9 @@ impl ProxyHandler {
     /// config from the ClusterState (failure threshold, success threshold,
     /// open duration).
     async fn get_circuit_breaker(&self, cluster_name: &str) -> Arc<CircuitBreaker> {
+        // Prune stale entries if config has changed since the last cleanup.
+        self.maybe_cleanup_stale_entries().await;
+
         // Fast path: check read lock.
         {
             let cbs = self.circuit_breakers.read().await;
@@ -125,6 +131,9 @@ impl ProxyHandler {
 
     /// Get or create a per-cluster outlier detector, using config from ClusterState.
     async fn get_outlier_detector(&self, cluster_name: &str) -> Arc<OutlierDetector> {
+        // Prune stale entries if config has changed since the last cleanup.
+        self.maybe_cleanup_stale_entries().await;
+
         // Fast path: check read lock.
         {
             let ods = self.outlier_detectors.read().await;
@@ -174,6 +183,51 @@ impl ProxyHandler {
         ods.entry(cluster_name.to_string())
             .or_insert_with(|| Arc::new(OutlierDetector::new(od_config)))
             .clone()
+    }
+
+    /// Remove circuit breaker and outlier detector entries for clusters that are
+    /// no longer present in the active configuration.  This prevents the maps
+    /// from growing monotonically as clusters are added and removed over time.
+    pub async fn cleanup_stale_entries(&self, active_clusters: &HashSet<String>) {
+        {
+            let mut cbs = self.circuit_breakers.write().await;
+            let before = cbs.len();
+            cbs.retain(|k, _| active_clusters.contains(k));
+            let removed = before - cbs.len();
+            if removed > 0 {
+                info!(
+                    removed,
+                    remaining = cbs.len(),
+                    "Pruned stale circuit breaker entries"
+                );
+            }
+        }
+        {
+            let mut ods = self.outlier_detectors.write().await;
+            let before = ods.len();
+            ods.retain(|k, _| active_clusters.contains(k));
+            let removed = before - ods.len();
+            if removed > 0 {
+                info!(
+                    removed,
+                    remaining = ods.len(),
+                    "Pruned stale outlier detector entries"
+                );
+            }
+        }
+    }
+
+    /// Check if the config generation has changed since the last cleanup and,
+    /// if so, prune stale circuit breaker and outlier detector entries.
+    async fn maybe_cleanup_stale_entries(&self) {
+        let current_gen = self.config.generation();
+        let last_gen = self.last_cleanup_generation.load(Ordering::Relaxed);
+        if current_gen != last_gen {
+            let active_clusters = self.config.cluster_names();
+            self.cleanup_stale_entries(&active_clusters).await;
+            self.last_cleanup_generation
+                .store(current_gen, Ordering::Relaxed);
+        }
     }
 
     /// Handle an incoming HTTP request: match route, select backend, forward.


### PR DESCRIPTION
## Summary
- **Circuit breaker/outlier detector cleanup**: Added `cleanup_stale_entries()` to `ProxyHandler` that prunes entries for clusters no longer in the active config. Triggered automatically via config generation tracking when `get_circuit_breaker` or `get_outlier_detector` is called after a config update.
- **Rate limiter config drift**: `RATE_LIMITERS` DashMap now stores config params (`requests_per_second`, `burst`) alongside each `TokenBucket`. On access, if the cached params don't match the current policy config, the entry is replaced with a fresh `TokenBucket`.
- Added `cluster_names()` method to `RuntimeConfig` to support the cleanup flow.

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (410 tests)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes